### PR TITLE
Fix repost feed row overflow and stats typography on mobile

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -9,7 +9,10 @@
 
 .feed-item {
   display: grid;
-  grid-template-columns: 4.5rem 1fr;
+  /* minmax(0, 1fr) lets the card column shrink below min-content width
+     (long handles, monospace paths) so the row never forces horizontal
+     page scroll on narrow viewports. */
+  grid-template-columns: 4.5rem minmax(0, 1fr);
   gap: var(--space-4);
   align-items: start;
   padding-bottom: var(--space-4);
@@ -72,6 +75,7 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
   flex-direction: column;
   gap: var(--space-2);
   padding-bottom: var(--space-2);
+  min-width: 0;
 }
 
 .feed-card-meta {
@@ -143,6 +147,18 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
   color: var(--ink-faint);
 }
 
+/* Explicit metadata typography so stats never inherit the serif body
+   scale from a stretched grid/flex ancestor when min-width was wrong. */
+article.post-card > footer.post-card-stats {
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  line-height: var(--leading-tight);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
 .post-card-reply {
   font-size: var(--text-xs);
   letter-spacing: 0.12em;
@@ -188,12 +204,15 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
   display: flex;
   align-items: center;
   margin-bottom: var(--space-2);
+  min-width: 0;
 }
 
 .post-card-author-link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: var(--space-2);
+  min-width: 0;
+  flex: 1 1 auto;
   text-decoration: none;
   color: inherit;
   border-bottom: 1px solid transparent;
@@ -218,24 +237,32 @@ a.post-card-author-link:focus-visible {
 }
 
 .post-card-author-names {
-  display: inline-flex;
+  display: flex;
   align-items: baseline;
   gap: 0.4rem;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .post-card-author-name {
   font-family: var(--sans);
   font-size: var(--text-sm);
   color: var(--ink);
+  flex: 0 1 auto;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .post-card-author-handle {
+  flex: 0 1 auto;
+  min-width: 0;
   font-size: var(--text-xs);
   color: var(--ink-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* BlogCard */
@@ -915,7 +942,7 @@ a.post-card-author-link:focus-visible {
 
 @media (max-width: 700px) {
   .feed-item {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-2);
   }
   .feed-item-verb {

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -109,7 +109,7 @@ export default function PostCard({ verb, payload, createdAt, atUri, variant = 't
       )}
       {embed && <PostEmbed embed={embed} did={authorDid} />}
       {(payload?.replyCount || payload?.repostCount || payload?.likeCount) ? (
-        <footer className="post-card-stats gutter">
+        <footer className="post-card-stats">
           {payload?.replyCount ? `${payload.replyCount} replies` : ''}
           {payload?.replyCount && (payload?.repostCount || payload?.likeCount) ? ' · ' : ''}
           {payload?.repostCount ? `${payload.repostCount} reposts` : ''}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Repost rows that showed another author’s long display name and handle could force the feed grid past the viewport width, which produced horizontal scrolling on phones. Engagement counts under those cards sometimes inherited the wrong font scale when the layout was stretched.

## Changes

- Use `minmax(0, 1fr)` for feed grid columns (including the single-column mobile layout) and `min-width: 0` on `.feed-card` so grid/flex children are allowed to shrink below their min-content width.
- Rework the repost author header: the profile link is a full-width flex row with `min-width: 0`, and both display name and handle use flex-shrink with ellipsis so long handles truncate instead of widening the page.
- Define small mono typography directly on `article.post-card > footer.post-card-stats` and remove the redundant `gutter` class from that footer so stats stay consistent metadata regardless of ancestor sizing quirks.

## Testing

- `npm install` and `npm run build:offline` (Vite production build) succeeded locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-400e57e4-2c14-4eb5-aaca-4608a760cd71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-400e57e4-2c14-4eb5-aaca-4608a760cd71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

