### PR TITLE
Square admin editor corners, add editor preview, show publication names

### DIFF
--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
+import { renderMarkdown } from '../lib/markdown.js';
 import BlocksEditor from './blocks/BlocksEditor.jsx';
+import LeafletDocument from './LeafletDocument.jsx';
 import '../pages/Admin.css';
 
 /**
@@ -45,6 +47,7 @@ export default function RecordEditor({
     lex?.rkeyMode === 'fixed' ? lex.rkeyDefault || '' : '',
   );
   const [rawMode, setRawMode] = useState(initialMode === 'raw' || !lex);
+  const [preview, setPreview] = useState(false);
   const [rawText, setRawText] = useState('');
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
@@ -227,13 +230,22 @@ export default function RecordEditor({
   return (
     <div className={`record-editor${compact ? ' record-editor-compact' : ''}`}>
       <div className="admin-toolbar admin-toolbar-inline">
-        {lex && (
+        {lex && !preview && (
           <button
             type="button"
             className="admin-link-subtle"
             onClick={toggleRawMode}
           >
             {rawMode ? 'Use form' : 'Edit JSON'}
+          </button>
+        )}
+        {lex && (
+          <button
+            type="button"
+            className="admin-link-subtle"
+            onClick={() => setPreview((p) => !p)}
+          >
+            {preview ? 'Back to editor' : 'Preview'}
           </button>
         )}
       </div>
@@ -258,7 +270,9 @@ export default function RecordEditor({
         </div>
       )}
 
-      {rawMode || !lex ? (
+      {preview && lex ? (
+        <RecordPreview lex={lex} record={previewRecordFor(rawMode, rawText, value)} />
+      ) : rawMode || !lex ? (
         <RawJsonEditor value={rawText} onChange={setRawText} />
       ) : (
         <FormEditor
@@ -314,6 +328,64 @@ function FormEditor({ lex, value, onChange, agent, did }) {
           did={did}
         />
       ))}
+    </div>
+  );
+}
+
+/**
+ * Choose what to preview. In form mode the live `value` is authoritative; in
+ * raw-JSON mode parse the textarea (falling back to `value` if it's mid-edit
+ * and not valid JSON yet).
+ */
+function previewRecordFor(rawMode, rawText, value) {
+  if (rawMode) {
+    try {
+      return JSON.parse(rawText);
+    } catch {
+      return value || {};
+    }
+  }
+  return value || {};
+}
+
+/**
+ * Render a record roughly as it appears on the site: title + lead, then any
+ * `blocks` body via the shared LeafletDocument renderer and any `markdown`
+ * body via the markdown pipeline. Other fields (timestamps, pickers) are
+ * omitted — this is a reading preview, not a field dump.
+ */
+function RecordPreview({ lex, record }) {
+  const v = record || {};
+  const fields = lex?.fields || [];
+  const lead = v.description ?? v.intro ?? v.tagline ?? v.summary ?? '';
+
+  const bodies = fields
+    .map((f) => {
+      if (f.type === 'blocks' && v[f.key]) {
+        return <LeafletDocument key={f.key} doc={v[f.key]} />;
+      }
+      if (f.type === 'markdown' && v[f.key]) {
+        const html = renderMarkdown(v[f.key], v.bodyFormat || 'markdown');
+        return (
+          <div
+            key={f.key}
+            className="blog-prose"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        );
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  const empty = !v.title && !lead && bodies.length === 0;
+
+  return (
+    <div className="record-preview blog-article">
+      {v.title && <h1 className="record-preview-title">{v.title}</h1>}
+      {lead && <p className="record-preview-lead">{lead}</p>}
+      {bodies}
+      {empty && <p className="admin-field-hint">Nothing to preview yet.</p>}
     </div>
   );
 }
@@ -675,10 +747,12 @@ function PublicationPickerField({ id, value, onChange, agent, did }) {
     >
       <option value="">— pick a publication —</option>
       {pubs.map((r) => {
-        const title = r?.value?.title || rkeyFromUri(r.uri);
+        // site.standard.publication records carry a `name`; fall back to a
+        // legacy `title`, then the rkey if neither is present.
+        const label = r?.value?.name || r?.value?.title || rkeyFromUri(r.uri);
         return (
           <option key={r.uri} value={r.uri}>
-            {title}
+            {label}
           </option>
         );
       })}

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -17,7 +17,7 @@
 
 .blocks-editor-item {
   border: 1px solid var(--rule, rgba(0, 0, 0, 0.12));
-  border-radius: 6px;
+  border-radius: 0;
   padding: 0.625rem 0.75rem;
   background: var(--surface-2, rgba(0, 0, 0, 0.015));
   display: flex;
@@ -72,7 +72,7 @@
   color: inherit;
   font: inherit;
   padding: 0.25rem 0.625rem;
-  border-radius: 4px;
+  border-radius: 0;
   cursor: pointer;
 }
 
@@ -108,7 +108,7 @@
   font: inherit;
   min-width: 1.75rem;
   padding: 0.125rem 0.5rem;
-  border-radius: 3px;
+  border-radius: 0;
   cursor: pointer;
 }
 
@@ -159,7 +159,7 @@
 
 .image-block-dropzone {
   border: 2px dashed var(--rule, rgba(0, 0, 0, 0.2));
-  border-radius: 6px;
+  border-radius: 0;
   min-height: 8rem;
   display: flex;
   align-items: center;
@@ -213,7 +213,7 @@
   height: auto;
   display: block;
   border: 1px solid var(--rule, rgba(0, 0, 0, 0.15));
-  border-radius: 4px;
+  border-radius: 0;
 }
 
 /* List block */

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -19,7 +19,7 @@
   color: var(--ink);
   background: var(--page);
   border: 1px solid var(--rule);
-  border-radius: var(--radius-2);
+  border-radius: 0;
   outline: none;
   transition: border-color 120ms ease;
 }
@@ -57,7 +57,7 @@
   color: var(--page);
   background: var(--ink);
   border: 1px solid var(--ink);
-  border-radius: var(--radius-2);
+  border-radius: 0;
   cursor: pointer;
   text-decoration: none;
   transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
@@ -97,7 +97,7 @@
   background: rgba(168, 140, 95, 0.08);
   border: 1px solid var(--rule-soft);
   padding: var(--space-3);
-  border-radius: var(--radius-2);
+  border-radius: 0;
 }
 
 .admin-error-inline {
@@ -313,7 +313,7 @@
   padding: var(--space-4);
   margin: var(--space-4) 0;
   border: 1px solid var(--rule-soft);
-  border-radius: var(--radius-2);
+  border-radius: 0;
 }
 
 .admin-page-panels .admin-page-panel {
@@ -353,7 +353,7 @@
   letter-spacing: 0.16em;
   font-size: var(--text-xs);
   padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-1);
+  border-radius: 0;
   border: 1px solid var(--rule);
 }
 
@@ -372,6 +372,29 @@
 select.admin-input {
   appearance: auto;
   cursor: pointer;
+}
+
+/* Editor reading preview */
+.record-preview {
+  border: 1px solid var(--rule-soft);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.record-preview-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: var(--text-xl);
+  line-height: 1.15;
+}
+
+.record-preview-lead {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  color: var(--ink-soft);
 }
 
 /* Category field — text input with suggestion chips below. */
@@ -396,7 +419,7 @@ select.admin-input {
   font-size: var(--text-xs);
   letter-spacing: 0.05em;
   padding: 0.125rem 0.5rem;
-  border-radius: 999px;
+  border-radius: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary

Three admin-editor refinements:

- **Square corners** — zeroed out every `border-radius` in the admin editor surface: inputs, buttons, error/success chrome, page panels, badges and category chips (`Admin.css`), plus block-editor items, add/toolbar buttons, image dropzone and link-card preview (`blocks.css`).
- **Editor preview mode** — added a **Preview / Back to editor** toggle to `RecordEditor`. It renders the record as it reads on the site: title + lead, `blocks` bodies via the shared `LeafletDocument` renderer, and `markdown` bodies via the markdown pipeline. Works from both form and raw-JSON mode.
- **Publication picker names** — the "pick a publication" dropdown now labels options by the publication's `name` (falling back to a legacy `title`, then rkey) instead of the bare rkey.

## Verification
- Offline `vite build` passes.
- No stray `border-radius` remains in the admin/blocks CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_