### PR TITLE
Animated skeleton loading for feeds and record pages

### DIFF
--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -4,6 +4,7 @@ import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { Link } from 'react-router-dom';
 import { renderPostText } from '../lib/postRichText.jsx';
 import PostEmbed from './PostEmbed.jsx';
+import { CommentsSkeleton } from './Skeleton.jsx';
 import './Comments.css';
 
 /**
@@ -37,7 +38,7 @@ export default function Comments({
 
 function CommentsBody({ replies, status, emptyMessage }) {
   if (status === 'loading' && (!replies || replies.length === 0)) {
-    return <p className="feed-empty">Loading replies…</p>;
+    return <CommentsSkeleton rows={3} />;
   }
   if (status === 'error' && (!replies || replies.length === 0)) {
     return <p className="feed-empty">Couldn't load replies.</p>;

--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -1,0 +1,313 @@
+/* Animated loading skeletons.
+
+   Two layered animations make the placeholders feel alive without being
+   noisy:
+
+     1. A slow shimmer sweep — a horizontal gradient driven by
+        `background-position`. This is the dominant cue that something is
+        loading and the colors are pulled from the page palette so it
+        reads as "blank parchment" rather than "Material UI".
+
+     2. A breathing opacity wrapper — applied via Motion in JS. The
+        wrapper fades the whole skeleton column in, holds it, and fades
+        out as the real content swaps in. Per-block opacity is also
+        gently animated so a static page-edge fallback (when a user has
+        prefers-reduced-motion: reduce) still doesn't look like an error
+        state. */
+
+.skeleton {
+  display: inline-block;
+  vertical-align: middle;
+  background: linear-gradient(
+    90deg,
+    var(--page-edge) 0%,
+    var(--rule-soft) 45%,
+    var(--rule) 50%,
+    var(--rule-soft) 55%,
+    var(--page-edge) 100%
+  );
+  background-size: 220% 100%;
+  background-repeat: no-repeat;
+  background-position: 100% 0;
+  animation: skeleton-shimmer 1.7s ease-in-out infinite;
+  border-radius: var(--radius-1, 0);
+  /* Browsers don't read empty inline-block content as anything; force a
+     baseline so the parent line-height keeps text-line skeletons aligned
+     with surrounding flow. */
+  line-height: 1;
+  color: transparent;
+  user-select: none;
+}
+
+.skeleton-block {
+  display: block;
+}
+
+@keyframes skeleton-shimmer {
+  0%   { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background: var(--rule-soft);
+    opacity: 0.7;
+  }
+}
+
+/* Stack of skeleton text lines that mimics a paragraph. */
+.skeleton-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45em;
+}
+
+.skeleton-text > .skeleton {
+  display: block;
+}
+
+/* Container Motion-fades — keeps things from snapping in. */
+.skeleton-shell {
+  display: block;
+  width: 100%;
+}
+
+/* Variant: feed-list skeleton, mirroring the .feed-item grid so the
+   placeholder doesn't reflow once the real items land. */
+.skeleton-feed {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  gap: var(--space-5);
+}
+
+.skeleton-feed-item {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  gap: var(--space-4);
+  align-items: start;
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.skeleton-feed-item:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.skeleton-feed-verb {
+  justify-self: end;
+  width: 3.4rem;
+  height: 0.8rem;
+  margin-top: 0.4rem;
+}
+
+.skeleton-feed-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton-feed-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.skeleton-feed-row .skeleton-feed-time {
+  flex: 0 0 auto;
+  width: 2.6rem;
+  height: 0.7rem;
+}
+
+.skeleton-feed-row .skeleton-feed-text {
+  flex: 1 1 auto;
+  height: 1.05em;
+  max-width: var(--measure);
+}
+
+@media (max-width: 700px) {
+  .skeleton-feed-item {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .skeleton-feed-verb {
+    justify-self: start;
+  }
+}
+
+/* Variant: blogging table-of-contents row skeleton. */
+.skeleton-toc {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.skeleton-toc-entry {
+  border-bottom: 1px dotted var(--rule);
+  display: grid;
+  grid-template-columns: 3rem 1fr auto;
+  gap: var(--space-4);
+  align-items: baseline;
+  padding: var(--space-4) 0;
+}
+
+.skeleton-toc-entry:first-child {
+  border-top: 1px dotted var(--rule);
+}
+
+.skeleton-toc-num {
+  width: 1.8rem;
+  height: 0.8rem;
+}
+
+.skeleton-toc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.skeleton-toc-title {
+  height: 1.2em;
+  max-width: 28ch;
+}
+
+.skeleton-toc-summary {
+  height: 0.8em;
+  max-width: 40ch;
+}
+
+.skeleton-toc-meta {
+  width: 4.5rem;
+  height: 0.75rem;
+  align-self: start;
+  margin-top: 0.4em;
+}
+
+@media (max-width: 700px) {
+  .skeleton-toc-entry {
+    grid-template-columns: 1fr;
+  }
+  .skeleton-toc-num,
+  .skeleton-toc-meta {
+    display: none;
+  }
+}
+
+/* Variant: creating grid card skeleton. */
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  gap: var(--space-5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.skeleton-grid-cell {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--rule-soft);
+  background: var(--page-edge);
+}
+
+.skeleton-grid-thumb {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  display: block;
+}
+
+.skeleton-grid-meta {
+  padding: var(--space-3) var(--space-4) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-grid-kind {
+  width: 4rem;
+  height: 0.65rem;
+}
+
+.skeleton-grid-title {
+  width: 70%;
+  height: 1.1em;
+}
+
+.skeleton-grid-time {
+  width: 30%;
+  height: 0.65rem;
+}
+
+/* Variant: single-record / blog-post / work skeleton. Lives inside the
+   page article so it gets the .record-page measure and gutters. */
+.skeleton-record {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.skeleton-record-meta {
+  display: flex;
+  gap: var(--space-3);
+  align-items: baseline;
+}
+
+.skeleton-record-meta-cell {
+  height: 0.75rem;
+  width: 5rem;
+}
+
+.skeleton-record-image {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  max-width: var(--measure);
+}
+
+/* Variant: comments tree skeleton (avatar + byline + text). Mirrors the
+   .comment / .comment-head layout so it lines up with real replies. */
+.skeleton-comments {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.skeleton-comments-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.skeleton-comments-item:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.skeleton-comments-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.skeleton-comments-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex: 0 0 auto;
+}
+
+.skeleton-comments-name {
+  height: 0.85rem;
+}
+
+.skeleton-comments-text {
+  padding-left: calc(1.75rem + var(--space-3));
+}

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -1,0 +1,314 @@
+import { motion } from 'motion/react';
+import './Skeleton.css';
+
+/**
+ * Animated loading skeletons for record-driven pages.
+ *
+ * Two layered animations make the placeholders feel alive without being
+ * noisy:
+ *
+ *   1. A slow shimmer sweep — a horizontal gradient on every individual
+ *      `.skeleton` block (driven by CSS `background-position`). The
+ *      gradient stops are pulled from the page palette so the effect
+ *      reads as "blank parchment" rather than "Material UI".
+ *
+ *   2. A breathing fade — applied via Motion on the outer `SkeletonShell`.
+ *      The wrapper fades the whole skeleton column in, then unmounts
+ *      (still via Motion if wrapped in `AnimatePresence`) when real
+ *      content arrives so the swap doesn't snap.
+ *
+ * The shimmer respects `prefers-reduced-motion` (CSS handles that), and
+ * the Motion fade is short (~250ms) so reduced-motion users still get a
+ * usable cue from the static gradient block.
+ */
+
+/**
+ * One animated rectangle. Pass any subset of width/height/radius — the
+ * defaults give you a single line of text on the current line-height.
+ */
+export function Skeleton({
+  width,
+  height = '1em',
+  radius,
+  className = '',
+  block = false,
+  style,
+  ...rest
+}) {
+  return (
+    <span
+      className={`skeleton ${block ? 'skeleton-block' : ''} ${className}`.trim()}
+      style={{
+        width,
+        height,
+        borderRadius: radius,
+        ...style,
+      }}
+      aria-hidden="true"
+      {...rest}
+    />
+  );
+}
+
+/**
+ * Several text-line skeletons stacked into a paragraph. The last line is
+ * shorter so it reads more like real prose than a brick of text.
+ */
+export function SkeletonText({
+  lines = 3,
+  lineHeight = '0.85em',
+  lastLineWidth = '60%',
+  className = '',
+}) {
+  return (
+    <span className={`skeleton-text ${className}`.trim()} aria-hidden="true">
+      {Array.from({ length: Math.max(1, lines) }, (_, i) => (
+        <Skeleton
+          key={i}
+          width={i === lines - 1 ? lastLineWidth : '100%'}
+          height={lineHeight}
+        />
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Outer Motion fade for any skeleton. Used so the skeleton column fades
+ * in (and, when wrapped in <AnimatePresence>, fades back out as the real
+ * content swaps in). Adds aria-busy on the section so assistive tech
+ * announces "loading" even though the inner blocks are aria-hidden.
+ */
+export function SkeletonShell({ children, className = '', label = 'Loading' }) {
+  return (
+    <motion.div
+      className={`skeleton-shell ${className}`.trim()}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/* -------------------------------------------------------------------- */
+/* Page-shaped variants                                                  */
+/* -------------------------------------------------------------------- */
+
+/**
+ * Skeleton for any feed list (Home, Posting, Logging). Mirrors the
+ * `.feed-item` two-column grid (4.5rem verb badge + body) so the
+ * placeholder doesn't reflow once the real items arrive.
+ *
+ * Each row's body has a couple of staggered text lines plus a tiny
+ * timestamp on the right.
+ */
+export function FeedSkeleton({ rows = 6, label = 'Loading feed' }) {
+  return (
+    <SkeletonShell label={label}>
+      <ul className="skeleton-feed">
+        {Array.from({ length: rows }, (_, i) => {
+          const longLine = 78 + ((i * 7) % 18); // 78 – 96 % to look organic
+          const shortLine = 38 + ((i * 13) % 32); // 38 – 70 %
+          return (
+            <li key={i} className="skeleton-feed-item">
+              <Skeleton className="skeleton-feed-verb" />
+              <div className="skeleton-feed-body">
+                <div className="skeleton-feed-row">
+                  <Skeleton
+                    className="skeleton-feed-text"
+                    style={{ width: `${longLine}%` }}
+                  />
+                  <Skeleton className="skeleton-feed-time" />
+                </div>
+                {i % 3 !== 0 && (
+                  <Skeleton
+                    block
+                    style={{ width: `${shortLine}%`, height: '0.85em' }}
+                  />
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for the Blogging table-of-contents. Mirrors the three-column
+ * `.blogging-toc-entry` grid (number / body / meta).
+ */
+export function BloggingTocSkeleton({ rows = 5 }) {
+  return (
+    <SkeletonShell label="Loading blog index">
+      <ul className="skeleton-toc">
+        {Array.from({ length: rows }, (_, i) => (
+          <li key={i} className="skeleton-toc-entry">
+            <Skeleton className="skeleton-toc-num" />
+            <div className="skeleton-toc-body">
+              <Skeleton
+                className="skeleton-toc-title"
+                style={{ width: `${55 + ((i * 11) % 35)}%` }}
+              />
+              {i % 2 === 0 && (
+                <Skeleton
+                  className="skeleton-toc-summary"
+                  style={{ width: `${65 + ((i * 7) % 25)}%` }}
+                />
+              )}
+            </div>
+            <Skeleton className="skeleton-toc-meta" />
+          </li>
+        ))}
+      </ul>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for the Creating grid. Mirrors `.creating-grid` cells with a
+ * 4:3 thumb plus the kind / title / time meta block.
+ */
+export function CreatingGridSkeleton({ cells = 6 }) {
+  return (
+    <SkeletonShell label="Loading works">
+      <ul className="skeleton-grid">
+        {Array.from({ length: cells }, (_, i) => (
+          <li key={i} className="skeleton-grid-cell">
+            <Skeleton className="skeleton-grid-thumb" />
+            <div className="skeleton-grid-meta">
+              <Skeleton className="skeleton-grid-kind" />
+              <Skeleton
+                className="skeleton-grid-title"
+                style={{ width: `${55 + ((i * 9) % 30)}%` }}
+              />
+              <Skeleton className="skeleton-grid-time" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for a single record page (Record.jsx). Renders a simple body
+ * stub plus a thin meta row that mirrors `.record-page-meta`.
+ */
+export function RecordSkeleton() {
+  return (
+    <SkeletonShell label="Loading record">
+      <div className="skeleton-record">
+        <SkeletonText lines={3} lineHeight="1.05em" lastLineWidth="55%" />
+        <div className="skeleton-record-meta">
+          <Skeleton className="skeleton-record-meta-cell" />
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '3.5rem' }} />
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '6rem' }} />
+        </div>
+      </div>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for a long-form page (BlogPost). A meta row above a stack of
+ * paragraph-shaped text skeletons.
+ */
+export function BlogPostSkeleton({ paragraphs = 4 }) {
+  return (
+    <SkeletonShell label="Loading post">
+      <div className="skeleton-record">
+        <div className="skeleton-record-meta">
+          <Skeleton className="skeleton-record-meta-cell" />
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '4.5rem' }} />
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '6rem' }} />
+        </div>
+        {Array.from({ length: paragraphs }, (_, i) => (
+          <SkeletonText
+            key={i}
+            lines={3 + (i % 2)}
+            lineHeight="0.95em"
+            lastLineWidth={`${40 + ((i * 17) % 35)}%`}
+          />
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for a Creating work page (image + summary + body).
+ */
+export function CreatingWorkSkeleton() {
+  return (
+    <SkeletonShell label="Loading work">
+      <div className="skeleton-record">
+        <div className="skeleton-record-meta">
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '4rem' }} />
+          <Skeleton className="skeleton-record-meta-cell" style={{ width: '6.5rem' }} />
+        </div>
+        <SkeletonText lines={2} lineHeight="1em" lastLineWidth="45%" />
+        <Skeleton className="skeleton-record-image" block />
+        <SkeletonText lines={4} lineHeight="0.95em" lastLineWidth="55%" />
+      </div>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for a comments tree. Mirrors the .comment layout (avatar +
+ * byline + body) so the placeholder doesn't reflow once replies arrive.
+ */
+export function CommentsSkeleton({ rows = 3 }) {
+  return (
+    <SkeletonShell label="Loading replies">
+      <ul className="skeleton-comments">
+        {Array.from({ length: rows }, (_, i) => (
+          <li key={i} className="skeleton-comments-item">
+            <div className="skeleton-comments-head">
+              <Skeleton className="skeleton-comments-avatar" />
+              <Skeleton
+                className="skeleton-comments-name"
+                style={{ width: `${30 + ((i * 13) % 25)}%` }}
+              />
+            </div>
+            <SkeletonText
+              className="skeleton-comments-text"
+              lines={1 + (i % 2)}
+              lineHeight="0.95em"
+              lastLineWidth={`${45 + ((i * 11) % 30)}%`}
+            />
+          </li>
+        ))}
+      </ul>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Generic prose skeleton — used for the Sharing page (and any other
+ * Markdown-only page in the future). Just stacked paragraph blocks.
+ */
+export function ProseSkeleton({ paragraphs = 3 }) {
+  return (
+    <SkeletonShell label="Loading">
+      <div className="skeleton-record">
+        {Array.from({ length: paragraphs }, (_, i) => (
+          <SkeletonText
+            key={i}
+            lines={3 + (i % 2)}
+            lineHeight="0.95em"
+            lastLineWidth={`${45 + ((i * 13) % 30)}%`}
+          />
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import LeafletDocument from '../components/LeafletDocument.jsx';
 import Comments from '../components/Comments.jsx';
+import { BlogPostSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { formatDateLong, relativeTime } from '../lib/time.js';
@@ -109,8 +110,10 @@ export default function BlogPost() {
 
   if (resolution.status === 'loading') {
     return (
-      <PageShell title={id} headTitle={`${id} — Dame is…`}>
-        <p className="feed-empty">Loading post…</p>
+      <PageShell headTitle={`${id} — Dame is…`}>
+        <article className="blog-article">
+          <BlogPostSkeleton paragraphs={4} />
+        </article>
       </PageShell>
     );
   }

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import FeedSearch, { matchesQuery } from '../components/FeedSearch.jsx';
+import { BloggingTocSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { rkeyFromAtUri } from '../lib/atproto.js';
 import { relativeTime } from '../lib/time.js';
@@ -21,7 +22,8 @@ import './Blogging.css';
  * in every JSX expression.
  */
 export default function Blogging() {
-  const [entries, setEntries] = useState([]);
+  // `null` = both snapshot fetches are still pending; `[]` = loaded.
+  const [entries, setEntries] = useState(null);
   const [params] = useSearchParams();
   const q = params.get('q') || '';
 
@@ -47,15 +49,17 @@ export default function Blogging() {
     };
   }, []);
 
+  const loading = entries === null;
+  const safeEntries = entries || [];
   const filtered = useMemo(
     () =>
-      entries.filter((e) =>
+      safeEntries.filter((e) =>
         matchesQuery(
           [e.title, e.summary, e.id].filter(Boolean).join(' '),
           q,
         ),
       ),
-    [entries, q],
+    [safeEntries, q],
   );
 
   return (
@@ -68,7 +72,9 @@ export default function Blogging() {
       <div className="feed-filters feed-filters-search-only">
         <FeedSearch label="Search blog posts" />
       </div>
-      {filtered.length === 0 ? (
+      {loading ? (
+        <BloggingTocSkeleton rows={5} />
+      ) : filtered.length === 0 ? (
         <p className="feed-empty">
           {q ? 'No blog posts match that search.' : 'No blog posts yet.'}
         </p>

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import FeedSearch, { matchesQuery } from '../components/FeedSearch.jsx';
+import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { relativeTime } from '../lib/time.js';
 import { ME_DID } from '../config.js';
@@ -9,7 +10,8 @@ import '../components/FeedFilters.css';
 import './Creating.css';
 
 export default function Creating() {
-  const [works, setWorks] = useState([]);
+  // `null` = snapshot still loading; `[]` = loaded but no works.
+  const [works, setWorks] = useState(null);
   const [kind, setKind] = useState(null);
   const [params] = useSearchParams();
   const q = params.get('q') || '';
@@ -17,7 +19,11 @@ export default function Creating() {
   useEffect(() => {
     let cancelled = false;
     fetchSnapshot('creations').then((snap) => {
-      if (cancelled || !Array.isArray(snap)) return;
+      if (cancelled) return;
+      if (!Array.isArray(snap)) {
+        setWorks([]);
+        return;
+      }
       setWorks(
         snap
           .filter((r) => r?.value)
@@ -33,10 +39,12 @@ export default function Creating() {
     };
   }, []);
 
-  const kinds = Array.from(new Set(works.map((r) => r.value?.kind).filter(Boolean)));
+  const loading = works === null;
+  const safeWorks = works || [];
+  const kinds = Array.from(new Set(safeWorks.map((r) => r.value?.kind).filter(Boolean)));
   const filtered = useMemo(
     () =>
-      works.filter((r) => {
+      safeWorks.filter((r) => {
         const v = r.value || {};
         if (kind && v.kind !== kind) return false;
         return matchesQuery(
@@ -44,7 +52,7 @@ export default function Creating() {
           q,
         );
       }),
-    [works, kind, q],
+    [safeWorks, kind, q],
   );
 
   return (
@@ -78,7 +86,9 @@ export default function Creating() {
         ) : null}
         <FeedSearch label="Search works" />
       </div>
-      {filtered.length === 0 ? (
+      {loading ? (
+        <CreatingGridSkeleton cells={6} />
+      ) : filtered.length === 0 ? (
         <p className="feed-empty">
           {q ? 'No works match that search.' : 'No works yet.'}
         </p>

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import { CreatingWorkSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { formatDateLong } from '../lib/time.js';
@@ -42,6 +43,16 @@ export default function CreatingWork() {
           No <code>is.dame.creating.work</code> with slug <code>{slug}</code>.{' '}
           <Link to="/creating">Back to the index.</Link>
         </p>
+      </PageShell>
+    );
+  }
+
+  if (!record) {
+    return (
+      <PageShell headTitle={`${slug} — Dame is…`}>
+        <article className="creating-work-page">
+          <CreatingWorkSkeleton />
+        </article>
       </PageShell>
     );
   }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import FeedFilters, { filterFeed } from '../components/FeedFilters.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
+import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { groupByDay } from '../lib/time.js';
 import { ME_DID } from '../config.js';
@@ -40,7 +41,10 @@ function collapseListens(items) {
 
 export default function Home() {
   const [params] = useSearchParams();
-  const [feed, setFeed] = useState([]);
+  // `null` here means "snapshot fetch hasn't resolved yet" — distinct
+  // from `[]` (loaded, but no records / no matches) so we can show a
+  // skeleton on first paint instead of the empty-state copy.
+  const [feed, setFeed] = useState(null);
   const [loadedAt, setLoadedAt] = useState(null);
 
   // The unified snapshot is built at prefetch time with every verb's
@@ -51,10 +55,9 @@ export default function Home() {
     let cancelled = false;
     async function run() {
       const snap = await fetchSnapshot('unifiedFeed');
-      if (!cancelled && Array.isArray(snap)) {
-        setFeed(snap);
-        setLoadedAt(new Date());
-      }
+      if (cancelled) return;
+      setFeed(Array.isArray(snap) ? snap : []);
+      setLoadedAt(new Date());
     }
     run();
     return () => {
@@ -62,13 +65,16 @@ export default function Home() {
     };
   }, []);
 
+  const loading = feed === null;
+  const safeFeed = feed || [];
+
   const counts = useMemo(() => {
     const c = {};
-    for (const item of feed) c[item.verb] = (c[item.verb] || 0) + 1;
+    for (const item of safeFeed) c[item.verb] = (c[item.verb] || 0) + 1;
     return c;
-  }, [feed]);
+  }, [safeFeed]);
 
-  const filtered = useMemo(() => filterFeed(feed, params), [feed, params]);
+  const filtered = useMemo(() => filterFeed(safeFeed, params), [safeFeed, params]);
   const collapsed = useMemo(() => collapseListens(filtered), [filtered]);
   const groups = useMemo(() => groupByDay(collapsed, (i) => i.createdAt), [collapsed]);
 
@@ -80,7 +86,9 @@ export default function Home() {
       headTitle="Dame is&hellip;"
     >
       <FeedFilters counts={counts} />
-      {filtered.length === 0 ? (
+      {loading ? (
+        <FeedSkeleton rows={8} />
+      ) : filtered.length === 0 ? (
         <p className="feed-empty">No records match these filters.</p>
       ) : (
         <ol className="feed-list">
@@ -96,9 +104,9 @@ export default function Home() {
           ))}
         </ol>
       )}
-      {loadedAt && (
+      {!loading && loadedAt && (
         <p className="gutter feed-loaded-at" style={{ marginTop: 'var(--space-7)', textAlign: 'center' }}>
-          {filtered.length} of {feed.length} records · refreshed {loadedAt.toLocaleTimeString()}
+          {filtered.length} of {safeFeed.length} records · refreshed {loadedAt.toLocaleTimeString()}
         </p>
       )}
     </PageShell>

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -4,20 +4,26 @@ import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import FeedSearch, { matchesQuery } from '../components/FeedSearch.jsx';
+import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { groupByDay } from '../lib/time.js';
 import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
 export default function Logging() {
-  const [items, setItems] = useState([]);
+  // `null` = snapshot still loading; `[]` = loaded but empty.
+  const [items, setItems] = useState(null);
   const [params] = useSearchParams();
   const q = params.get('q') || '';
 
   useEffect(() => {
     let cancelled = false;
     fetchSnapshot('now').then((snap) => {
-      if (cancelled || !Array.isArray(snap)) return;
+      if (cancelled) return;
+      if (!Array.isArray(snap)) {
+        setItems([]);
+        return;
+      }
       setItems(
         snap
           .filter((r) => r?.uri && r.value)
@@ -35,13 +41,15 @@ export default function Logging() {
     };
   }, []);
 
+  const loading = items === null;
+  const safeItems = items || [];
   const filtered = useMemo(
     () =>
-      items.filter((i) => {
+      safeItems.filter((i) => {
         const p = i.payload || {};
         return matchesQuery([p.status, p.text].filter(Boolean).join(' '), q);
       }),
-    [items, q],
+    [safeItems, q],
   );
   const groups = groupByDay(filtered, (i) => i.createdAt);
 
@@ -55,7 +63,9 @@ export default function Logging() {
       <div className="feed-filters feed-filters-search-only">
         <FeedSearch label="Search status updates" />
       </div>
-      {groups.length === 0 ? (
+      {loading ? (
+        <FeedSkeleton rows={5} label="Loading status updates" />
+      ) : groups.length === 0 ? (
         <p className="feed-empty">
           {q ? 'No status records match that search.' : 'No status records yet.'}
         </p>

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -4,20 +4,26 @@ import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import FeedSearch, { matchesQuery } from '../components/FeedSearch.jsx';
+import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { groupByDay } from '../lib/time.js';
 import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
 export default function Posting() {
-  const [items, setItems] = useState([]);
+  // `null` = snapshot still loading; `[]` = loaded but empty.
+  const [items, setItems] = useState(null);
   const [params] = useSearchParams();
   const q = params.get('q') || '';
 
   useEffect(() => {
     let cancelled = false;
     fetchSnapshot('posts').then((snap) => {
-      if (cancelled || !Array.isArray(snap)) return;
+      if (cancelled) return;
+      if (!Array.isArray(snap)) {
+        setItems([]);
+        return;
+      }
       const mapped = snap
         // Reposts are surfaced under the dedicated `reposting` verb (and
         // their own per-record pages). The /posting index only shows
@@ -57,9 +63,11 @@ export default function Posting() {
     };
   }, []);
 
+  const loading = items === null;
+  const safeItems = items || [];
   const filtered = useMemo(
-    () => items.filter((i) => matchesQuery(i.payload?.text, q)),
-    [items, q],
+    () => safeItems.filter((i) => matchesQuery(i.payload?.text, q)),
+    [safeItems, q],
   );
   const groups = groupByDay(filtered, (i) => i.createdAt);
 
@@ -73,7 +81,9 @@ export default function Posting() {
       <div className="feed-filters feed-filters-search-only">
         <FeedSearch label="Search posts" />
       </div>
-      {groups.length === 0 ? (
+      {loading ? (
+        <FeedSkeleton rows={6} label="Loading posts" />
+      ) : groups.length === 0 ? (
         <p className="feed-empty">{q ? 'No posts match that search.' : 'No posts yet.'}</p>
       ) : (
         <ol className="feed-list">

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -8,6 +8,7 @@ import BlogCard from '../components/BlogCard.jsx';
 import CreatingCard from '../components/CreatingCard.jsx';
 import Comments from '../components/Comments.jsx';
 import ReferenceCard from '../components/ReferenceCard.jsx';
+import { RecordSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, getRecord, getPostThread } from '../lib/atproto.js';
 import { ME_DID } from '../config.js';
@@ -191,10 +192,10 @@ export default function Record({ verb, nsid, source }) {
         {item ? (
           <RecordBody verb={verb} item={item} collection={collection} />
         ) : (
-          <p className="feed-empty">Loading record…</p>
+          <RecordSkeleton />
         )}
 
-        <RecordMeta collection={collection} createdAt={createdAt} />
+        {item && <RecordMeta collection={collection} createdAt={createdAt} />}
 
         {(verb === 'posting' || verb === 'reposting') && item?.atUri && (
           <Comments

--- a/src/pages/Sharing.jsx
+++ b/src/pages/Sharing.jsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
 import PageShell from '../components/PageShell.jsx';
+import { ProseSkeleton } from '../components/Skeleton.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
 export default function Sharing() {
+  // 'loading' = fetch in flight, 'ready' = resolved (possibly with no
+  // record). Splitting the flag from `record` lets us draw skeleton
+  // prose on first paint instead of the empty-state copy.
+  const [status, setStatus] = useState('loading');
   const [record, setRecord] = useState(null);
 
   useEffect(() => {
@@ -13,6 +18,7 @@ export default function Sharing() {
     fetchSnapshot('pages').then((pages) => {
       if (cancelled) return;
       if (pages && pages.sharing) setRecord(pages.sharing);
+      setStatus('ready');
     });
     return () => {
       cancelled = true;
@@ -32,7 +38,9 @@ export default function Sharing() {
       atUri={`at://${ME_DID}/is.dame.page/sharing`}
       headTitle="Sharing — Dame is&hellip;"
     >
-      {html ? (
+      {status === 'loading' ? (
+        <ProseSkeleton paragraphs={4} />
+      ) : html ? (
         <div className="blog-prose" dangerouslySetInnerHTML={{ __html: html }} />
       ) : (
         <p className="feed-empty">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a small skeleton-loading system that renders animated placeholders during the brief window between mount and the snapshot fetch resolving — replacing the previous plain-text "Loading…" copy on every record-driven page.

## What's new

A single skeleton module (`src/components/Skeleton.jsx` + `Skeleton.css`) exposes:

- **Primitives** — `Skeleton`, `SkeletonText`, `SkeletonShell`. Every block uses a CSS shimmer sweep (linear-gradient driven by `background-position`) so it reads as "blank parchment" rather than a generic Material loader. The shell wraps the column in a `motion.div` for a short fade-in (and a fade-out when paired with `AnimatePresence`).
- **Page-shaped variants** — `FeedSkeleton`, `BloggingTocSkeleton`, `CreatingGridSkeleton`, `RecordSkeleton`, `BlogPostSkeleton`, `CreatingWorkSkeleton`, `CommentsSkeleton`, `ProseSkeleton`. Each one mirrors the real layout's grid columns, gaps, and borders so the placeholder occupies the same footprint as the resulting content (no reflow when records arrive).

The shimmer respects `prefers-reduced-motion` (CSS disables the keyframe and falls back to a static page-edge block). The Motion fade is short (~250ms) so reduced-motion users still get a usable cue.

## Where it's wired

| Page | Skeleton |
|---|---|
| `Home`, `Posting`, `Logging` | `FeedSkeleton` (verb-badge + body rows) |
| `Blogging` | `BloggingTocSkeleton` (number + title + summary + meta) |
| `Creating` | `CreatingGridSkeleton` (4:3 thumb + kind/title/time) |
| `Sharing` | `ProseSkeleton` |
| `Record` | `RecordSkeleton` (replaces "Loading record…") |
| `BlogPost` | `BlogPostSkeleton` (replaces "Loading post…") |
| `CreatingWork` | `CreatingWorkSkeleton` (new — page previously rendered nothing while loading) |
| `Comments` (sub-component on post pages) | `CommentsSkeleton` (replaces "Loading replies…") |

## Loading-state pattern

Pages that previously initialized list state with `useState([])` now use `useState(null)`, so we can distinguish "snapshot fetch hasn't resolved" from "loaded but empty / no matches". The empty-state copy still renders correctly after load.

## Verified

- `npm run build:offline` is clean (one Vite warning about chunk size which already existed).
- `npm run dev` starts cleanly; `/`, `/src/components/Skeleton.jsx`, and `/src/pages/Home.jsx` all return 200.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9358a96-fe5a-49e6-bc43-211383038482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9358a96-fe5a-49e6-bc43-211383038482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

