### PR TITLE
Collapse consecutive newlines in feed post text

### DIFF
--- a/src/lib/postRichText.jsx
+++ b/src/lib/postRichText.jsx
@@ -156,8 +156,14 @@ function renderFeature(feature, text) {
 
 function withLineBreaks(text) {
   if (!text) return null;
-  if (!text.includes('\n')) return text;
-  const parts = text.split('\n');
+  // Collapse runs of consecutive newlines into a single line break. Authors
+  // often separate paragraphs with a blank line ("\n\n"), which would
+  // otherwise render as <br><br> — a full empty line that reads as an
+  // oversized gap in the compact feed. One <br> keeps the break visible
+  // without the extra dead space.
+  const normalized = text.replace(/\n{2,}/g, '\n');
+  if (!normalized.includes('\n')) return normalized;
+  const parts = normalized.split('\n');
   const out = [];
   parts.forEach((part, i) => {
     if (part) out.push(<Fragment key={`s-${i}`}>{part}</Fragment>);


### PR DESCRIPTION
## Summary

Feed posts authored with a blank line between paragraphs (`\n\n`) were rendering as `<br><br>` — a full empty line that reads as an oversized gap in the compact feed. This collapses runs of consecutive newlines into a single line break so the break stays visible without the extra dead space.

## Changes

- `src/lib/postRichText.jsx`: in `withLineBreaks`, normalize `\n{2,}` → `\n` before splitting into `<br>` elements.

The collapse happens inside `withLineBreaks` (operating on already-sliced text segments) rather than on the raw text, so it doesn't disturb the byte-offset math that rich-text facets (links/mentions/tags) depend on.

Long-form Leaflet rendering (`leafletRichText.jsx`) is intentionally left untouched, where paragraph spacing is desirable.

## Testing

- `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014KEmiqN9UB5FcfVU8NCSzq)_