### PR TITLE
Admin: Local-vs-PDS page management + hero phrase lexicon

### DIFF
--- a/lexicons/is.dame.hero.phrase.json
+++ b/lexicons/is.dame.hero.phrase.json
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.hero.phrase",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["part", "text", "createdAt"],
+        "properties": {
+          "part":      { "type": "string", "enum": ["role", "clause"], "description": "Which pool the phrase belongs to. \"role\" fills 'dame is [a design engineer]'; \"clause\" fills 'who [makes social software]'." },
+          "text":      { "type": "string", "maxLength": 200, "description": "The phrase. For role, include the article (e.g. \"an artist\"); for clause, start with \"who …\"." },
+          "enabled":   { "type": "boolean", "default": true, "description": "When false, the phrase is excluded from the rotation." },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -123,6 +123,14 @@ async function main() {
   }
   await writeJson('pages', pages);
 
+  // --- Hero phrases (is.dame.hero.phrase) -----------------------------------
+  const heroPhrases = await safe(
+    'listRecords:heroPhrase',
+    () => listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.heroPhrase, max: 200 }),
+    [],
+  );
+  await writeJson('hero', heroPhrases);
+
   // --- Registry-driven ingest (delegated to the shared builder) -------------
   const { unified, perCollection, perVerb, authorFeed, counts } = await buildUnifiedFeed({
     pds,

--- a/src/components/HeroSentence.jsx
+++ b/src/components/HeroSentence.jsx
@@ -1,5 +1,8 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { resolvePds, listRecords } from '../lib/atproto.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
 
 /**
  * The home-page hero is one combinatorial sentence:
@@ -10,10 +13,12 @@ import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
  * intervals (random 4–8 s) so you almost never see the same pair
  * twice in a row. "dame is" itself stays put as the muted lead.
  *
- * Pools are intentionally short and editable in-file — adding a new
- * role or clause is a one-line append to the relevant const.
+ * Phrases live on the PDS as `is.dame.hero.phrase` records (managed in
+ * the admin panel) and are loaded at runtime. The in-file VARIANTS_A /
+ * VARIANTS_B arrays below are the fallback shown before/without any
+ * records, and the seed the admin "Seed defaults" button writes.
  */
-const VARIANTS_A = [
+export const VARIANTS_A = [
   'a design engineer',
   'an artist',
   'a lepidopterist',
@@ -26,7 +31,7 @@ const VARIANTS_A = [
   'an interface designer',
 ];
 
-const VARIANTS_B = [
+export const VARIANTS_B = [
   'who sometimes stays up late mothing',
   'who makes social software with open protocols',
   'who unconsciously hums christmas music all year round',
@@ -61,6 +66,36 @@ const wordVariants = {
 
 export default function HeroSentence({ shuffleRef = null } = {}) {
   const reduce = useReducedMotion();
+
+  // Phrases come from the PDS (`is.dame.hero.phrase`), snapshot-first with a
+  // live overlay. The in-file VARIANTS_* arrays are the fallback when the
+  // collection is empty or unreachable.
+  const { items: heroRecords } = useLiveFeed({
+    name: 'hero',
+    strategy: 'snapshot-first',
+    fetchLive: async () => {
+      const pds = await resolvePds(ME_DID);
+      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.heroPhrase, max: 200 });
+    },
+    mapItems: (snap) => (Array.isArray(snap) ? snap.filter((r) => r?.value) : []),
+  });
+
+  // Split records into the two pools by `part`, dropping disabled ones.
+  // Fallback is per-part: if the PDS has roles but no clauses, clauses use
+  // the in-file defaults rather than emptying the second half of the sentence.
+  const { poolA, poolB } = useMemo(() => {
+    const recs = heroRecords || [];
+    const enabled = recs.filter(
+      (r) => r.value?.enabled !== false && typeof r.value?.text === 'string' && r.value.text.trim(),
+    );
+    const roles = enabled.filter((r) => r.value.part === 'role').map((r) => r.value.text);
+    const clauses = enabled.filter((r) => r.value.part === 'clause').map((r) => r.value.text);
+    return {
+      poolA: roles.length ? roles : VARIANTS_A,
+      poolB: clauses.length ? clauses : VARIANTS_B,
+    };
+  }, [heroRecords]);
+
   // Random starting pair so returning visitors don't always see the
   // same opener. Under reduced motion both pin to 0 for a predictable,
   // non-surprising default.
@@ -71,6 +106,13 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
     reduce ? 0 : Math.floor(Math.random() * VARIANTS_B.length),
   );
 
+  // Pools are dynamic (they load and can change). Keep indices in range so
+  // `Rotator` never dereferences an out-of-bounds phrase.
+  useEffect(() => {
+    setIndexA((i) => (poolA.length ? i % poolA.length : 0));
+    setIndexB((i) => (poolB.length ? i % poolB.length : 0));
+  }, [poolA.length, poolB.length]);
+
   // Imperative shuffle handle the parent (Home) wires to a button so
   // users can advance the sentence manually instead of waiting for the
   // next timed swap. Always picks a fresh A and B both — picking the
@@ -78,13 +120,13 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
   useEffect(() => {
     if (!shuffleRef) return undefined;
     shuffleRef.current = () => {
-      setIndexA((i) => pickDifferent(i, VARIANTS_A.length));
-      setIndexB((i) => pickDifferent(i, VARIANTS_B.length));
+      setIndexA((i) => pickDifferent(i, poolA.length));
+      setIndexB((i) => pickDifferent(i, poolB.length));
     };
     return () => {
       if (shuffleRef.current) shuffleRef.current = null;
     };
-  }, [shuffleRef]);
+  }, [shuffleRef, poolA.length, poolB.length]);
   const [paused, setPaused] = useState(false);
   const [minHeight, setMinHeight] = useState(null);
   const wrapRef = useRef(null);
@@ -97,11 +139,11 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
     if (reduce || paused) return;
     const ms = 4000 + Math.random() * 4000;
     const id = setTimeout(
-      () => setIndexA((i) => (i + 1) % VARIANTS_A.length),
+      () => setIndexA((i) => (i + 1) % poolA.length),
       ms,
     );
     return () => clearTimeout(id);
-  }, [indexA, paused, reduce]);
+  }, [indexA, paused, reduce, poolA.length]);
 
   // Part-B timer: same logic, but a small phase offset (4500 base
   // instead of 4000) so A and B drift independently rather than
@@ -110,11 +152,11 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
     if (reduce || paused) return;
     const ms = 4500 + Math.random() * 4000;
     const id = setTimeout(
-      () => setIndexB((i) => (i + 1) % VARIANTS_B.length),
+      () => setIndexB((i) => (i + 1) % poolB.length),
       ms,
     );
     return () => clearTimeout(id);
-  }, [indexB, paused, reduce]);
+  }, [indexB, paused, reduce, poolB.length]);
 
   // Pause when the tab is hidden — otherwise the timer fires
   // unattended and the user comes back to an arbitrary mid-cycle pair.
@@ -173,8 +215,8 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
       onBlurCapture={() => setPaused(false)}
     >
       <span className="hero-sentence-lead">dame is</span>{' '}
-      <Rotator index={indexA} pool={VARIANTS_A} reduce={reduce} className="hero-rotator-a" />{' '}
-      <Rotator index={indexB} pool={VARIANTS_B} reduce={reduce} className="hero-rotator-b" />
+      <Rotator index={indexA} pool={poolA} reduce={reduce} className="hero-rotator-a" />{' '}
+      <Rotator index={indexB} pool={poolB} reduce={reduce} className="hero-rotator-b" />
 
       {/* Each measure entry mirrors the live nested structure (lead +
           two inline-block rotators) so wrapping at the rotator
@@ -187,8 +229,8 @@ export default function HeroSentence({ shuffleRef = null } = {}) {
         className="hero-sentence-measure"
         ref={measureRef}
       >
-        {VARIANTS_A.flatMap((a) =>
-          VARIANTS_B.map((b) => (
+        {poolA.flatMap((a) =>
+          poolB.map((b) => (
             <span key={`${a}|${b}`}>
               <span className="hero-sentence-lead">dame is</span>{' '}
               <span className="hero-rotator hero-rotator-a">
@@ -217,8 +259,12 @@ function pickDifferent(current, length) {
 function Rotator({ index, pool, reduce, className = '' }) {
   // Split the active phrase into words once per index change. Real
   // space text nodes between word spans preserve the wrap-anywhere
-  // behavior the measure layer already counts on.
-  const words = useMemo(() => pool[index].split(' '), [pool, index]);
+  // behavior the measure layer already counts on. Guard the lookup: the
+  // pool can change a render before the parent clamps `index` back in range.
+  const words = useMemo(() => {
+    const phrase = pool[index] ?? pool[0] ?? '';
+    return phrase.split(' ');
+  }, [pool, index]);
 
   return (
     <span className={`hero-rotator ${className}`}>

--- a/src/components/PageContentPanel.jsx
+++ b/src/components/PageContentPanel.jsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { pageDefault } from '../lib/pageRegistry.js';
+import { blankRecordFor } from '../lib/lexicons.js';
+import { COLLECTIONS } from '../config.js';
+
+/**
+ * Local-vs-PDS control for a single page's chrome (title / intro / body).
+ *
+ * Shows whether an `is.dame.page/<slug>` record exists and lets the owner
+ * migrate the hardcoded defaults onto the PDS, edit the record, or revert
+ * back to local (delete the record).
+ *
+ * Used in two places:
+ *   - embedded atop a backing collection's record list (self-fetches status)
+ *   - the standalone Site-pages overview (status seeded via the `exists` prop
+ *     from one batched listRecords, so it skips the per-panel getRecord)
+ */
+export default function PageContentPanel({ agent, did, slug, exists: initialExists }) {
+  const def = pageDefault(slug);
+  const [exists, setExists] = useState(initialExists);
+  const [checking, setChecking] = useState(initialExists === undefined);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Self-fetch status when the caller didn't supply it (embedded usage).
+  useEffect(() => {
+    if (initialExists !== undefined) {
+      setExists(initialExists);
+      setChecking(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setChecking(true);
+    agent.com.atproto.repo
+      .getRecord({ repo: did, collection: COLLECTIONS.page, rkey: slug })
+      .then(() => {
+        if (!cancelled) setExists(true);
+      })
+      .catch(() => {
+        if (!cancelled) setExists(false);
+      })
+      .finally(() => {
+        if (!cancelled) setChecking(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did, slug, initialExists]);
+
+  const migrate = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const record = { ...blankRecordFor(COLLECTIONS.page), title: def.title, intro: def.intro };
+      if (def.body) record.body = def.body;
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: COLLECTIONS.page,
+        rkey: slug,
+        record,
+      });
+      setExists(true);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [agent, did, slug, def]);
+
+  const revert = useCallback(async () => {
+    if (
+      !window.confirm(
+        `Revert "${def.label}" to local? This deletes is.dame.page/${slug} from your PDS; the page falls back to its hardcoded title and intro.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await agent.com.atproto.repo.deleteRecord({ repo: did, collection: COLLECTIONS.page, rkey: slug });
+      setExists(false);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [agent, did, slug, def]);
+
+  if (!def) return null;
+
+  return (
+    <div className="admin-page-panel">
+      <div className="admin-page-panel-head">
+        <span className="admin-page-panel-label">{def.label} — page content</span>
+        <span className={`admin-badge ${exists ? 'admin-badge-pds' : 'admin-badge-local'}`}>
+          {checking ? '…' : exists ? 'PDS' : 'Local'}
+        </span>
+      </div>
+      <p className="admin-page-panel-desc">
+        {checking ? (
+          'Checking status…'
+        ) : exists ? (
+          <>
+            Title &amp; intro are served from <code>is.dame.page/{slug}</code> on your PDS.
+          </>
+        ) : (
+          <>
+            Title &amp; intro are hardcoded in the site. Migrate to edit them on your PDS.
+          </>
+        )}
+      </p>
+      <div className="admin-page-panel-actions">
+        {exists ? (
+          <>
+            <Link
+              className="admin-gate-button admin-gate-button-tight"
+              to={`/admin?c=${encodeURIComponent(COLLECTIONS.page)}&r=${encodeURIComponent(slug)}`}
+            >
+              Edit
+            </Link>
+            <button
+              type="button"
+              className="admin-gate-button admin-gate-button-tight admin-danger"
+              onClick={revert}
+              disabled={busy}
+            >
+              {busy ? 'Reverting…' : 'Revert to local'}
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="admin-gate-button admin-gate-button-tight"
+            onClick={migrate}
+            disabled={busy || checking}
+          >
+            {busy ? 'Migrating…' : 'Migrate to PDS'}
+          </button>
+        )}
+      </div>
+      {error && <p className="admin-error">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -356,6 +356,27 @@ function Field({ field, value, onChange }) {
         />
       );
       break;
+    case 'select':
+      control = (
+        <select
+          id={id}
+          className="admin-input"
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {!field.required && <option value="">—</option>}
+          {(field.options || []).map((opt) => {
+            const val = typeof opt === 'string' ? opt : opt.value;
+            const lbl = typeof opt === 'string' ? opt : opt.label ?? opt.value;
+            return (
+              <option key={val} value={val}>
+                {lbl}
+              </option>
+            );
+          })}
+        </select>
+      );
+      break;
     case 'boolean':
       control = (
         <label className="admin-checkbox">

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ export const PLC_DIRECTORY = 'https://plc.directory';
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';
+const HERO_PHRASE_NSID = 'is.dame.hero.phrase';
 
 /**
  * Legacy verb-or-shorthand → NSID lookup. Existing call sites
@@ -31,6 +32,7 @@ export const COLLECTIONS = {
   listen: primaryNsid('listening'),
   page: PAGE_NSID,
   profile: PROFILE_NSID,
+  heroPhrase: HERO_PHRASE_NSID,
 };
 
 /** Gerund verbs surfaced on the home feed. Sourced from the registry. */

--- a/src/hooks/usePageContent.js
+++ b/src/hooks/usePageContent.js
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { useLiveFeed } from './useLiveFeed.js';
+import { resolvePds, getRecord } from '../lib/atproto.js';
+import { renderMarkdown } from '../lib/markdown.js';
+import { pageDefault } from '../lib/pageRegistry.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
+
+// Sentinel returned when there is no `is.dame.page/<slug>` record — distinct
+// from `null` (which keeps `useLiveFeed` in its loading state) so a genuinely
+// local page resolves to a 'ready' fallback instead of an error.
+const LOCAL = { __local: true };
+
+/**
+ * Resolve a page's chrome (title / intro / body) from the PDS when an
+ * `is.dame.page/<slug>` record exists, otherwise fall back to the hardcoded
+ * defaults in `pageRegistry`. Mirrors the snapshot-first pattern used by the
+ * content pages so first paint comes from the snapshot and live confirms.
+ *
+ *   { title, intro, html, source: 'pds' | 'local', loading }
+ */
+export function usePageContent(slug) {
+  const def = pageDefault(slug) || {};
+
+  const { items, status } = useLiveFeed({
+    name: 'pages',
+    strategy: 'snapshot-first',
+    deps: [slug],
+    fetchLive: async () => {
+      const pds = await resolvePds(ME_DID);
+      try {
+        return await getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.page, rkey: slug });
+      } catch {
+        // A missing record throws; treat it as "this page is local".
+        return LOCAL;
+      }
+    },
+    mapItems: (data) => {
+      if (!data) return null;
+      if (data.__local) return data; // explicit "no record" sentinel
+      if (data.uri || data.value) return data; // live getRecord shape
+      if (data[slug]) return data[slug]; // snapshot shape: { [slug]: record }
+      return LOCAL; // snapshot present but no entry for this slug
+    },
+  });
+
+  const record = items && (items.uri || items.value) ? items : null;
+  const v = record?.value || {};
+
+  const html = useMemo(
+    () => (v.body ? renderMarkdown(v.body, v.bodyFormat || 'markdown') : ''),
+    [v.body, v.bodyFormat],
+  );
+
+  return {
+    title: v.title || def.title,
+    intro: v.intro || def.intro,
+    html,
+    source: record ? 'pds' : 'local',
+    loading: status === 'loading',
+  };
+}

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -18,6 +18,7 @@ import { COLLECTIONS } from '../config.js';
  *   - json:      raw JSON; stored as parsed object/array
  *   - boolean:   checkbox
  *   - number:    numeric input
+ *   - select:    dropdown; pass `options` as string[] or { value, label }[]
  *
  * Optional flags per field:
  *   - required        — must be present to submit
@@ -99,6 +100,37 @@ export const LEXICONS = {
       { key: 'tagline', label: 'Tagline', type: 'text' },
       { key: 'bio', label: 'Bio (Markdown)', type: 'markdown' },
       ...COMMON_TIMESTAMPS,
+    ],
+  },
+
+  [COLLECTIONS.heroPhrase]: {
+    label: 'Hero phrase',
+    summary:
+      'Rotating phrases for the home hero sentence. "role" fills "dame is [a design engineer]"; "clause" fills "who [makes social software]".',
+    rkeyMode: 'tid',
+    typeFieldValue: COLLECTIONS.heroPhrase,
+    fields: [
+      {
+        key: 'part',
+        label: 'Part',
+        type: 'select',
+        required: true,
+        default: 'role',
+        options: [
+          { value: 'role', label: 'Role — "a design engineer"' },
+          { value: 'clause', label: 'Clause — "who makes…"' },
+        ],
+      },
+      {
+        key: 'text',
+        label: 'Phrase',
+        type: 'text',
+        required: true,
+        maxLength: 200,
+        hint: 'Role: include the article, e.g. "an artist". Clause: start with "who…".',
+      },
+      { key: 'enabled', label: 'Enabled (shown in rotation)', type: 'boolean', default: true },
+      { key: 'createdAt', label: 'Created at', type: 'datetime', default: 'now', required: true },
     ],
   },
 

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -1,0 +1,74 @@
+// Registry of site "pages" whose chrome (title + intro, and optionally a
+// markdown body) can live either hardcoded here ("local") or as an
+// `is.dame.page/<slug>` record on the PDS.
+//
+// This file is the single source of the *local* defaults AND the seed used
+// when migrating a page onto the PDS — `usePageContent(slug)` falls back to
+// these values when no record exists, and the admin Page-content panel copies
+// them into a new record so a migration is visually lossless.
+//
+// `collection` maps a page to the feed collection whose admin record-list
+// hosts an embedded panel. `null` means the page has no backing feed
+// collection (it's pure page content) and only appears in the standalone
+// Site-pages overview.
+
+import { COLLECTIONS } from '../config.js';
+
+export const PAGE_REGISTRY = {
+  creating: {
+    slug: 'creating',
+    label: 'Creating',
+    title: 'Creating',
+    intro: 'A portfolio of works — art, software, writing, music, and more.',
+    collection: COLLECTIONS.creating,
+  },
+  blogging: {
+    slug: 'blogging',
+    label: 'Blogging',
+    title: 'Blogging',
+    intro:
+      'A book of long-form posts. Each entry is an is.dame.blogging.post or pub.leaflet.document record.',
+    collection: COLLECTIONS.blogging,
+  },
+  logging: {
+    slug: 'logging',
+    label: 'Logging',
+    title: 'Logging',
+    intro: 'Status updates, archived. Each entry is one is.dame.now record.',
+    collection: COLLECTIONS.now,
+  },
+  posting: {
+    slug: 'posting',
+    label: 'Posting',
+    title: 'Posting',
+    intro: 'Bluesky posts, freshest first, grouped by day-of-life.',
+    collection: 'app.bsky.feed.post',
+  },
+  listening: {
+    slug: 'listening',
+    label: 'Listening',
+    title: 'Listening',
+    intro: 'Songs played, freshest first, grouped by day-of-life.',
+    collection: COLLECTIONS.listen,
+  },
+  sharing: {
+    slug: 'sharing',
+    label: 'Sharing',
+    title: 'Sharing',
+    intro: 'Things worth handing off.',
+    collection: null,
+  },
+};
+
+export function pageDefault(slug) {
+  return PAGE_REGISTRY[slug] || null;
+}
+
+export function knownPageSlugs() {
+  return Object.keys(PAGE_REGISTRY);
+}
+
+/** Reverse lookup used by the embedded panel: collection NSID → page slug. */
+export function pageSlugForCollection(nsid) {
+  return Object.values(PAGE_REGISTRY).find((p) => p.collection === nsid)?.slug || null;
+}

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -298,3 +298,78 @@
   align-items: center;
   margin-top: var(--space-3);
 }
+
+/* Page content (Local vs PDS) panels */
+.admin-page-panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.admin-page-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  margin: var(--space-4) 0;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+}
+
+.admin-page-panels .admin-page-panel {
+  margin: 0;
+}
+
+.admin-page-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.admin-page-panel-label {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+}
+
+.admin-page-panel-desc {
+  margin: 0;
+  font-family: var(--serif);
+  color: var(--ink-soft);
+  font-size: var(--text-sm);
+}
+
+.admin-page-panel-actions {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  margin-top: var(--space-1);
+}
+
+.admin-badge {
+  flex-shrink: 0;
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.16em;
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-1);
+  border: 1px solid var(--rule);
+}
+
+.admin-badge-pds {
+  color: var(--page);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.admin-badge-local {
+  color: var(--ink-soft);
+  background: transparent;
+  border-color: var(--rule);
+}
+
+select.admin-input {
+  appearance: auto;
+  cursor: pointer;
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -2,9 +2,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
+import PageContentPanel from '../components/PageContentPanel.jsx';
+import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
-import { ME_DID } from '../config.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
 import { LEXICONS, lexiconFor, knownCollections } from '../lib/lexicons.js';
+import { knownPageSlugs, pageSlugForCollection } from '../lib/pageRegistry.js';
 import './Admin.css';
 
 /**
@@ -24,6 +27,7 @@ export default function Admin() {
   const collection = params.get('c');
   const rkey = params.get('r');
   const mode = params.get('mode');
+  const view = params.get('view');
 
   if (loading) {
     return (
@@ -52,6 +56,9 @@ export default function Admin() {
     );
   }
 
+  if (view === 'pages') {
+    return <PagesOverview agent={agent} did={did} />;
+  }
   if (!collection) {
     return <CollectionPicker />;
   }
@@ -120,6 +127,16 @@ function CollectionPicker() {
       headTitle="Admin — Dame is…"
     >
       <ul className="admin-collection-list">
+        <li className="admin-collection-row">
+          <Link to="/admin?view=pages" className="admin-collection-link">
+            <span className="admin-collection-label">Site pages (Local vs PDS)</span>
+            <code className="admin-collection-nsid">is.dame.page</code>
+          </Link>
+          <p className="admin-collection-summary">
+            See which pages serve their title &amp; intro from the PDS vs hardcoded
+            defaults, and migrate or revert them.
+          </p>
+        </li>
         {knownCollections().map((nsid) => {
           const lex = LEXICONS[nsid];
           return (
@@ -175,6 +192,8 @@ function RecordList({ agent, did, collection }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const lex = lexiconFor(collection);
+  const pageSlug = pageSlugForCollection(collection);
+  const isHero = collection === COLLECTIONS.heroPhrase;
 
   const loadPage = useCallback(
     async (after) => {
@@ -201,12 +220,16 @@ function RecordList({ agent, did, collection }) {
     [agent, did, collection],
   );
 
-  useEffect(() => {
+  const reload = useCallback(() => {
     setRecords([]);
     setCursor(undefined);
     setDone(false);
     loadPage(undefined);
   }, [loadPage]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
 
   return (
     <PageShell
@@ -222,7 +245,12 @@ function RecordList({ agent, did, collection }) {
         >
           New record
         </Link>
+        {isHero && (
+          <HeroSeedButton agent={agent} did={did} existingCount={records.length} onSeeded={reload} />
+        )}
       </div>
+
+      {pageSlug && <PageContentPanel agent={agent} did={did} slug={pageSlug} />}
 
       {error && <p className="admin-error">{error}</p>}
 
@@ -281,6 +309,128 @@ function previewFor(value, lex) {
 function truncate(s, n) {
   if (!s) return '';
   return s.length <= n ? s : s.slice(0, n - 1).trimEnd() + '…';
+}
+
+/* ------------------------------------------------------------------ */
+/* Hero phrase seeding                                                  */
+/* ------------------------------------------------------------------ */
+
+function HeroSeedButton({ agent, did, existingCount, onSeeded }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function seed() {
+    if (existingCount > 0) {
+      if (
+        !window.confirm(
+          `This collection already has ${existingCount} record(s). Seed the built-in defaults anyway? This may create duplicates.`,
+        )
+      ) {
+        return;
+      }
+    } else if (!window.confirm('Create the built-in hero phrases as records on your PDS?')) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const seedPart = async (part, list) => {
+        for (const text of list) {
+          await agent.com.atproto.repo.createRecord({
+            repo: did,
+            collection: COLLECTIONS.heroPhrase,
+            record: {
+              $type: COLLECTIONS.heroPhrase,
+              part,
+              text,
+              enabled: true,
+              createdAt: new Date().toISOString(),
+            },
+          });
+        }
+      };
+      await seedPart('role', VARIANTS_A);
+      await seedPart('clause', VARIANTS_B);
+      onSeeded?.();
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="admin-gate-button admin-gate-button-tight"
+        onClick={seed}
+        disabled={busy}
+      >
+        {busy ? 'Seeding…' : 'Seed defaults'}
+      </button>
+      {error && <p className="admin-error">{error}</p>}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Site pages overview                                                  */
+/* ------------------------------------------------------------------ */
+
+function PagesOverview({ agent, did }) {
+  const [existing, setExisting] = useState(null); // Set of slugs that have a record
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    agent.com.atproto.repo
+      .listRecords({ repo: did, collection: COLLECTIONS.page, limit: 100 })
+      .then((res) => {
+        const next = res?.data || res;
+        const set = new Set((next?.records || []).map((r) => rkeyFromUri(r.uri)));
+        if (!cancelled) setExisting(set);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err?.message || String(err));
+          setExisting(new Set());
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did]);
+
+  return (
+    <PageShell
+      title="Site pages"
+      intro="Each page's title and intro can live in the site (Local) or as an is.dame.page record on your PDS."
+      headTitle="Site pages — Admin — Dame is…"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+
+      {existing === null ? (
+        <p className="placeholder-card">Loading pages…</p>
+      ) : (
+        <div className="admin-page-panels">
+          {knownPageSlugs().map((slug) => (
+            <PageContentPanel
+              key={slug}
+              agent={agent}
+              did={did}
+              slug={slug}
+              exists={existing.has(slug)}
+            />
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { BloggingTocSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
@@ -24,6 +25,7 @@ import './Blogging.css';
 export default function Blogging() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
+  const { title, intro } = usePageContent('blogging');
 
   const { items: entries, status } = useLiveFeed({
     strategy: 'snapshot-first',
@@ -57,8 +59,8 @@ export default function Blogging() {
 
   return (
     <PageShell
-      title="Blogging"
-      intro="A book of long-form posts. Each entry is an is.dame.blogging.post or pub.leaflet.document record."
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/blogging`}
       headTitle="Blogging — Dame is&hellip;"
     >

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import CreatingFilters, { filterCreatingItems } from '../components/CreatingFilters.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -13,6 +14,7 @@ import './Creating.css';
 export default function Creating() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
+  const { title, intro } = usePageContent('creating');
 
   const { items: works, status } = useLiveFeed({
     name: 'creations',
@@ -51,8 +53,8 @@ export default function Creating() {
 
   return (
     <PageShell
-      title="Creating"
-      intro="A portfolio of works — art, software, writing, music, and more."
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/creating`}
       headTitle="Creating — Dame is&hellip;"
     >

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -6,6 +6,7 @@ import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
 import { groupByDay } from '../lib/time.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -14,6 +15,7 @@ import '../components/Feed.css';
 export default function Listening() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
+  const { title, intro } = usePageContent('listening');
 
   const { items, status, refreshedAt } = useLiveFeed({
     name: 'listening',
@@ -47,8 +49,8 @@ export default function Listening() {
 
   return (
     <PageShell
-      title="Listening"
-      intro="Songs played, freshest first, grouped by day-of-life."
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/listening`}
       headTitle="Listening — Dame is&hellip;"
     >

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -6,6 +6,7 @@ import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
 import { groupByDay } from '../lib/time.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -14,6 +15,7 @@ import '../components/Feed.css';
 export default function Logging() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
+  const { title, intro } = usePageContent('logging');
 
   const { items, status, refreshedAt } = useLiveFeed({
     name: 'now',
@@ -39,8 +41,8 @@ export default function Logging() {
 
   return (
     <PageShell
-      title="Logging"
-      intro="Status updates, archived. Each entry is one is.dame.now record."
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/logging`}
       headTitle="Logging — Dame is&hellip;"
     >

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -6,6 +6,7 @@ import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import PostingFilters, { filterPostingItems, postingCategories } from '../components/PostingFilters.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
 import { groupByDay } from '../lib/time.js';
 import { getAuthorFeed } from '../lib/atproto.js';
 import { blueskyPostToFeedItem } from '../lib/feedBuilder.js';
@@ -15,6 +16,7 @@ import '../components/Feed.css';
 
 export default function Posting() {
   const [params] = useSearchParams();
+  const { title, intro } = usePageContent('posting');
 
   const { items, status, refreshedAt } = useLiveFeed({
     name: 'posts',
@@ -46,8 +48,8 @@ export default function Posting() {
 
   return (
     <PageShell
-      title="Posting"
-      intro="Bluesky posts, freshest first, grouped by day-of-life."
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/posting`}
       headTitle="Posting — Dame is&hellip;"
     >

--- a/src/pages/Sharing.jsx
+++ b/src/pages/Sharing.jsx
@@ -1,47 +1,22 @@
-import { useMemo } from 'react';
 import PageShell from '../components/PageShell.jsx';
 import { ProseSkeleton } from '../components/Skeleton.jsx';
-import { useLiveFeed } from '../hooks/useLiveFeed.js';
-import { resolvePds, getRecord } from '../lib/atproto.js';
-import { renderMarkdown } from '../lib/markdown.js';
-import { ME_DID, COLLECTIONS } from '../config.js';
+import { usePageContent } from '../hooks/usePageContent.js';
+import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
 export default function Sharing() {
-  // The snapshot stores all pages keyed by rkey; the live fetch goes
-  // directly for the single record. The mapper normalizes both into
-  // the same `{uri, cid, value}` shape.
-  const { items: record, status } = useLiveFeed({
-    name: 'pages',
-    strategy: 'snapshot-first',
-    fetchLive: async () => {
-      const pds = await resolvePds(ME_DID);
-      return getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.page, rkey: 'sharing' });
-    },
-    mapItems: (data) => {
-      if (!data) return null;
-      // Snapshot shape: { home: {...}, sharing: {...}, ... }
-      if (data.sharing) return data.sharing;
-      // Live shape: { uri, cid, value }
-      if (data.uri || data.value) return data;
-      return null;
-    },
-  });
-
-  const v = record?.value || {};
-  const html = useMemo(() => {
-    if (!v?.body) return '';
-    return renderMarkdown(v.body, v.bodyFormat || 'markdown');
-  }, [v]);
+  // Title / intro / body all resolve from `is.dame.page/sharing` when present,
+  // falling back to the local defaults in the page registry.
+  const { title, intro, html, loading } = usePageContent('sharing');
 
   return (
     <PageShell
-      title={v.title || 'Sharing'}
-      intro={v.intro || 'Things worth handing off.'}
+      title={title}
+      intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/sharing`}
       headTitle="Sharing — Dame is&hellip;"
     >
-      {status === 'loading' ? (
+      {loading ? (
         <ProseSkeleton paragraphs={4} />
       ) : html ? (
         <div className="blog-prose reveal" dangerouslySetInnerHTML={{ __html: html }} />


### PR DESCRIPTION
## Summary

Two related admin features for moving content from hardcoded ("local") defaults onto the PDS.

### 1. Local-vs-PDS page management
- `src/lib/pageRegistry.js` — central registry of hardcoded title/intro for each content page (creating, blogging, logging, posting, listening, sharing) + a collection→slug map. Serves as both the local default and the migration seed.
- `src/hooks/usePageContent.js` — resolves a page's title/intro/body from an `is.dame.page/<slug>` record (snapshot-first), falling back to the registry default; reports `source: 'pds' | 'local'`.
- Content pages now read chrome from the hook instead of hardcoding it; Sharing reuses it for its body too.
- `src/components/PageContentPanel.jsx` — **Local**/**PDS** badge with **Migrate to PDS** / **Edit** / **Revert to local** actions. Embedded atop each backing collection's record list and listed in a standalone **Site pages** overview at `/admin?view=pages`.

### 2. Hero phrases lexicon + CRUD
- New `is.dame.hero.phrase` lexicon (`part` role/clause, `text`, `enabled`).
- Registered in config + lexicons so it appears in the admin picker with a form; added a reusable `select` field type to `RecordEditor`.
- `prefetch.mjs` snapshots phrases to `public/data/hero.json`.
- `HeroSentence` loads phrases from the PDS (per-part fallback to the in-file arrays) with index clamping for dynamic pools.
- "Seed defaults" admin button bulk-creates the built-in phrases.

## Verification
- Offline `vite build` succeeds.
- `prefetch` runs clean and writes `hero.json` as `[]` when empty (build stays green).
- `public/data/*.json` is gitignored; no data snapshots committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_