### PR TITLE
Drag-to-reorder blocks + faint dashed block borders

### DIFF
--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -27,6 +27,8 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
   const blocks = content.pages[0].blocks;
 
   const [activeIndex, setActiveIndex] = useState(null);
+  const [dragIndex, setDragIndex] = useState(null);
+  const [dropIndex, setDropIndex] = useState(null); // insertion slot (0..length)
   const rootRef = useRef(null);
   const activeItemRef = useRef(null);
 
@@ -98,6 +100,71 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
     [blocks, updateBlocks],
   );
 
+  // Move a block from `from` to an insertion slot (0..length).
+  const moveTo = useCallback(
+    (from, insertion) => {
+      if (from == null) return;
+      const next = blocks.slice();
+      const [moved] = next.splice(from, 1);
+      let target = from < insertion ? insertion - 1 : insertion;
+      target = Math.max(0, Math.min(target, next.length));
+      next.splice(target, 0, moved);
+      updateBlocks(next);
+      setActiveIndex(null);
+    },
+    [blocks, updateBlocks],
+  );
+
+  const handleDragStart = useCallback((e, i) => {
+    setActiveIndex(null); // collapse any open editor while dragging
+    setDragIndex(i);
+    e.dataTransfer.effectAllowed = 'move';
+    try {
+      e.dataTransfer.setData('text/plain', String(i));
+    } catch {
+      /* some browsers disallow setData here; index lives in state anyway */
+    }
+    const li = e.currentTarget.closest('li');
+    if (li) {
+      try {
+        e.dataTransfer.setDragImage(li, 16, 16);
+      } catch {
+        /* setDragImage unsupported — fall back to the default handle image */
+      }
+    }
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null);
+    setDropIndex(null);
+  }, []);
+
+  const slotFor = (e, i) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    return e.clientY > rect.top + rect.height / 2 ? i + 1 : i;
+  };
+
+  const handleDragOver = useCallback(
+    (e, i) => {
+      if (dragIndex == null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDropIndex(slotFor(e, i));
+    },
+    [dragIndex],
+  );
+
+  const handleDrop = useCallback(
+    (e, i) => {
+      if (dragIndex == null) return;
+      e.preventDefault();
+      moveTo(dragIndex, slotFor(e, i));
+      setDragIndex(null);
+      setDropIndex(null);
+    },
+    [dragIndex, moveTo],
+  );
+
   // Collapse the active editor when the user clicks outside the editor.
   useEffect(() => {
     if (activeIndex == null) return undefined;
@@ -120,76 +187,118 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
         {blocks.map((wrap, i) => {
           const block = wrap?.block || {};
           const isActive = i === activeIndex;
-          if (!isActive) {
-            return (
-              <li
-                key={i}
-                className="blocks-editor-item is-preview"
-                onClick={() => setActiveIndex(i)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    setActiveIndex(i);
-                  }
-                }}
-                aria-label={`Edit ${labelFor(block.$type)} block`}
-              >
-                <BlockPreview block={block} />
-              </li>
-            );
-          }
+          // Drop indicator, suppressed for no-op drops back into the same slot.
+          const showBefore =
+            dragIndex != null &&
+            dropIndex === i &&
+            dropIndex !== dragIndex &&
+            dropIndex !== dragIndex + 1;
+          const showAfter =
+            dragIndex != null &&
+            i === blocks.length - 1 &&
+            dropIndex === blocks.length &&
+            dropIndex !== dragIndex + 1;
+          const cls = [
+            'blocks-editor-item',
+            isActive ? 'is-active' : 'is-preview',
+            dragIndex === i ? 'is-dragging' : '',
+            showBefore ? 'drop-before' : '',
+            showAfter ? 'drop-after' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
           return (
-            <li key={i} ref={activeItemRef} className="blocks-editor-item is-active">
-              <div className="blocks-editor-item-controls">
-                <span className="blocks-editor-item-type small-caps">{labelFor(block.$type)}</span>
-                <div className="blocks-editor-item-buttons">
-                  <button
-                    type="button"
-                    className="admin-link-subtle"
-                    onClick={() => moveBlock(i, -1)}
-                    disabled={i === 0}
-                    aria-label="Move up"
-                    title="Move up"
-                  >
-                    ↑
-                  </button>
-                  <button
-                    type="button"
-                    className="admin-link-subtle"
-                    onClick={() => moveBlock(i, 1)}
-                    disabled={i === blocks.length - 1}
-                    aria-label="Move down"
-                    title="Move down"
-                  >
-                    ↓
-                  </button>
-                  <button
-                    type="button"
-                    className="admin-link-subtle"
-                    onClick={() => removeBlock(i)}
-                    aria-label="Delete block"
-                    title="Delete"
-                  >
-                    ✕
-                  </button>
-                  <button
-                    type="button"
-                    className="admin-link-subtle blocks-editor-done"
-                    onClick={() => setActiveIndex(null)}
-                    title="Done editing this block"
-                  >
-                    Done
-                  </button>
-                </div>
+            <li
+              key={i}
+              ref={isActive ? activeItemRef : null}
+              className={cls}
+              onDragOver={(e) => handleDragOver(e, i)}
+              onDrop={(e) => handleDrop(e, i)}
+            >
+              <div
+                className="blocks-editor-handle"
+                draggable
+                onDragStart={(e) => handleDragStart(e, i)}
+                onDragEnd={handleDragEnd}
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                role="button"
+                tabIndex={-1}
+                aria-label="Drag to reorder"
+                title="Drag to reorder"
+              >
+                ⠿
               </div>
-              <BlockBody
-                block={block}
-                agent={agent}
-                did={did}
-                onChange={(next) => updateBlock(i, next)}
-              />
+
+              {isActive ? (
+                <div className="blocks-editor-main">
+                  <div className="blocks-editor-item-controls">
+                    <span className="blocks-editor-item-type small-caps">{labelFor(block.$type)}</span>
+                    <div className="blocks-editor-item-buttons">
+                      <button
+                        type="button"
+                        className="admin-link-subtle"
+                        onClick={() => moveBlock(i, -1)}
+                        disabled={i === 0}
+                        aria-label="Move up"
+                        title="Move up"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        className="admin-link-subtle"
+                        onClick={() => moveBlock(i, 1)}
+                        disabled={i === blocks.length - 1}
+                        aria-label="Move down"
+                        title="Move down"
+                      >
+                        ↓
+                      </button>
+                      <button
+                        type="button"
+                        className="admin-link-subtle"
+                        onClick={() => removeBlock(i)}
+                        aria-label="Delete block"
+                        title="Delete"
+                      >
+                        ✕
+                      </button>
+                      <button
+                        type="button"
+                        className="admin-link-subtle blocks-editor-done"
+                        onClick={() => setActiveIndex(null)}
+                        title="Done editing this block"
+                      >
+                        Done
+                      </button>
+                    </div>
+                  </div>
+                  <BlockBody
+                    block={block}
+                    agent={agent}
+                    did={did}
+                    onChange={(next) => updateBlock(i, next)}
+                  />
+                </div>
+              ) : (
+                <div
+                  className="blocks-editor-main blocks-editor-click"
+                  onClick={() => setActiveIndex(i)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setActiveIndex(i);
+                    }
+                  }}
+                  aria-label={`Edit ${labelFor(block.$type)} block`}
+                >
+                  <BlockPreview block={block} />
+                </div>
+              )}
             </li>
           );
         })}

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -12,41 +12,90 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  /* Spacing is driven per-item below so previews sit at a tight, uniform
-     rhythm (their rendered blocks carry the full document margins, which
-     would otherwise compound with a list gap). */
-  gap: 0;
+  /* Small gap between the (now dashed-bordered) blocks. Rendered block
+     margins are zeroed below so they don't compound into large gaps. */
+  gap: 0.3rem;
 }
 
 .blocks-editor-item {
-  border: 1px solid var(--rule, rgba(0, 0, 0, 0.12));
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  border: 1px dashed var(--rule-soft, rgba(0, 0, 0, 0.16));
   border-radius: 0;
-  padding: 0.625rem 0.75rem;
-  background: var(--surface-2, rgba(0, 0, 0, 0.015));
+  background: transparent;
+  padding: 0.1rem 0.4rem 0.1rem 0.1rem;
+}
+
+.blocks-editor-main {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  padding: 0.2rem 0.35rem;
 }
 
 /* Collapsed (preview) block — reads as the live document; click to edit. */
-.blocks-editor-item.is-preview {
-  border-color: transparent;
-  background: transparent;
-  padding: 0.35rem 0.75rem;
+.blocks-editor-item.is-preview .blocks-editor-main {
   gap: 0;
+}
+
+.blocks-editor-click {
   cursor: text;
-  transition: background 100ms ease;
 }
 
 .blocks-editor-item.is-preview:hover,
-.blocks-editor-item.is-preview:focus-visible {
-  background: var(--surface-2, rgba(0, 0, 0, 0.04));
-  outline: none;
+.blocks-editor-item.is-preview:focus-within {
+  background: var(--surface-2, rgba(0, 0, 0, 0.03));
 }
 
-/* An editing block is a bordered box — give it room from its neighbours. */
+/* An editing block reads as a firmer, solid box. */
 .blocks-editor-item.is-active {
-  margin: 0.5rem 0;
+  border-style: solid;
+  border-color: var(--rule, rgba(0, 0, 0, 0.2));
+  background: var(--surface-2, rgba(0, 0, 0, 0.015));
+  margin: 0.35rem 0;
+}
+
+/* Drag handle — subtle until you hover the block. */
+.blocks-editor-handle {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  color: var(--ink-faint, rgba(0, 0, 0, 0.35));
+  font-size: 0.9rem;
+  line-height: 1;
+  user-select: none;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.blocks-editor-item:hover .blocks-editor-handle,
+.blocks-editor-item.is-active .blocks-editor-handle,
+.blocks-editor-handle:focus-visible {
+  opacity: 1;
+}
+
+.blocks-editor-handle:active {
+  cursor: grabbing;
+}
+
+.blocks-editor-item.is-dragging {
+  opacity: 0.4;
+}
+
+/* Insertion indicator while dragging. */
+.blocks-editor-item.drop-before {
+  box-shadow: inset 0 2px 0 var(--accent, #5e7a47);
+}
+
+.blocks-editor-item.drop-after {
+  box-shadow: inset 0 -2px 0 var(--accent, #5e7a47);
 }
 
 .blocks-editor-preview-body {


### PR DESCRIPTION
## Summary

- **Drag-to-reorder** — each block gets a drag handle (subtle until hover) that reorders blocks via native HTML5 drag-and-drop. The handle is the only draggable element, so it never interferes with click-to-edit or text selection. An accent insertion line shows where the block will land (top/bottom half of the hovered block decides before/after), and the move up/down buttons stay for keyboard use.
- **Faint dashed borders** — every block now has a faint dashed border; the active (editing) block firms up to a solid box. Each item is restructured into a handle column + content column.

## Verification
- Offline `vite build` passes.
- Reorder math (splice-out then index-adjusted insert, no-op slots suppressed) verified by hand.
- Native drag-and-drop interaction is best smoke-tested in a browser via the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_