### PR TITLE
Tighten block-preview spacing

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -12,7 +12,10 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  /* Spacing is driven per-item below so previews sit at a tight, uniform
+     rhythm (their rendered blocks carry the full document margins, which
+     would otherwise compound with a list gap). */
+  gap: 0;
 }
 
 .blocks-editor-item {
@@ -29,7 +32,7 @@
 .blocks-editor-item.is-preview {
   border-color: transparent;
   background: transparent;
-  padding: 0.25rem 0.75rem;
+  padding: 0.35rem 0.75rem;
   gap: 0;
   cursor: text;
   transition: background 100ms ease;
@@ -41,8 +44,21 @@
   outline: none;
 }
 
+/* An editing block is a bordered box — give it room from its neighbours. */
+.blocks-editor-item.is-active {
+  margin: 0.5rem 0;
+}
+
 .blocks-editor-preview-body {
   pointer-events: none;
+}
+
+/* Drop the rendered block's own document margins; the editor controls the
+   inter-block rhythm instead so headings/lists/images don't balloon the gaps.
+   (Two classes keeps this ahead of the single-class leaflet element rules.) */
+.blocks-editor-preview > .blocks-editor-preview-body > * {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .blocks-editor-preview-empty {


### PR DESCRIPTION
## Summary

The collapsed block previews rendered with their full document margins (`space-6` above headings, `space-4` below paragraphs), which compounded with the list gap and item padding into large gaps between blocks.

- Zero each rendered block's own top/bottom margins inside the preview body.
- Drop the list gap and drive a tight, uniform rhythm (~0.7rem) from per-item padding.
- Give an active (editing) block a small margin so its bordered box still breathes against its neighbours.

CSS-only; offline `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_