### PR TITLE
ChromeBar: keep the status signal visible on collapsed mobile

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -239,11 +239,3 @@
     gap: var(--space-2);
   }
 }
-
-/* On collapsed state, hide the primary row's status signal on very narrow
-   screens so the title + handle have room. Tap-to-expand brings it back. */
-@media (max-width: 480px) {
-  .chrome-bar.is-collapsed .chrome-signals-primary {
-    display: none;
-  }
-}


### PR DESCRIPTION
## Summary

The collapsed chrome bar hid `.chrome-signals-primary` on screens ≤480px so the title + expand handle had room. You'd rather see a truncated status than nothing — the existing `TickerText` plus `.chrome-signal-value { overflow: hidden; text-overflow: ellipsis; }` already handle narrow viewports cleanly.

## Change

- `src/components/ChromeBar.css`: drop the `@media (max-width: 480px) { .chrome-bar.is-collapsed .chrome-signals-primary { display: none; } }` rule. Status now reads on mobile regardless of expansion state, ellipsizing when space runs out.

## Test plan

- [x] `npm run build:offline` succeeds
- [ ] Visual check on mobile (≤480px wide): collapsed chrome bar shows `dame.is <status text…>` with the expand handle still on the right
- [ ] Expand still works and reveals the three secondary signals

https://claude.ai/code/session_01M54y6h5pAzbK4uAPbRVKnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M54y6h5pAzbK4uAPbRVKnr)_