### PR TITLE
Remove dim/blur backdrop from default modals

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -34,8 +34,9 @@
   display: block;
 }
 
-/* The scrim is purely a visual layer for the dim variant. Clicks pass
-   through it to the modal-root underneath, which owns dismissal.
+/* The scrim is purely a visual layer for the "dark" lightbox variant —
+   default modals render no scrim at all. Clicks pass through it to the
+   modal-root underneath, which owns dismissal.
 
    We deliberately inset the scrim's top/bottom by --chrome-h so it
    doesn't cover the chrome bars: iOS Safari samples the visible page
@@ -58,12 +59,9 @@
 /* The dim color and blur radius are driven by motion inline styles
    (see Modal.jsx) so the close animation can interpolate them to 0
    smoothly. Setting them here too would cause a one-frame flash of
-   the static values before motion's initial state applies. */
-.modal-scrim-dim {
-  background-color: rgba(0, 0, 0, 0);
-}
+   the static values before motion's initial state applies.
 
-/* Dark scrim is used for immersive surfaces like the image lightbox
+   Dark scrim is used for immersive surfaces like the image lightbox
    where the chrome bars should also dim out — bypass the chrome-bar
    inset and cover the full viewport again. */
 .modal-scrim-dark {

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -36,13 +36,14 @@ const PRESETS = {
  *
  * Outside-click dismissal lives on the modal-root div itself (gated by
  * `e.target === e.currentTarget`) rather than a separate scrim button.
- * The transparent variant therefore renders zero scrim elements — no
- * backdrop-filter compositor layer to tear down on close, which is what
- * caused the underlying page to flash darker mid-transition.
+ * Default modals therefore render zero scrim elements — no dim, no blur,
+ * no backdrop-filter compositor layer to tear down on close. The panel's
+ * own drop-shadow is the sole depth cue separating it from the page.
  *
- * The dim variant adds a non-interactive motion.div as the visual layer,
- * animating its backgroundColor and backdropFilter directly (not opacity)
- * so both ramp smoothly to 0 instead of snapping off at unmount.
+ * The "dark" variant (image lightbox) is the lone exception: it adds a
+ * non-interactive motion.div as the visual layer, animating its
+ * backgroundColor and backdropFilter directly (not opacity) so both ramp
+ * smoothly to 0 instead of snapping off at unmount.
  */
 export default function Modal({
   open,
@@ -71,12 +72,15 @@ export default function Modal({
   const ease = [0.32, 0.72, 0, 1];
   const panelDuration = reduce ? 0 : 0.24;
   const scrimDuration = reduce ? 0 : 0.24;
-  const isDim = scrim === 'dim' || scrim === 'dark';
-  // "dark" — pushes the scrim well past the default tint/blur, for
-  // surfaces like the image lightbox where the photo needs to read
-  // against the page rather than alongside it.
-  const dimColor = scrim === 'dark' ? 'rgba(0, 0, 0, 0.78)' : 'rgba(0, 0, 0, 0.08)';
-  const dimBlur = scrim === 'dark' ? 'blur(8px)' : 'blur(2px)';
+  // Only the "dark" variant paints a scrim — an immersive tint + blur for
+  // surfaces like the image lightbox where the photo needs to read against
+  // the page rather than alongside it. The default ("dim") and "none"
+  // modes render no visual layer; default modals lean on the panel's
+  // drop-shadow alone, while still dismissing on outside click because
+  // that's owned by modal-root (see handleRootClick), not the scrim.
+  const paintsScrim = scrim === 'dark';
+  const dimColor = 'rgba(0, 0, 0, 0.78)';
+  const dimBlur = 'blur(8px)';
 
   function handleRootClick(e) {
     if (!open || scrim === 'none') return;
@@ -99,7 +103,7 @@ export default function Modal({
       onClick={handleRootClick}
     >
       <AnimatePresence>
-        {open && isDim && (
+        {open && paintsScrim && (
           <motion.div
             key="scrim-dim"
             className={`modal-scrim modal-scrim-${scrim}`}


### PR DESCRIPTION
Default modals no longer dim or blur the page behind them. The panel's own drop-shadow is now the sole depth cue separating it from the page.

## Changes
- The default `dim` scrim renders no visual layer — no background tint, no `backdrop-filter` blur.
- Outside-click dismissal is unaffected (it's owned by `modal-root`, not the scrim).
- The immersive image lightbox keeps its `dark` scrim unchanged.
- Removed the now-dead `.modal-scrim-dim` CSS rule and updated surrounding comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014FL9zMLGpD2YKP38mQyiKi)_