### PR TITLE
WYSIWYG rich-text block editor with pending marks

### DIFF
--- a/src/components/blocks/TextBlockEditor.jsx
+++ b/src/components/blocks/TextBlockEditor.jsx
@@ -1,11 +1,16 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   charsToBytes,
   toggleFeature,
   applyLink,
-  remapFacets,
+  applyFeatureAlways,
+  removeFeatureAlways,
+  featureTypesForRange,
+  facetRuns,
+  runsToFacets,
   FORMAT_TYPES,
   LINK_TYPE,
+  KEY_FOR_TYPE,
 } from './facetUtils.js';
 
 export default function TextBlockEditor({ block, onChange }) {
@@ -13,160 +18,458 @@ export default function TextBlockEditor({ block, onChange }) {
     <RichTextField
       text={block.plaintext || ''}
       facets={block.facets || []}
-      onChange={({ text, facets }) =>
-        onChange({ ...block, plaintext: text, facets })
-      }
+      onChange={({ text, facets }) => onChange({ ...block, plaintext: text, facets })}
       rows={4}
     />
   );
 }
 
+/* ------------------------------------------------------------------ */
+/* WYSIWYG rich-text editor                                            */
+/* ------------------------------------------------------------------ */
+
+const FORMAT_BUTTONS = [
+  { key: 'bold', node: <strong>B</strong>, title: 'Bold' },
+  { key: 'italic', node: <em>I</em>, title: 'Italic' },
+  { key: 'underline', node: <u>U</u>, title: 'Underline' },
+  { key: 'strikethrough', node: <s>S</s>, title: 'Strikethrough' },
+  { key: 'code', node: <code>{'<>'}</code>, title: 'Inline code' },
+  { key: 'highlight', node: <mark>H</mark>, title: 'Highlight' },
+];
+
 /**
- * Plain textarea + a toolbar that mutates the accompanying facets[]
- * based on the current selection. Reused by HeadingBlockEditor and the
- * list-item editor.
+ * A contentEditable surface that renders leaflet `plaintext` + `facets`
+ * inline (WYSIWYG) and serializes edits back to the same shape. Reused by
+ * the text block, heading block, and list items.
  *
- * Note: the textarea itself doesn't visually reflect bold/italic/etc. —
- * that lives in the rendered output. The toolbar applies semantic marks
- * to the selection; users see the formatted result on the published
- * page. This trade-off keeps the editor's selection model simple and
- * dodges contentEditable's bag of bugs.
+ * Model: the DOM is the source of truth while typing (we parse it back on
+ * `input`); formatting commands and "pending marks" rewrite the DOM and
+ * restore the caret by character offset. The marks toolbar can be toggled
+ * with no selection to arm formatting for whatever you type next, and
+ * reflects the formatting under the caret / selection.
  */
 export function RichTextField({ text, facets, onChange, rows = 4 }) {
-  const taRef = useRef(null);
-  const [selection, setSelection] = useState({ start: 0, end: 0 });
+  const editorRef = useRef(null);
+  const lastEmittedRef = useRef('');
+  const pendingCaretRef = useRef(null);
+  const prevTextRef = useRef(text);
+  const pendingMarksRef = useRef({}); // { key: boolean } overrides for next typed text
+  const composingRef = useRef(false);
 
-  const captureSelection = useCallback(() => {
-    const el = taRef.current;
-    if (!el) return;
-    setSelection({ start: el.selectionStart, end: el.selectionEnd });
+  const textRef = useRef(text);
+  textRef.current = text;
+  const facetsRef = useRef(facets);
+  facetsRef.current = facets;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const [active, setActive] = useState({});
+  const [hasSelection, setHasSelection] = useState(false);
+
+  const refreshActive = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const r = getSelectionRange(editor);
+    if (!r) {
+      setHasSelection(false);
+      setActive(effectiveActive([], pendingMarksRef.current));
+      return;
+    }
+    setHasSelection(!r.collapsed);
+    const t = textRef.current;
+    if (r.collapsed) {
+      let leftKeys = [];
+      if (r.start > 0) {
+        const bs = charsToBytes(t, r.start - 1);
+        const be = charsToBytes(t, r.start);
+        leftKeys = typesToKeys(featureTypesForRange(facetsRef.current, bs, be));
+      }
+      setActive(effectiveActive(leftKeys, pendingMarksRef.current));
+    } else {
+      const bs = charsToBytes(t, r.start);
+      const be = charsToBytes(t, r.end);
+      const map = {};
+      for (const k of typesToKeys(featureTypesForRange(facetsRef.current, bs, be))) map[k] = true;
+      setActive(map);
+    }
   }, []);
 
-  const handleTextChange = useCallback(
-    (e) => {
-      const nextText = e.target.value;
-      const nextFacets = remapFacets(text, nextText, facets);
-      onChange({ text: nextText, facets: nextFacets });
+  // Sync DOM ⇆ value. Skip when the incoming value is exactly what we just
+  // emitted from typing (the DOM already reflects it) so the caret never
+  // jumps mid-keystroke. Otherwise rebuild and restore the caret.
+  useLayoutEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const incoming = serialize(text, facets);
+    if (incoming === lastEmittedRef.current && pendingCaretRef.current == null) return;
+
+    const html = valueToHtml(text, facets);
+    const focused = editor === document.activeElement || editor.contains(document.activeElement);
+    let restore = pendingCaretRef.current;
+    if (restore == null && focused) {
+      const r = getSelectionRange(editor);
+      if (r) restore = { start: r.start, end: r.end };
+    }
+    if (editor.innerHTML !== html) editor.innerHTML = html;
+    lastEmittedRef.current = incoming;
+    if (restore != null && (focused || pendingCaretRef.current != null)) {
+      const len = text.length;
+      editor.focus();
+      setSelectionRange(editor, Math.min(restore.start, len), Math.min(restore.end, len));
+    }
+    pendingCaretRef.current = null;
+    refreshActive();
+  }, [text, facets, refreshActive]);
+
+  // Keep the toolbar in sync with the caret/selection while focused.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return undefined;
+    const onSel = () => {
+      const ae = document.activeElement;
+      if (ae === editor || editor.contains(ae)) refreshActive();
+    };
+    document.addEventListener('selectionchange', onSel);
+    return () => document.removeEventListener('selectionchange', onSel);
+  }, [refreshActive]);
+
+  const emit = useCallback((value, opts = {}) => {
+    prevTextRef.current = value.text;
+    if (opts.rewrite) {
+      lastEmittedRef.current = null;
+      pendingCaretRef.current = opts.caret || null;
+    } else {
+      lastEmittedRef.current = serialize(value.text, value.facets);
+      pendingCaretRef.current = null;
+    }
+    onChangeRef.current(value);
+  }, []);
+
+  const handleInput = useCallback(() => {
+    if (composingRef.current) return;
+    const editor = editorRef.current;
+    if (!editor) return;
+    const parsed = parseEditor(editor);
+    const oldText = prevTextRef.current;
+    const pending = pendingMarksRef.current;
+    const pendingKeys = Object.keys(pending);
+
+    if (pendingKeys.length && parsed.text.length > oldText.length) {
+      const [is, ie] = insertedRange(oldText, parsed.text);
+      const bs = charsToBytes(parsed.text, is);
+      const be = charsToBytes(parsed.text, ie);
+      let next = parsed.facets;
+      for (const k of pendingKeys) {
+        const type = FORMAT_TYPES[k];
+        if (!type) continue;
+        next = pending[k]
+          ? applyFeatureAlways(next, bs, be, { $type: type })
+          : removeFeatureAlways(next, bs, be, { $type: type });
+      }
+      emit({ text: parsed.text, facets: next }, { rewrite: true, caret: { start: ie, end: ie } });
+    } else {
+      emit({ text: parsed.text, facets: parsed.facets });
+      refreshActive();
+    }
+  }, [emit, refreshActive]);
+
+  const onToolbar = useCallback(
+    (key) => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const r = getSelectionRange(editor);
+      const t = textRef.current;
+      const f = facetsRef.current;
+      if (r && !r.collapsed) {
+        const bs = charsToBytes(t, r.start);
+        const be = charsToBytes(t, r.end);
+        pendingMarksRef.current = {};
+        emit(
+          { text: t, facets: toggleFeature(f, bs, be, { $type: FORMAT_TYPES[key] }) },
+          { rewrite: true, caret: { start: r.start, end: r.end } },
+        );
+      } else {
+        const on = !active[key];
+        pendingMarksRef.current = { ...pendingMarksRef.current, [key]: on };
+        editor.focus();
+        refreshActive();
+      }
     },
-    [text, facets, onChange],
+    [active, emit, refreshActive],
   );
 
-  const toggle = useCallback(
-    (typeKey) => {
-      const el = taRef.current;
-      if (!el) return;
-      const start = el.selectionStart;
-      const end = el.selectionEnd;
-      if (end <= start) return;
-      const byteStart = charsToBytes(text, start);
-      const byteEnd = charsToBytes(text, end);
-      const nextFacets = toggleFeature(facets, byteStart, byteEnd, {
-        $type: FORMAT_TYPES[typeKey],
-      });
-      onChange({ text, facets: nextFacets });
-    },
-    [text, facets, onChange],
-  );
-
-  const addLink = useCallback(() => {
-    const el = taRef.current;
-    if (!el) return;
-    const start = el.selectionStart;
-    const end = el.selectionEnd;
-    if (end <= start) {
-      window.alert('Select some text first, then click the link button.');
+  const onLink = useCallback(() => {
+    const editor = editorRef.current;
+    const r = getSelectionRange(editor);
+    if (!r || r.collapsed) {
+      window.alert('Select some text first, then add a link.');
       return;
     }
     const url = window.prompt('Link URL', 'https://');
     if (!url || url === 'https://') return;
-    const byteStart = charsToBytes(text, start);
-    const byteEnd = charsToBytes(text, end);
-    onChange({ text, facets: applyLink(facets, byteStart, byteEnd, url) });
-  }, [text, facets, onChange]);
+    const t = textRef.current;
+    const bs = charsToBytes(t, r.start);
+    const be = charsToBytes(t, r.end);
+    emit({ text: t, facets: applyLink(facetsRef.current, bs, be, url) }, {
+      rewrite: true,
+      caret: { start: r.start, end: r.end },
+    });
+  }, [emit]);
 
-  const removeLink = useCallback(() => {
-    const el = taRef.current;
-    if (!el) return;
-    const start = el.selectionStart;
-    const end = el.selectionEnd;
-    if (end <= start) return;
-    const byteStart = charsToBytes(text, start);
-    const byteEnd = charsToBytes(text, end);
-    onChange({ text, facets: toggleFeature(facets, byteStart, byteEnd, { $type: LINK_TYPE }) });
-  }, [text, facets, onChange]);
+  const onUnlink = useCallback(() => {
+    const editor = editorRef.current;
+    const r = getSelectionRange(editor);
+    if (!r || r.collapsed) return;
+    const t = textRef.current;
+    const bs = charsToBytes(t, r.start);
+    const be = charsToBytes(t, r.end);
+    emit({ text: t, facets: removeFeatureAlways(facetsRef.current, bs, be, { $type: LINK_TYPE }) }, {
+      rewrite: true,
+      caret: { start: r.start, end: r.end },
+    });
+  }, [emit]);
 
-  const hasSelection = selection.end > selection.start;
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      document.execCommand('insertText', false, '\n');
+      return;
+    }
+    if (NAV_KEYS.has(e.key)) pendingMarksRef.current = {};
+  }, []);
+
+  const handlePaste = useCallback((e) => {
+    e.preventDefault();
+    const clip = e.clipboardData || window.clipboardData;
+    const plain = clip ? clip.getData('text/plain') : '';
+    if (plain) document.execCommand('insertText', false, plain);
+  }, []);
 
   return (
     <div className="rich-text-field">
       <div className="rich-text-toolbar" role="toolbar" aria-label="Formatting">
-        <ToolbarButton onClick={() => toggle('bold')} disabled={!hasSelection} title="Bold">
-          <strong>B</strong>
-        </ToolbarButton>
-        <ToolbarButton onClick={() => toggle('italic')} disabled={!hasSelection} title="Italic">
-          <em>I</em>
-        </ToolbarButton>
-        <ToolbarButton onClick={() => toggle('underline')} disabled={!hasSelection} title="Underline">
-          <u>U</u>
-        </ToolbarButton>
-        <ToolbarButton onClick={() => toggle('strikethrough')} disabled={!hasSelection} title="Strikethrough">
-          <s>S</s>
-        </ToolbarButton>
-        <ToolbarButton onClick={() => toggle('code')} disabled={!hasSelection} title="Inline code">
-          <code>{'<>'}</code>
-        </ToolbarButton>
-        <ToolbarButton onClick={() => toggle('highlight')} disabled={!hasSelection} title="Highlight">
-          <mark>H</mark>
-        </ToolbarButton>
-        <ToolbarButton onClick={addLink} disabled={!hasSelection} title="Add or replace link">
+        {FORMAT_BUTTONS.map((b) => (
+          <ToolbarButton key={b.key} title={b.title} active={!!active[b.key]} onClick={() => onToolbar(b.key)}>
+            {b.node}
+          </ToolbarButton>
+        ))}
+        <ToolbarButton title="Add or replace link" active={!!active.link} disabled={!hasSelection} onClick={onLink}>
           🔗
         </ToolbarButton>
-        <ToolbarButton onClick={removeLink} disabled={!hasSelection} title="Remove link">
+        <ToolbarButton title="Remove link" disabled={!hasSelection} onClick={onUnlink}>
           ⛓️‍💥
         </ToolbarButton>
       </div>
-      <textarea
-        ref={taRef}
-        className="admin-input admin-textarea rich-text-textarea"
-        value={text}
-        rows={rows}
-        onChange={handleTextChange}
-        onSelect={captureSelection}
-        onKeyUp={captureSelection}
-        onMouseUp={captureSelection}
+      <div
+        ref={editorRef}
+        className="admin-input rich-text-editable"
+        contentEditable
+        suppressContentEditableWarning
+        role="textbox"
+        aria-multiline="true"
+        aria-label="Rich text"
+        data-placeholder="Write…"
+        style={{ minHeight: `${Math.max(2, rows) * 1.7}em` }}
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onMouseDown={() => {
+          pendingMarksRef.current = {};
+        }}
+        onKeyUp={refreshActive}
+        onMouseUp={refreshActive}
+        onBlur={() => {
+          pendingMarksRef.current = {};
+        }}
+        onCompositionStart={() => {
+          composingRef.current = true;
+        }}
+        onCompositionEnd={() => {
+          composingRef.current = false;
+          handleInput();
+        }}
       />
-      {facets.length > 0 && (
-        <p className="admin-field-hint rich-text-facet-summary">
-          {summarize(facets)}
-        </p>
-      )}
     </div>
   );
 }
 
-function ToolbarButton({ children, onClick, disabled, title }) {
+function ToolbarButton({ children, onClick, disabled, title, active }) {
   return (
     <button
       type="button"
-      className="rich-text-toolbar-btn"
+      className={`rich-text-toolbar-btn${active ? ' is-active' : ''}`}
+      // Keep the editor's focus/selection when clicking the button.
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
       disabled={disabled}
       title={title}
+      aria-pressed={active ? 'true' : undefined}
     >
       {children}
     </button>
   );
 }
 
-function summarize(facets) {
-  const counts = {};
-  for (const f of facets) {
-    for (const feat of f.features || []) {
-      const key = feat.$type.replace('pub.leaflet.richtext.facet#', '');
-      counts[key] = (counts[key] || 0) + 1;
+/* ------------------------------------------------------------------ */
+/* Pure helpers                                                         */
+/* ------------------------------------------------------------------ */
+
+const NAV_KEYS = new Set([
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+]);
+
+function serialize(text, facets) {
+  return JSON.stringify([text, facets]);
+}
+
+function typesToKeys(types) {
+  return types
+    .map((t) => (t === LINK_TYPE ? 'link' : KEY_FOR_TYPE[t]))
+    .filter(Boolean);
+}
+
+function effectiveActive(baseKeys, pending) {
+  const map = {};
+  for (const k of baseKeys) map[k] = true;
+  for (const k of Object.keys(pending)) {
+    if (pending[k]) map[k] = true;
+    else delete map[k];
+  }
+  return map;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s) {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}
+
+function valueToHtml(text, facets) {
+  const runs = facetRuns(text, facets);
+  if (runs.length === 0) return '';
+  return runs.map((r) => spanHtml(r.text, r.features)).join('');
+}
+
+function spanHtml(runText, features) {
+  const keys = [];
+  let uri = '';
+  for (const f of features || []) {
+    if (f.$type === LINK_TYPE) {
+      keys.push('link');
+      uri = f.uri || '';
+    } else if (KEY_FOR_TYPE[f.$type]) {
+      keys.push(KEY_FOR_TYPE[f.$type]);
     }
   }
-  const parts = Object.entries(counts).map(([k, v]) => `${k}×${v}`);
-  return `${facets.length} facet${facets.length === 1 ? '' : 's'} (${parts.join(', ')})`;
+  const inner = escapeHtml(runText);
+  if (keys.length === 0) return `<span>${inner}</span>`;
+  const cls = keys.map((k) => `rt-${k}`).join(' ');
+  const data = ` data-feat="${keys.join(',')}"${uri ? ` data-uri="${escapeAttr(uri)}"` : ''}`;
+  return `<span class="${cls}"${data}>${inner}</span>`;
+}
+
+function featuresFromEl(el, inherited) {
+  const feats = inherited.slice();
+  const raw = el.dataset ? el.dataset.feat : '';
+  const keys = raw ? raw.split(',').filter(Boolean) : [];
+  for (const k of keys) {
+    if (k === 'link') continue;
+    const type = FORMAT_TYPES[k];
+    if (type && !feats.some((f) => f.$type === type)) feats.push({ $type: type });
+  }
+  if (keys.includes('link') && el.dataset && el.dataset.uri) {
+    if (!feats.some((f) => f.$type === LINK_TYPE)) feats.push({ $type: LINK_TYPE, uri: el.dataset.uri });
+  }
+  return feats;
+}
+
+function parseEditor(editor) {
+  const runs = [];
+  (function walk(node, inherited) {
+    for (const child of node.childNodes) {
+      if (child.nodeType === 3) {
+        if (child.data) runs.push({ text: child.data, features: inherited });
+      } else if (child.nodeType === 1) {
+        if (child.tagName === 'BR') {
+          runs.push({ text: '\n', features: inherited });
+          continue;
+        }
+        walk(child, featuresFromEl(child, inherited));
+      }
+    }
+  })(editor, []);
+  const text = runs.map((r) => r.text).join('');
+  return { text, facets: runsToFacets(text, runs) };
+}
+
+function insertedRange(oldText, newText) {
+  let p = 0;
+  const maxP = Math.min(oldText.length, newText.length);
+  while (p < maxP && oldText[p] === newText[p]) p++;
+  let s = 0;
+  const maxS = Math.min(oldText.length - p, newText.length - p);
+  while (s < maxS && oldText[oldText.length - 1 - s] === newText[newText.length - 1 - s]) s++;
+  return [p, newText.length - s];
+}
+
+/** Character offset from the editor's start to (container, offset). */
+function getCharOffset(editor, container, offset) {
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  try {
+    range.setEnd(container, offset);
+  } catch {
+    return null;
+  }
+  return range.toString().length;
+}
+
+function getSelectionRange(editor) {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return null;
+  const r = sel.getRangeAt(0);
+  if (!editor.contains(r.startContainer) || !editor.contains(r.endContainer)) return null;
+  const a = getCharOffset(editor, r.startContainer, r.startOffset);
+  const b = getCharOffset(editor, r.endContainer, r.endOffset);
+  if (a == null || b == null) return null;
+  return { start: Math.min(a, b), end: Math.max(a, b), collapsed: a === b };
+}
+
+function domPointAt(editor, target) {
+  let remaining = Math.max(0, target);
+  const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT, null);
+  let node;
+  let last = null;
+  while ((node = walker.nextNode())) {
+    const len = node.data.length;
+    if (remaining <= len) return { node, offset: remaining };
+    remaining -= len;
+    last = node;
+  }
+  if (last) return { node: last, offset: last.data.length };
+  return { node: editor, offset: 0 };
+}
+
+function setSelectionRange(editor, start, end) {
+  const sp = domPointAt(editor, start);
+  const ep = domPointAt(editor, end);
+  const range = document.createRange();
+  try {
+    range.setStart(sp.node, sp.offset);
+    range.setEnd(ep.node, ep.offset);
+  } catch {
+    return;
+  }
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
 }

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -121,13 +121,59 @@
   cursor: not-allowed;
 }
 
-.rich-text-textarea {
-  width: 100%;
+.rich-text-toolbar-btn.is-active:not(:disabled) {
+  background: var(--ink);
+  color: var(--page);
+  border-color: var(--ink);
 }
 
-.rich-text-facet-summary {
-  opacity: 0.6;
-  font-size: 0.8em;
+/* contentEditable WYSIWYG surface */
+.rich-text-editable {
+  width: 100%;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  cursor: text;
+  line-height: 1.55;
+}
+
+.rich-text-editable:focus {
+  border-color: var(--accent);
+}
+
+.rich-text-editable:empty::before {
+  content: attr(data-placeholder);
+  color: var(--ink-faint, rgba(0, 0, 0, 0.4));
+  pointer-events: none;
+}
+
+/* Inline mark styles — mirror the published renderer so the editor is WYSIWYG. */
+.rich-text-editable .rt-bold {
+  font-weight: 700;
+}
+.rich-text-editable .rt-italic {
+  font-style: italic;
+}
+.rich-text-editable .rt-underline {
+  text-decoration: underline;
+}
+.rich-text-editable .rt-strikethrough {
+  text-decoration: line-through;
+}
+.rich-text-editable .rt-underline.rt-strikethrough {
+  text-decoration: underline line-through;
+}
+.rich-text-editable .rt-code {
+  font-family: var(--mono, monospace);
+  font-size: 0.9em;
+  background: var(--surface-3, rgba(0, 0, 0, 0.06));
+  padding: 0 0.15em;
+}
+.rich-text-editable .rt-highlight {
+  background: var(--highlight, #fbe7a1);
+}
+.rich-text-editable .rt-link {
+  color: var(--accent, #5e7a47);
+  text-decoration: underline;
 }
 
 /* Heading block */

--- a/src/components/blocks/facetUtils.js
+++ b/src/components/blocks/facetUtils.js
@@ -39,6 +39,11 @@ export const FORMAT_TYPES = {
 };
 export const LINK_TYPE = 'pub.leaflet.richtext.facet#link';
 
+/** Reverse of FORMAT_TYPES: facet $type → short key used in the editor DOM. */
+export const KEY_FOR_TYPE = Object.fromEntries(
+  Object.entries(FORMAT_TYPES).map(([key, type]) => [type, key]),
+);
+
 /**
  * Toggle a feature on/off across a byte range. If every byte in the
  * range already has the feature, it's removed; otherwise it's added.
@@ -73,6 +78,12 @@ export function toggleFeature(facets, byteStart, byteEnd, feature) {
 
   // Fill the gap with bare segments if the range wasn't fully covered.
   const inRange = split.filter((s) => s.start >= byteStart && s.end <= byteEnd);
+  // No existing segment overlaps the range at all (e.g. the first mark on a
+  // fresh block, or formatting an unformatted region past every facet) — the
+  // whole range is a gap, so seed it as one bare segment.
+  if (inRange.length === 0) {
+    split.push({ start: byteStart, end: byteEnd, features: [] });
+  }
   const fillStart = inRange.length ? Math.min(...inRange.map((s) => s.start)) : byteStart;
   const fillEnd = inRange.length ? Math.max(...inRange.map((s) => s.end)) : byteEnd;
   if (fillStart > byteStart) {
@@ -126,7 +137,7 @@ export function applyLink(facets, byteStart, byteEnd, uri) {
   return applyFeatureAlways(stripped, byteStart, byteEnd, { $type: LINK_TYPE, uri });
 }
 
-function applyFeatureAlways(facets, byteStart, byteEnd, feature) {
+export function applyFeatureAlways(facets, byteStart, byteEnd, feature) {
   const segments = facetsToSegments(facets);
   const split = [];
   for (const s of segments) {
@@ -157,6 +168,108 @@ function applyFeatureAlways(facets, byteStart, byteEnd, feature) {
     }
   }
   return segmentsToFacets(split);
+}
+
+/** Force-remove a feature across a byte range (no toggle semantics). */
+export function removeFeatureAlways(facets, byteStart, byteEnd, feature) {
+  if (byteEnd <= byteStart) return facets;
+  const segments = facetsToSegments(facets);
+  const split = [];
+  for (const s of segments) {
+    if (s.end <= byteStart || s.start >= byteEnd) {
+      split.push(s);
+      continue;
+    }
+    if (s.start < byteStart) split.push({ start: s.start, end: byteStart, features: s.features });
+    const innerStart = Math.max(s.start, byteStart);
+    const innerEnd = Math.min(s.end, byteEnd);
+    split.push({ start: innerStart, end: innerEnd, features: removeFeature(s.features, feature) });
+    if (s.end > byteEnd) split.push({ start: byteEnd, end: s.end, features: s.features });
+  }
+  return segmentsToFacets(split);
+}
+
+/** Feature $types that cover the ENTIRE [byteStart, byteEnd) range. */
+export function featureTypesForRange(facets, byteStart, byteEnd) {
+  if (byteEnd <= byteStart) return [];
+  const types = new Set();
+  for (const f of facets || []) {
+    for (const ft of f.features || []) if (ft?.$type) types.add(ft.$type);
+  }
+  return Array.from(types).filter((t) => rangeFullyCovered(facets, byteStart, byteEnd, t));
+}
+
+function rangeFullyCovered(facets, bs, be, type) {
+  const intervals = (facets || [])
+    .filter((f) => (f.features || []).some((x) => x?.$type === type))
+    .map((f) => [Math.max(f.index.byteStart, bs), Math.min(f.index.byteEnd, be)])
+    .filter(([a, b]) => b > a)
+    .sort((a, b) => a[0] - b[0]);
+  let cursor = bs;
+  for (const [a, b] of intervals) {
+    if (a > cursor) return false;
+    cursor = Math.max(cursor, b);
+    if (cursor >= be) return true;
+  }
+  return cursor >= be;
+}
+
+/**
+ * Break text + facets into contiguous runs covering the whole string, each
+ * carrying the features active across it. Gap-free, so the editor can render
+ * a flat span-per-run structure (and parse it back the same way).
+ */
+export function facetRuns(text, facets) {
+  const safe = typeof text === 'string' ? text : '';
+  if (!safe) return [];
+  const totalBytes = ENCODER.encode(safe).length;
+  const valid = Array.isArray(facets)
+    ? facets.filter((f) => f?.index?.byteStart != null && f?.index?.byteEnd != null)
+    : [];
+  const points = new Set([0, totalBytes]);
+  for (const f of valid) {
+    if (f.index.byteStart >= 0 && f.index.byteStart <= totalBytes) points.add(f.index.byteStart);
+    if (f.index.byteEnd >= 0 && f.index.byteEnd <= totalBytes) points.add(f.index.byteEnd);
+  }
+  const sorted = Array.from(points).sort((a, b) => a - b);
+  const runs = [];
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const bs = sorted[i];
+    const be = sorted[i + 1];
+    if (be <= bs) continue;
+    const features = [];
+    for (const f of valid) {
+      if (f.index.byteStart <= bs && f.index.byteEnd >= be) {
+        for (const ft of f.features || []) {
+          if (ft?.$type && !features.some((x) => x.$type === ft.$type)) features.push(ft);
+        }
+      }
+    }
+    runs.push({ text: safe.slice(bytesToChars(safe, bs), bytesToChars(safe, be)), features });
+  }
+  return runs;
+}
+
+/**
+ * Inverse of facetRuns: ordered runs whose text concatenates to `text` →
+ * merged, gap-free leaflet facets.
+ */
+export function runsToFacets(text, runs) {
+  const safe = typeof text === 'string' ? text : '';
+  let charPos = 0;
+  const byteSegs = [];
+  for (const r of runs || []) {
+    const len = r.text ? r.text.length : 0;
+    if (len > 0 && Array.isArray(r.features) && r.features.length) {
+      byteSegs.push({
+        start: charsToBytes(safe, charPos),
+        end: charsToBytes(safe, charPos + len),
+        features: r.features,
+      });
+    }
+    charPos += len;
+  }
+  return segmentsToFacets(byteSegs);
 }
 
 function hasFeature(features, target) {


### PR DESCRIPTION
## Summary

Replaces the plain textarea behind the block / heading / list rich-text fields with a contentEditable WYSIWYG surface that renders leaflet facets inline.

- **Visible formatting** — bold, italic, underline, strikethrough, code, highlight, and links render inline while editing, mirroring the published output.
- **Pending marks** — formatting buttons now work with *or* without a selection. With a selection they apply/toggle across it; with no selection they arm the mark so it applies to whatever you type next. The toolbar reflects the formatting under the caret/selection, and buttons are no longer disabled when nothing is selected.
- **Mechanics** — the editor parses its DOM back to `plaintext` + `facets` on input and only rewrites/repositions the caret for discrete formatting commands, keeping typing smooth and byte offsets exact. Enter inserts a newline; paste is coerced to plain text.
- **Bug fix** — `toggleFeature` previously no-op'd when applying a mark to a range overlapping no existing facet (the first mark on a fresh block, or any unformatted region); the gap is now seeded. Verified with an 11-case round-trip suite (overlapping marks, multibyte UTF-8/emoji, links).
- Adds facet helpers (`facetRuns` / `runsToFacets` / `removeFeatureAlways` / `featureTypesForRange` / `KEY_FOR_TYPE`) and editor mark styles.

## Verification
- Offline `vite build` passes.
- Facet round-trip/unit suite passes (11/11).
- contentEditable caret/selection interaction is best smoke-tested in a browser via the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_