### PR TITLE
Compact feed embeds per density mode

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1327,13 +1327,16 @@ a.reference-card-profile:focus-visible {
   font-size: var(--text-base);
 }
 
-/* Drop the stats footer (replies/reposts/likes) and any post-embed
-   in tight mode — they multiply row height. Don't hide content the
-   user can opt back in to via an expand button (listen-row-children,
-   reference-card-subject) — that would make those buttons appear to
-   do nothing in tight mode. */
+/* Drop the stats footer (replies/reposts/likes) in tight mode — it
+   multiplies row height. Don't hide content the user can opt back in
+   to via an expand button (listen-row-children, reference-card-subject)
+   — that would make those buttons appear to do nothing in tight mode.
+
+   Post embeds (images / link cards / video / quotes) are tightened and
+   hidden per-density in PostEmbed.css alongside the rest of the embed
+   styling — the leaf classes there (.post-embed-images, etc.) are the
+   real hooks; there is no `.post-embed` wrapper element. */
 [data-density='tight'] .post-card-stats,
-[data-density='tight'] .post-embed,
 [data-density='tight'] .media-card-grid {
   display: none;
 }

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -103,7 +103,7 @@ export default function PostCard({
           )}
         </div>
       )}
-      {embed && <PostEmbed embed={embed} did={authorDid} />}
+      {embed && <PostEmbed embed={embed} did={authorDid} collapsible />}
       {(payload?.replyCount || payload?.repostCount || payload?.likeCount) ? (
         <footer className="post-card-stats">
           {payload?.replyCount ? `${payload.replyCount} ${payload.replyCount === 1 ? 'reply' : 'replies'}` : ''}

--- a/src/components/PostEmbed.css
+++ b/src/components/PostEmbed.css
@@ -295,3 +295,124 @@ a.post-embed-quote {
   color: var(--ink-soft);
   overflow-wrap: anywhere;
 }
+
+/* ----------------------------------------------------------------------
+   Density-aware embeds (toggled by [data-density] on <html>).
+
+   At full density an embed renders at its natural size. In the feed's
+   compact / tight views it should shrink in step with everything else
+   rather than dominating the row. These rules are scoped to `.feed-item`
+   so embeds on record/detail pages — where vertical space isn't at a
+   premium — keep their full size.
+
+   compact: a genuinely smaller version of each embed — shorter media,
+            a tighter link card, a trimmed quote.
+   tight:   embeds drop out entirely (matching the rest of tight's
+            aggressive minimal list view).
+   ---------------------------------------------------------------------- */
+
+/* Pull the embed closer to the post text — the larger normal-mode
+   rhythm reads as a gap when rows are dense. */
+[data-density='compact'] .feed-item .post-embed-images,
+[data-density='compact'] .feed-item .post-embed-video,
+[data-density='compact'] .feed-item .post-embed-link-card,
+[data-density='compact'] .feed-item .post-embed-quote {
+  margin-top: var(--space-2);
+}
+
+/* Images — cap the footprint. Single images shrink via a lower
+   max-height; multi-image grids shrink by capping the grid width and
+   tightening the gutters. */
+[data-density='compact'] .feed-item .post-embed-images {
+  gap: var(--space-1);
+  max-width: 22rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-images[data-count='1'] .post-embed-image img {
+  max-height: 18rem;
+}
+
+/* Video — same height cap as a single image so the two read alike. */
+[data-density='compact'] .feed-item .post-embed-video {
+  max-height: 18rem;
+  max-width: 22rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-video video,
+[data-density='compact'] .feed-item .post-embed-video img {
+  max-height: 18rem;
+}
+
+/* Link card — narrower thumbnail, tighter padding, smaller title, and
+   drop the description so it collapses to a compact one/two-line strip. */
+[data-density='compact'] .feed-item .post-embed-link-card {
+  grid-template-columns: minmax(0, 4.5rem) 1fr;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  max-width: 22rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-link-card-thumb img {
+  max-height: 4.5rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-link-card-title {
+  font-size: var(--text-sm);
+  -webkit-line-clamp: 2;
+}
+
+[data-density='compact'] .feed-item .post-embed-link-card-desc {
+  display: none;
+}
+
+/* On narrow viewports the link card stacks to one column (see the
+   max-width: 480px block above) and the thumbnail grows tall. Keep the
+   compact card single-column too but with a much shorter thumbnail so it
+   doesn't balloon back to full height. */
+@media (max-width: 480px) {
+  [data-density='compact'] .feed-item .post-embed-link-card {
+    grid-template-columns: 1fr;
+  }
+  [data-density='compact'] .feed-item .post-embed-link-card-thumb img {
+    max-height: 8rem;
+  }
+}
+
+/* Quote — tighter box and a clamped body so a long quoted post doesn't
+   stretch the row. */
+[data-density='compact'] .feed-item .post-embed-quote {
+  gap: var(--space-1);
+  padding: var(--space-2);
+  max-width: 22rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-quote-avatar {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+[data-density='compact'] .feed-item .post-embed-quote-text {
+  font-size: var(--text-sm);
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* A quote embed can itself carry nested media; hide it in compact so the
+   quote stays a compact strip rather than nesting a second media block. */
+[data-density='compact'] .feed-item .post-embed-quote .post-embed-images,
+[data-density='compact'] .feed-item .post-embed-quote .post-embed-video,
+[data-density='compact'] .feed-item .post-embed-quote .post-embed-link-card {
+  display: none;
+}
+
+/* tight: embeds are dropped entirely, matching the stats footer / media
+   grid already hidden for this density in Feed.css. */
+[data-density='tight'] .feed-item .post-embed-images,
+[data-density='tight'] .feed-item .post-embed-video,
+[data-density='tight'] .feed-item .post-embed-link-card,
+[data-density='tight'] .feed-item .post-embed-quote {
+  display: none;
+}

--- a/src/components/PostEmbed.css
+++ b/src/components/PostEmbed.css
@@ -408,11 +408,74 @@ a.post-embed-quote {
   display: none;
 }
 
-/* tight: embeds are dropped entirely, matching the stats footer / media
-   grid already hidden for this density in Feed.css. */
-[data-density='tight'] .feed-item .post-embed-images,
-[data-density='tight'] .feed-item .post-embed-video,
-[data-density='tight'] .feed-item .post-embed-link-card,
-[data-density='tight'] .feed-item .post-embed-quote {
-  display: none;
+/* tight: the embed collapses to a one-line chip (rendered by
+   CollapsibleEmbed in PostEmbed.jsx) that the reader can expand on
+   demand — so a tight row stays scannable without hiding the fact that
+   an embed exists. The chip + expanded body are styled below. */
+
+.post-embed-collapsible {
+  margin-top: var(--space-2);
+}
+
+.post-embed-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  padding: 0.2rem 0.6rem;
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  cursor: pointer;
+  max-width: 100%;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.post-embed-toggle:hover,
+.post-embed-toggle:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  outline: none;
+}
+
+.post-embed-toggle-icon {
+  color: var(--ink-faint);
+  flex: 0 0 auto;
+  transition: color 120ms ease;
+}
+
+.post-embed-toggle:hover .post-embed-toggle-icon,
+.post-embed-toggle:focus-visible .post-embed-toggle-icon {
+  color: var(--accent);
+}
+
+.post-embed-toggle-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.post-embed-toggle-caret {
+  color: var(--ink-faint);
+  flex: 0 0 auto;
+  transition: transform 120ms ease;
+}
+
+.post-embed-toggle-caret.is-open {
+  transform: rotate(180deg);
+}
+
+/* The expanded embed renders at its natural size — the reader asked to
+   see it. Zero the leading margin the embed type already carries so it
+   doesn't stack on top of the body's own gap. */
+.post-embed-collapsible-body {
+  margin-top: var(--space-2);
+}
+
+.post-embed-collapsible-body > * {
+  margin-top: 0;
 }

--- a/src/components/PostEmbed.jsx
+++ b/src/components/PostEmbed.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Images, Film, Link2, Quote, ChevronDown } from 'lucide-react';
 import { ME_DID } from '../config.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import { useDensity } from '../hooks/useDensity.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
 import { renderPostText } from '../lib/postRichText.jsx';
 import Lightbox from './Lightbox.jsx';
@@ -18,9 +20,106 @@ import './PostEmbed.css';
  *      the CDN URL.
  *
  * Pass the post's author `did` so we can build CDN URLs for raw embeds.
+ *
+ * `collapsible` is set by the feed card renderers. In the feed's `tight`
+ * density it swaps the embed for a small labeled chip the reader can
+ * expand on demand — keeping rows scannable without losing the signal
+ * that an embed exists. At every other density (and everywhere
+ * `collapsible` is unset, e.g. record/detail pages) the embed renders
+ * inline as usual; compact sizing is handled in CSS.
  */
-export default function PostEmbed({ embed, did, depth = 0 }) {
+export default function PostEmbed({ embed, did, depth = 0, collapsible = false }) {
   if (!embed) return null;
+  const content = renderEmbed(embed, did, depth);
+  if (!content) return null;
+  if (collapsible) {
+    return <CollapsibleEmbed embed={embed}>{content}</CollapsibleEmbed>;
+  }
+  return content;
+}
+
+/**
+ * In `tight` density a feed embed collapses to a one-line chip
+ * (icon + label + caret) that toggles the real embed open. Other
+ * densities render the embed inline untouched.
+ */
+function CollapsibleEmbed({ embed, children }) {
+  const { density } = useDensity();
+  const [open, setOpen] = useState(false);
+  if (density !== 'tight') return children;
+  const summary = embedSummary(embed);
+  // Unknown embed type — nothing useful to label, so just show it.
+  if (!summary) return children;
+  const { Icon, label } = summary;
+  return (
+    <div className="post-embed-collapsible">
+      <button
+        type="button"
+        className="post-embed-toggle"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <Icon size={13} strokeWidth={1.75} className="post-embed-toggle-icon" aria-hidden="true" />
+        <span className="post-embed-toggle-label">{label}</span>
+        <ChevronDown
+          size={13}
+          strokeWidth={1.75}
+          className={`post-embed-toggle-caret ${open ? 'is-open' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+      {open && <div className="post-embed-collapsible-body">{children}</div>}
+    </div>
+  );
+}
+
+/**
+ * One-line descriptor (icon + label) for an embed, used by the tight-mode
+ * collapse chip. Returns null for embed types we don't summarize.
+ */
+function embedSummary(embed) {
+  if (!embed) return null;
+  switch (embed.$type) {
+    case 'app.bsky.embed.images#view':
+    case 'app.bsky.embed.images': {
+      const n = (embed.images || []).length || 0;
+      return { Icon: Images, label: n === 1 ? '1 image' : `${n} images` };
+    }
+    case 'app.bsky.embed.video#view':
+    case 'app.bsky.embed.video':
+      return { Icon: Film, label: 'Video' };
+    case 'app.bsky.embed.external#view':
+    case 'app.bsky.embed.external': {
+      let host = 'Link';
+      try {
+        host = new URL(embed.external?.uri).hostname.replace(/^www\./, '');
+      } catch {
+        /* ignore */
+      }
+      return { Icon: Link2, label: host };
+    }
+    case 'app.bsky.embed.record#view':
+    case 'app.bsky.embed.record':
+      return { Icon: Quote, label: 'Quoted post' };
+    case 'app.bsky.embed.recordWithMedia#view':
+    case 'app.bsky.embed.recordWithMedia': {
+      const media = embed.media ? embedSummary(embed.media) : null;
+      return {
+        Icon: media?.Icon || Quote,
+        label: media ? `${media.label} + quote` : 'Quoted post',
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolves an embed object to its rendered element. Split out from the
+ * default export so `PostEmbed` can optionally wrap the result in the
+ * tight-mode collapse chip.
+ */
+function renderEmbed(embed, did, depth) {
   const type = embed.$type;
   switch (type) {
     case 'app.bsky.embed.images#view':


### PR DESCRIPTION
Post embeds (images, link cards, video, quote posts) previously rendered at full size in every feed density mode, so compact/tight views were dominated by embed-sized blocks. (The `[data-density='tight'] .post-embed` rule that was meant to address this targeted a wrapper class that doesn't exist, so it never matched.)

## Changes

**Compact density** — embeds render inline but smaller:
- single image / video capped in height; multi-image grids width-capped with tighter gutters
- link card: narrower thumbnail, smaller title, description dropped
- quote: tighter box, smaller avatar, body clamped to 4 lines
- all scoped to `.feed-item` so record/detail pages keep full-size embeds

**Tight density** — embeds collapse to a one-line expandable chip instead of being hidden:
- chip shows an icon + summary (`bookshop.org`, `2 images`, `Quoted post`, `Video`, `… + quote`) and expands inline on click to reveal the full embed
- implemented as `CollapsibleEmbed` in `PostEmbed.jsx`, gated on `tight` density via `useDensity` and opted into by feed cards with a new `collapsible` prop; other densities and detail pages are unchanged
- proper `<button aria-expanded>`; the row's tap-to-navigate handler already ignores button clicks

## Files
- `src/components/PostEmbed.jsx` — split the type switch into `renderEmbed()`; add `CollapsibleEmbed` + `embedSummary()`
- `src/components/PostEmbed.css` — compact sizing rules + collapse-chip styling
- `src/components/Feed.css` — remove the dead `.post-embed` selector
- `src/components/PostCard.jsx` — pass `collapsible`

Verified with `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJFcBGGnukpjxTaXW5dw7R)_