### PR TITLE
Render post paragraph breaks with a small gap

### DIFF
--- a/src/lib/postRichText.jsx
+++ b/src/lib/postRichText.jsx
@@ -156,18 +156,26 @@ function renderFeature(feature, text) {
 
 function withLineBreaks(text) {
   if (!text) return null;
-  // Collapse runs of consecutive newlines into a single line break. Authors
-  // often separate paragraphs with a blank line ("\n\n"), which would
-  // otherwise render as <br><br> — a full empty line that reads as an
-  // oversized gap in the compact feed. One <br> keeps the break visible
-  // without the extra dead space.
-  const normalized = text.replace(/\n{2,}/g, '\n');
-  if (!normalized.includes('\n')) return normalized;
-  const parts = normalized.split('\n');
+  if (!text.includes('\n')) return text;
+  // Distinguish a single line break from a paragraph break. Splitting on
+  // (\n+) keeps the newline runs as their own array entries so we can tell
+  // them apart: one "\n" is a plain line break (<br>), while a blank line
+  // ("\n\n" or more) is a paragraph break. We render the paragraph break as
+  // a block spacer rather than <br><br> so it gets a small, controlled gap
+  // — visible separation without the oversized full-empty-line dead space.
+  const parts = text.split(/(\n+)/);
   const out = [];
   parts.forEach((part, i) => {
-    if (part) out.push(<Fragment key={`s-${i}`}>{part}</Fragment>);
-    if (i < parts.length - 1) out.push(<br key={`br-${i}`} />);
+    if (part === '') return;
+    if (part[0] === '\n') {
+      if (part.length >= 2) {
+        out.push(<span className="post-para-break" key={`p-${i}`} />);
+      } else {
+        out.push(<br key={`br-${i}`} />);
+      }
+      return;
+    }
+    out.push(<Fragment key={`s-${i}`}>{part}</Fragment>);
   });
   return out;
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -128,3 +128,12 @@ blockquote {
   margin: var(--space-6) 0;
 }
 
+
+/* Paragraph break inside rendered post text (see renderPostText). A blank
+   line in the source ("\n\n") becomes one of these block spacers instead of
+   a doubled <br>, giving a small paragraph gap — visible separation without
+   a full empty line's worth of dead space. */
+.post-para-break {
+  display: block;
+  height: 0.5em;
+}


### PR DESCRIPTION
## Summary

Follow-up to #46. That change collapsed a blank line (`\n\n`) down to a single line break, which removed paragraph separation entirely. This reintroduces *some* paragraph spacing — just less than a full empty line.

A blank line in the source now renders as a dedicated block spacer with a small `0.5em` gap, instead of either `<br><br>` (too much) or a single `<br>` (no gap). Single line breaks (`\n`) still render as a plain `<br>`.

## Changes

- `src/lib/postRichText.jsx`: `withLineBreaks` now splits on `(\n+)` so it can tell a single newline from a blank line, emitting `<br>` for the former and a `<span class="post-para-break">` block spacer for the latter.
- `src/styles/typography.css`: `.post-para-break { display: block; height: 0.5em; }`.

Long-form Leaflet rendering (`leafletRichText.jsx`) remains untouched.

## Testing

- `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014KEmiqN9UB5FcfVU8NCSzq)_