### PR TITLE
Truncate long URLs in feed items and rich-text links

### DIFF
--- a/src/components/BlogCard.jsx
+++ b/src/components/BlogCard.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { rkeyFromAtUri } from '../lib/atproto.js';
+import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 
 /**
  * Compact card for a long-form entry inside the unified Home feed.
@@ -48,7 +49,9 @@ export default function BlogCard({ payload, atUri, source }) {
           <span className="small-caps blog-card-source">{resolvedSource}</span>
         )}
       </header>
-      {summary && <p className="blog-card-summary">{summary}</p>}
+      {summary && (
+        <p className="blog-card-summary">{renderPlainTextWithTruncatedUrls(summary)}</p>
+      )}
     </article>
   );
 }

--- a/src/components/CreatingCard.jsx
+++ b/src/components/CreatingCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 
 export default function CreatingCard({ payload, atUri }) {
   const slug = payload?.slug;
@@ -20,7 +21,9 @@ export default function CreatingCard({ payload, atUri }) {
           </h3>
         </header>
         {kind && <span className="small-caps creating-card-kind">{kind}</span>}
-        {summary && <p className="creating-card-summary">{summary}</p>}
+        {summary && (
+          <p className="creating-card-summary">{renderPlainTextWithTruncatedUrls(summary)}</p>
+        )}
       </div>
     </article>
   );

--- a/src/components/ReferenceCard.jsx
+++ b/src/components/ReferenceCard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { relativeTime } from '../lib/time.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { renderPostText } from '../lib/postRichText.jsx';
+import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import PostEmbed from './PostEmbed.jsx';
 import { ME_DID } from '../config.js';
 
@@ -258,7 +259,9 @@ function BskyProfilePreview({ view }) {
   return (
     <article className="reference-card-subject reference-card-subject-profile">
       {view.description && (
-        <p className="reference-card-subject-profile-desc">{view.description}</p>
+        <p className="reference-card-subject-profile-desc">
+          {renderPlainTextWithTruncatedUrls(view.description)}
+        </p>
       )}
     </article>
   );
@@ -271,7 +274,7 @@ function AtprotoRecordPreview({ record, source }) {
   if (!summary) return null;
   return (
     <article className="reference-card-subject reference-card-subject-atproto">
-      <p className="reference-card-subject-desc">{summary}</p>
+      <p className="reference-card-subject-desc">{renderPlainTextWithTruncatedUrls(summary)}</p>
     </article>
   );
 }

--- a/src/components/StatusEntry.jsx
+++ b/src/components/StatusEntry.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { relativeTime } from '../lib/time.js';
 import { rkeyFromAtUri } from '../lib/atproto.js';
+import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 
 export default function StatusEntry({ payload, atUri, createdAt }) {
   const text = (payload?.status || payload?.text || '').trim();
@@ -12,7 +13,9 @@ export default function StatusEntry({ payload, atUri, createdAt }) {
       <div className="status-entry-row">
         <p className="status-entry-text">
           <span className="status-entry-prefix">dame.is</span>{' '}
-          <span className="status-entry-body">{text || <em>—</em>}</span>
+          <span className="status-entry-body">
+            {text ? renderPlainTextWithTruncatedUrls(text) : <em>—</em>}
+          </span>
         </p>
         {ts && (
           recordHref ? (

--- a/src/components/cards/CommentCard.jsx
+++ b/src/components/cards/CommentCard.jsx
@@ -4,6 +4,8 @@
  * thing they comment on (`subject` / `on` / `target`). We surface the
  * comment text and a small "on …" hint linking to the parent.
  */
+import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
+
 export default function CommentCard({ payload, atUri, source }) {
   const text = payload?.text || payload?.body || payload?.content || '';
   const subjectRef = payload?.subject || payload?.on || payload?.target || null;
@@ -12,7 +14,9 @@ export default function CommentCard({ payload, atUri, source }) {
 
   return (
     <article className="comment-card feed-card" data-at-uri={atUri}>
-      <p className="comment-card-text">{text || <em>—</em>}</p>
+      <p className="comment-card-text">
+        {text ? renderPlainTextWithTruncatedUrls(text) : <em>—</em>}
+      </p>
       {subjectUri && (
         <p className="comment-card-on gutter small-caps">
           on{' '}

--- a/src/components/cards/GeneratorCard.jsx
+++ b/src/components/cards/GeneratorCard.jsx
@@ -1,3 +1,5 @@
+import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
+
 /**
  * Renders an `app.bsky.feed.generator` record — a custom feed that the
  * user has published. Avatar (when the record carries one as a blob) is
@@ -35,7 +37,9 @@ export default function GeneratorCard({ payload, atUri }) {
               displayName
             )}
           </h3>
-          {description && <p className="generator-card-desc">{description}</p>}
+          {description && (
+            <p className="generator-card-desc">{renderPlainTextWithTruncatedUrls(description)}</p>
+          )}
         </div>
       </div>
     </article>

--- a/src/components/cards/ListCard.jsx
+++ b/src/components/cards/ListCard.jsx
@@ -4,6 +4,8 @@
  * the underlying record, so `payload.members` (when populated) gives us
  * the count without an extra round-trip.
  */
+import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
+
 export default function ListCard({ payload, atUri }) {
   const name = payload?.name || 'Untitled list';
   const purpose = payload?.purpose || '';
@@ -26,7 +28,9 @@ export default function ListCard({ payload, atUri }) {
           <span className="small-caps list-card-purpose">{purposeLabel(purpose)}</span>
         )}
       </header>
-      {description && <p className="list-card-desc">{description}</p>}
+      {description && (
+        <p className="list-card-desc">{renderPlainTextWithTruncatedUrls(description)}</p>
+      )}
       {count > 0 && (
         <p className="gutter list-card-count">
           {count} {count === 1 ? 'member' : 'members'}

--- a/src/components/cards/MediaCard.jsx
+++ b/src/components/cards/MediaCard.jsx
@@ -4,6 +4,8 @@
  * blobs plus optional title and description; the card surfaces a thumb
  * grid (or first frame for stories) with caption + link out.
  */
+import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
+
 export default function MediaCard({ payload, atUri, source }) {
   const title = payload?.title || payload?.name || '';
   const description = payload?.description || payload?.caption || '';
@@ -25,7 +27,9 @@ export default function MediaCard({ payload, atUri, source }) {
               )}
             </h3>
           )}
-          {description && <p className="media-card-desc">{description}</p>}
+          {description && (
+            <p className="media-card-desc">{renderPlainTextWithTruncatedUrls(description)}</p>
+          )}
         </header>
       )}
       {visible.length > 0 && (

--- a/src/lib/feedUrlFormat.jsx
+++ b/src/lib/feedUrlFormat.jsx
@@ -1,0 +1,61 @@
+import { Fragment } from 'react';
+
+const DEFAULT_MAX_LEN = 52;
+
+/**
+ * Shorten a long URL for inline display (middle ellipsis). The full string
+ * should still be exposed via `href` / `title` where applicable.
+ */
+export function truncateUrlDisplay(url, maxLen = DEFAULT_MAX_LEN) {
+  const u = String(url);
+  if (u.length <= maxLen) return u;
+  const inner = maxLen - 1;
+  const left = Math.max(12, Math.ceil(inner * 0.45));
+  const right = inner - left;
+  return `${u.slice(0, left)}…${u.slice(-right)}`;
+}
+
+/**
+ * True when `s` is a single-line http(s) URL (typical facet link label).
+ */
+export function isLikelyBareHttpUrl(s) {
+  if (typeof s !== 'string') return false;
+  if (s.includes('\n') || s.includes('\r')) return false;
+  const t = s.trim();
+  return t.length >= 12 && /^https?:\/\//i.test(t) && !/\s/.test(t);
+}
+
+/**
+ * Split plain text on http(s) URLs and render each URL as a truncated
+ * outbound link (full URL in `href` and `title` when truncated).
+ */
+export function renderPlainTextWithTruncatedUrls(text) {
+  if (typeof text !== 'string' || !text) return text;
+  const re = /https?:\/\/[^\s<>"{}|\\^`[\]]+/gi;
+  const nodes = [];
+  let last = 0;
+  let key = 0;
+  let matched = false;
+  for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+    matched = true;
+    if (m.index > last) nodes.push(text.slice(last, m.index));
+    const url = m[0];
+    const label = truncateUrlDisplay(url);
+    nodes.push(
+      <a
+        key={`feedurl-${key++}`}
+        className="post-rich-link feed-plain-url-link"
+        href={url}
+        target="_blank"
+        rel="noreferrer noopener"
+        title={label.length < url.length ? url : undefined}
+      >
+        {label}
+      </a>,
+    );
+    last = m.index + url.length;
+  }
+  if (!matched) return text;
+  if (last < text.length) nodes.push(text.slice(last));
+  return <Fragment>{nodes}</Fragment>;
+}

--- a/src/lib/leafletRichText.jsx
+++ b/src/lib/leafletRichText.jsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import { isLikelyBareHttpUrl, truncateUrlDisplay } from './feedUrlFormat.jsx';
 
 /**
  * Render leaflet `plaintext` + `facets` to React. Mirrors the bsky
@@ -82,19 +83,26 @@ function wrapWithFeatures(features, text) {
     .map((f) => f?.$type)
     .filter((t) => INLINE_FORMATS[t]);
 
-  let node = withLineBreaks(text);
+  const trimmed = text.trim();
+  const useTrunc = Boolean(link?.uri) && isLikelyBareHttpUrl(text);
+  const sourceText = useTrunc ? truncateUrlDisplay(trimmed) : text;
+
+  let node = withLineBreaks(sourceText);
   for (const t of formatTypes) {
     const Wrapper = INLINE_FORMATS[t];
     node = <Wrapper>{node}</Wrapper>;
   }
 
   if (link?.uri) {
+    const titleAttr =
+      useTrunc && sourceText.length < trimmed.length ? trimmed : undefined;
     return (
       <a
         className="post-rich-link"
         href={link.uri}
         target="_blank"
         rel="noreferrer noopener"
+        title={titleAttr}
       >
         {node}
       </a>

--- a/src/lib/postRichText.jsx
+++ b/src/lib/postRichText.jsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { ME_DID } from '../config.js';
+import { isLikelyBareHttpUrl, truncateUrlDisplay } from './feedUrlFormat.jsx';
 
 /**
  * Render `app.bsky.feed.post#text` with its `facets` resolved into
@@ -89,17 +90,24 @@ function renderFeature(feature, text) {
   if (!feature) return text;
   switch (feature.$type) {
     case 'app.bsky.richtext.facet#link':
-    case 'pub.leaflet.richtext.facet#link':
+    case 'pub.leaflet.richtext.facet#link': {
+      const trimmed = text.trim();
+      const useTrunc = isLikelyBareHttpUrl(text);
+      const label = useTrunc ? truncateUrlDisplay(trimmed) : text;
+      const titleAttr =
+        useTrunc && label.length < trimmed.length ? trimmed : undefined;
       return (
         <a
           className="post-rich-link"
           href={feature.uri}
           target="_blank"
           rel="noreferrer noopener"
+          title={titleAttr}
         >
-          {text}
+          {label}
         </a>
       );
+    }
     case 'app.bsky.richtext.facet#mention': {
       // Strip a leading "@" so we can re-render it consistently as part of
       // the link label; the facet text usually already includes it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long `http(s)` URLs were shown in full inside several feed card bodies (for example custom feed descriptions) and in Bluesky/Leaflet rich-text link facets, which stretched layouts on narrow viewports.

## Changes

- Added `src/lib/feedUrlFormat.jsx` with `truncateUrlDisplay` (middle ellipsis), `isLikelyBareHttpUrl`, and `renderPlainTextWithTruncatedUrls` for plain string fields.
- Rich-text link facets in `postRichText.jsx` and `leafletRichText.jsx` now shorten bare URL labels while keeping the full destination in `href` and a `title` tooltip when the label is shortened.
- Plain-text summaries and descriptions on generator, list, media, blog, creating, status, comment, and reference preview cards turn detected URLs into outbound links with shortened labels.

## Verification

- `npm run build:offline` succeeds after `npm install`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a131a453-4a81-472a-80b9-981bb279f765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a131a453-4a81-472a-80b9-981bb279f765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

