### PR TITLE
Reply posts: show “replying to …” as the feed verb header

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -70,6 +70,29 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
   border-bottom-color: var(--accent-soft);
 }
 
+.feed-item.feed-item-reply-verb {
+  grid-template-columns: 5.25rem minmax(0, 1fr);
+}
+
+.feed-item-verb.feed-item-verb-reply {
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  text-align: right;
+}
+
+.feed-item-verb-label-reply {
+  line-height: 1.35;
+  letter-spacing: 0.12em;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+.feed-item-verb-reply-handle {
+  color: var(--ink-soft);
+  letter-spacing: 0.08em;
+}
+
 .feed-card {
   display: flex;
   flex-direction: column;
@@ -952,6 +975,9 @@ a.post-card-author-link:focus-visible {
     text-align: left;
     padding-top: 0;
     justify-self: start;
+  }
+  .feed-item-verb.feed-item-verb-reply {
+    align-items: flex-start;
   }
   .creating-card {
     grid-template-columns: 1fr;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { CornerDownRight } from 'lucide-react';
 import StatusEntry from './StatusEntry.jsx';
 import PostCard from './PostCard.jsx';
 import BlogCard from './BlogCard.jsx';
@@ -12,6 +13,7 @@ import CommentCard from './cards/CommentCard.jsx';
 import VoteCard from './cards/VoteCard.jsx';
 import VerbIcon from './VerbIcon.jsx';
 import { rkeyFromAtUri } from '../lib/atproto.js';
+import { getReplyHint } from '../lib/postReplyHint.js';
 import { verbConfig, recordHrefFor } from '../lib/verbRegistry.js';
 
 /**
@@ -31,6 +33,23 @@ const RENDERERS = {
   CommentCard,
   VoteCard,
 };
+
+function postingReplyVerbLabel(reply) {
+  switch (reply.kind) {
+    case 'resolved':
+      return (
+        <>
+          replying to{' '}
+          <span className="feed-item-verb-reply-handle">@{reply.handle}</span>
+        </>
+      );
+    case 'missing':
+      return <>replying to {reply.label}</>;
+    case 'unresolved':
+    default:
+      return <>replying to a post</>;
+  }
+}
 
 /**
  * Per-record route. Verbs may declare a custom `recordHref` template in
@@ -58,20 +77,47 @@ export default function FeedItem({ item }) {
   const Component = cfg.renderer ? RENDERERS[cfg.renderer] : null;
   if (!Component) return null;
   const href = hrefFor(item);
+  const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
+  const replyAsVerbColumn = Boolean(replyHint);
+  const verbClassName = [
+    'feed-item-verb',
+    'small-caps',
+    replyAsVerbColumn ? 'feed-item-verb-reply' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const verbInner = replyAsVerbColumn ? (
+    <>
+      <CornerDownRight size={15} strokeWidth={1.75} className="feed-item-verb-icon" aria-hidden="true" />
+      <span className="feed-item-verb-label feed-item-verb-label-reply">
+        {postingReplyVerbLabel(replyHint)}
+      </span>
+    </>
+  ) : (
+    <>
+      <VerbIcon verb={item.verb} size={15} className="feed-item-verb-icon" />
+      <span className="feed-item-verb-label">{item.verb}</span>
+    </>
+  );
   return (
-    <li className={`feed-item feed-item-${item.verb}`} data-verb={item.verb}>
+    <li
+      className={`feed-item feed-item-${item.verb}${replyAsVerbColumn ? ' feed-item-reply-verb' : ''}`}
+      data-verb={item.verb}
+    >
       {href ? (
-        <Link className="feed-item-verb small-caps" to={href}>
-          <VerbIcon verb={item.verb} size={15} className="feed-item-verb-icon" />
-          <span className="feed-item-verb-label">{item.verb}</span>
+        <Link className={verbClassName} to={href}>
+          {verbInner}
         </Link>
       ) : (
-        <span className="feed-item-verb small-caps">
-          <VerbIcon verb={item.verb} size={15} className="feed-item-verb-icon" />
-          <span className="feed-item-verb-label">{item.verb}</span>
+        <span className={verbClassName}>
+          {verbInner}
         </span>
       )}
-      <Component {...item} verb={item.verb} />
+      <Component
+        {...item}
+        verb={item.verb}
+        suppressReplyBadge={replyAsVerbColumn}
+      />
     </li>
   );
 }

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -4,37 +4,17 @@ import { relativeTime } from '../lib/time.js';
 import { rkeyFromAtUri } from '../lib/atproto.js';
 import { ME_DID } from '../config.js';
 import { renderPostText } from '../lib/postRichText.jsx';
+import { getReplyHint } from '../lib/postReplyHint.js';
 import PostEmbed from './PostEmbed.jsx';
 
-/**
- * Pull a parent-post hint from the payload. Prefers the AppView's resolved
- * `payload.parent` (has handle + text), falls back to the `payload.reply`
- * record itself (URI only, lets us still link out).
- */
-function getReplyHint(payload) {
-  if (!payload) return null;
-  const parent = payload.parent;
-  if (parent?.$type === 'app.bsky.feed.defs#notFoundPost') {
-    return { kind: 'missing', label: 'a deleted post', uri: parent.uri || null };
-  }
-  if (parent?.$type === 'app.bsky.feed.defs#blockedPost') {
-    return { kind: 'missing', label: 'a blocked post', uri: parent.uri || null };
-  }
-  if (parent?.author?.handle) {
-    return {
-      kind: 'resolved',
-      handle: parent.author.handle,
-      uri: parent.uri,
-    };
-  }
-  // Last-ditch: we only have the at:// uri from the record's reply field.
-  if (payload.reply?.parent?.uri) {
-    return { kind: 'unresolved', uri: payload.reply.parent.uri };
-  }
-  return null;
-}
-
-export default function PostCard({ verb, payload, createdAt, atUri, variant = 'timeline' }) {
+export default function PostCard({
+  verb,
+  payload,
+  createdAt,
+  atUri,
+  variant = 'timeline',
+  suppressReplyBadge = false,
+}) {
   const text = payload?.text || '';
   const facets = payload?.facets || null;
   const ts = createdAt || payload?.indexedAt;
@@ -43,9 +23,10 @@ export default function PostCard({ verb, payload, createdAt, atUri, variant = 't
     || payload?.reason?.$type === 'app.bsky.feed.defs#reasonRepost';
   const recordHref = rkey ? `/${isRepost ? 'reposting' : 'posting'}/${rkey}` : null;
   const reply = getReplyHint(payload);
-  // Show the "↳ replying to …" badge in the timeline only. On the record
-  // page itself, the parent chain renders above and would duplicate it.
-  const showReplyBadge = reply && variant !== 'parent' && variant !== 'record';
+  // Inline "↳ replying to …" only when the feed verb column is not already
+  // showing that context (see FeedItem). Hidden on record/parent views.
+  const showReplyBadge =
+    reply && variant !== 'parent' && variant !== 'record' && !suppressReplyBadge;
   const embed = payload?.embed || payload?.embedRecord || null;
   const authorDid = payload?.author?.did;
   const isOriginalAuthorMe = authorDid === ME_DID;

--- a/src/lib/postReplyHint.js
+++ b/src/lib/postReplyHint.js
@@ -1,0 +1,26 @@
+/**
+ * Pull a parent-post hint from a Bluesky post payload. Prefers the AppView's
+ * resolved `payload.parent` (has handle + text), falls back to the
+ * `payload.reply` record itself (URI only, lets us still link out).
+ */
+export function getReplyHint(payload) {
+  if (!payload) return null;
+  const parent = payload.parent;
+  if (parent?.$type === 'app.bsky.feed.defs#notFoundPost') {
+    return { kind: 'missing', label: 'a deleted post', uri: parent.uri || null };
+  }
+  if (parent?.$type === 'app.bsky.feed.defs#blockedPost') {
+    return { kind: 'missing', label: 'a blocked post', uri: parent.uri || null };
+  }
+  if (parent?.author?.handle) {
+    return {
+      kind: 'resolved',
+      handle: parent.author.handle,
+      uri: parent.uri,
+    };
+  }
+  if (payload.reply?.parent?.uri) {
+    return { kind: 'unresolved', uri: payload.reply.parent.uri };
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reply threads on the home feed and `/posting` used to show **posting** in the left verb column plus a second **↳ replying to …** line inside the card. That stacked two different ways of describing the same activity.

## Changes

- **Feed verb column:** For Bluesky posts that are replies, the left rail now shows a reply icon and **replying to @handle** (or the same fallbacks as before for missing/blocked parents) as the primary linked label, still pointing at `/posting/:rkey`.
- **Card body:** The inline reply badge is hidden in that case so the context is not duplicated.
- **Shared helper:** `getReplyHint` lives in `src/lib/postReplyHint.js` and is used by both `FeedItem` and `PostCard`.
- **Layout:** Reply rows use a slightly wider verb column on desktop so the wrapped label fits; mobile keeps a single-column feed with the verb row above the card.

## Verification

- `npm run build:offline` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce2f8915-a5fb-4b42-8c4b-42aaff6b8225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce2f8915-a5fb-4b42-8c4b-42aaff6b8225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

