### PR TITLE
Inline block-type controls, hover delete, and document-level undo

### DIFF
--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -29,11 +29,24 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
   const [activeIndex, setActiveIndex] = useState(null);
   const [dragIndex, setDragIndex] = useState(null);
   const [dropIndex, setDropIndex] = useState(null); // insertion slot (0..length)
+  const [canUndo, setCanUndo] = useState(false);
   const rootRef = useRef(null);
   const activeItemRef = useRef(null);
+  // Document-level undo history of whole-content snapshots. Consecutive text
+  // edits to the same block coalesce into one entry so undo steps by edit
+  // session (and by structural op), not by keystroke.
+  const historyRef = useRef([]);
+  const coalesceRef = useRef(null);
 
-  const updateBlocks = useCallback(
-    (nextBlocks) => {
+  const commit = useCallback(
+    (nextBlocks, meta = {}) => {
+      const coalesce = meta.kind === 'text' && coalesceRef.current === meta.blockIndex;
+      if (!coalesce) {
+        historyRef.current.push(content);
+        if (historyRef.current.length > 200) historyRef.current.shift();
+        setCanUndo(true);
+      }
+      coalesceRef.current = meta.kind === 'text' ? meta.blockIndex : null;
       onChange({
         ...content,
         pages: [{ ...content.pages[0], blocks: nextBlocks }],
@@ -42,13 +55,24 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
     [content, onChange],
   );
 
+  const undo = useCallback(() => {
+    const prev = historyRef.current.pop();
+    if (prev == null) return;
+    coalesceRef.current = null;
+    setCanUndo(historyRef.current.length > 0);
+    setActiveIndex(null);
+    onChange(prev);
+  }, [onChange]);
+
   const updateBlock = useCallback(
     (index, nextBlock) => {
+      // A same-type edit is text (coalesces); a $type change is structural.
+      const kind = blocks[index]?.block?.$type === nextBlock?.$type ? 'text' : 'structural';
       const next = blocks.slice();
       next[index] = { $type: WRAPPER_TYPE, block: nextBlock };
-      updateBlocks(next);
+      commit(next, { kind, blockIndex: index });
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   const insertBlock = useCallback(
@@ -58,18 +82,18 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
       const index = atIndex == null ? next.length : atIndex;
       if (atIndex == null) next.push(wrapped);
       else next.splice(atIndex, 0, wrapped);
-      updateBlocks(next);
+      commit(next, { kind: 'structural' });
       setActiveIndex(index); // jump straight into editing the new block
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   const insertMany = useCallback(
     (newBlocks) => {
       const next = blocks.concat(newBlocks.map((b) => ({ $type: WRAPPER_TYPE, block: b })));
-      updateBlocks(next);
+      commit(next, { kind: 'structural' });
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   const removeBlock = useCallback(
@@ -82,10 +106,10 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
           block: { $type: 'pub.leaflet.blocks.text', plaintext: '', facets: [] },
         });
       }
-      updateBlocks(next);
+      commit(next, { kind: 'structural' });
       setActiveIndex(null);
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   const moveBlock = useCallback(
@@ -94,10 +118,10 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
       if (target < 0 || target >= blocks.length) return;
       const next = blocks.slice();
       [next[index], next[target]] = [next[target], next[index]];
-      updateBlocks(next);
+      commit(next, { kind: 'structural' });
       setActiveIndex(target); // follow the block that moved
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   // Move a block from `from` to an insertion slot (0..length).
@@ -109,10 +133,10 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
       let target = from < insertion ? insertion - 1 : insertion;
       target = Math.max(0, Math.min(target, next.length));
       next.splice(target, 0, moved);
-      updateBlocks(next);
+      commit(next, { kind: 'structural' });
       setActiveIndex(null);
     },
-    [blocks, updateBlocks],
+    [blocks, commit],
   );
 
   const handleDragStart = useCallback((e, i) => {
@@ -175,14 +199,37 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
     return () => document.removeEventListener('mousedown', onDown);
   }, [activeIndex]);
 
-  // Drop focus into the block that just became active.
+  // Drop focus into the block that just became active — and again if its type
+  // changes underfoot (e.g. converting text → heading swaps the editor).
+  const activeType = activeIndex != null ? blocks[activeIndex]?.block?.$type : null;
   useEffect(() => {
     if (activeIndex == null) return;
     focusFirstField(activeItemRef.current);
-  }, [activeIndex]);
+  }, [activeIndex, activeType]);
+
+  const handleRootKeyDown = useCallback(
+    (e) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && (e.key === 'z' || e.key === 'Z')) {
+        e.preventDefault();
+        undo();
+      }
+    },
+    [undo],
+  );
 
   return (
-    <div className="blocks-editor" ref={rootRef}>
+    <div className="blocks-editor" ref={rootRef} onKeyDown={handleRootKeyDown}>
+      <div className="blocks-editor-toolbar">
+        <button
+          type="button"
+          className="admin-link-subtle"
+          onClick={undo}
+          disabled={!canUndo}
+          title="Undo (⌘/Ctrl+Z) — reorders, deletes, type changes"
+        >
+          ↶ Undo
+        </button>
+      </div>
       <ol className="blocks-editor-list">
         {blocks.map((wrap, i) => {
           const block = wrap?.block || {};
@@ -258,15 +305,6 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
                       </button>
                       <button
                         type="button"
-                        className="admin-link-subtle"
-                        onClick={() => removeBlock(i)}
-                        aria-label="Delete block"
-                        title="Delete"
-                      >
-                        ✕
-                      </button>
-                      <button
-                        type="button"
                         className="admin-link-subtle blocks-editor-done"
                         onClick={() => setActiveIndex(null)}
                         title="Done editing this block"
@@ -299,6 +337,20 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
                   <BlockPreview block={block} />
                 </div>
               )}
+
+              <button
+                type="button"
+                className="blocks-editor-delete"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeBlock(i);
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                aria-label="Delete block"
+                title="Delete block"
+              >
+                ✕
+              </button>
             </li>
           );
         })}

--- a/src/components/blocks/HeadingBlockEditor.jsx
+++ b/src/components/blocks/HeadingBlockEditor.jsx
@@ -3,28 +3,26 @@ import { RichTextField } from './TextBlockEditor.jsx';
 export default function HeadingBlockEditor({ block, onChange }) {
   const level = clampLevel(block.level);
   return (
-    <div className="heading-block-editor">
-      <div className="heading-block-editor-level">
-        <label className="admin-field-hint">Level</label>
-        <select
-          className="admin-input admin-input-narrow"
-          value={level}
-          onChange={(e) => onChange({ ...block, level: Number(e.target.value) })}
-        >
-          {[1, 2, 3, 4, 5, 6].map((n) => (
-            <option key={n} value={n}>H{n}</option>
-          ))}
-        </select>
-      </div>
-      <RichTextField
-        text={block.plaintext || ''}
-        facets={block.facets || []}
-        rows={2}
-        onChange={({ text, facets }) =>
-          onChange({ ...block, plaintext: text, facets })
+    <RichTextField
+      text={block.plaintext || ''}
+      facets={block.facets || []}
+      rows={2}
+      blockType="heading"
+      headingLevel={level}
+      onConvert={({ type, level: nextLevel }) => {
+        if (type === 'text') {
+          // Drop to a body paragraph, keeping the text + marks.
+          onChange({
+            $type: 'pub.leaflet.blocks.text',
+            plaintext: block.plaintext || '',
+            facets: block.facets || [],
+          });
+        } else {
+          onChange({ ...block, level: clampLevel(nextLevel) });
         }
-      />
-    </div>
+      }}
+      onChange={({ text, facets }) => onChange({ ...block, plaintext: text, facets })}
+    />
   );
 }
 

--- a/src/components/blocks/TextBlockEditor.jsx
+++ b/src/components/blocks/TextBlockEditor.jsx
@@ -18,6 +18,17 @@ export default function TextBlockEditor({ block, onChange }) {
     <RichTextField
       text={block.plaintext || ''}
       facets={block.facets || []}
+      blockType="text"
+      onConvert={({ type, level }) => {
+        if (type === 'heading') {
+          onChange({
+            $type: 'pub.leaflet.blocks.header',
+            plaintext: block.plaintext || '',
+            facets: block.facets || [],
+            level: level || 2,
+          });
+        }
+      }}
       onChange={({ text, facets }) => onChange({ ...block, plaintext: text, facets })}
       rows={4}
     />
@@ -48,7 +59,15 @@ const FORMAT_BUTTONS = [
  * with no selection to arm formatting for whatever you type next, and
  * reflects the formatting under the caret / selection.
  */
-export function RichTextField({ text, facets, onChange, rows = 4 }) {
+export function RichTextField({
+  text,
+  facets,
+  onChange,
+  rows = 4,
+  blockType = null,
+  headingLevel = null,
+  onConvert = null,
+}) {
   const editorRef = useRef(null);
   const lastEmittedRef = useRef('');
   const pendingCaretRef = useRef(null);
@@ -248,6 +267,28 @@ export function RichTextField({ text, facets, onChange, rows = 4 }) {
   return (
     <div className="rich-text-field">
       <div className="rich-text-toolbar" role="toolbar" aria-label="Formatting">
+        {onConvert && (
+          <>
+            <ToolbarButton
+              title="Body text"
+              active={blockType === 'text'}
+              onClick={() => onConvert({ type: 'text' })}
+            >
+              ¶
+            </ToolbarButton>
+            {[1, 2, 3].map((lvl) => (
+              <ToolbarButton
+                key={lvl}
+                title={`Heading ${lvl}`}
+                active={blockType === 'heading' && headingLevel === lvl}
+                onClick={() => onConvert({ type: 'heading', level: lvl })}
+              >
+                {`H${lvl}`}
+              </ToolbarButton>
+            ))}
+            <span className="rich-text-toolbar-divider" aria-hidden="true" />
+          </>
+        )}
         {FORMAT_BUTTONS.map((b) => (
           <ToolbarButton key={b.key} title={b.title} active={!!active[b.key]} onClick={() => onToolbar(b.key)}>
             {b.node}

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -6,6 +6,36 @@
   gap: 0.75rem;
 }
 
+.blocks-editor-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: -0.4rem;
+}
+
+/* Per-block quick delete — appears on the far right on hover. */
+.blocks-editor-delete {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 1.4rem;
+  border: 0;
+  background: transparent;
+  color: var(--ink-faint, rgba(0, 0, 0, 0.35));
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 100ms ease, color 100ms ease;
+}
+
+.blocks-editor-item:hover .blocks-editor-delete,
+.blocks-editor-delete:focus-visible {
+  opacity: 1;
+}
+
+.blocks-editor-delete:hover {
+  color: var(--tan, #a88c5f);
+}
+
 .blocks-editor-list {
   list-style: none;
   padding: 0;
@@ -194,6 +224,14 @@
   display: flex;
   gap: 0.25rem;
   flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.rich-text-toolbar-divider {
+  width: 1px;
+  align-self: stretch;
+  background: var(--rule-soft, rgba(0, 0, 0, 0.18));
+  margin: 0.15rem 0.15rem;
 }
 
 .rich-text-toolbar-btn {


### PR DESCRIPTION
## Summary

- **Inline text ↔ heading conversion** — text/heading blocks gain ¶ / H1 / H2 / H3 buttons in the formatting toolbar (active state reflects the current type), replacing the dedicated level dropdown (removed). Text + marks carry across the conversion and focus returns to the block.
- **Quick hover delete** — each block shows a ✕ on the far right on hover; the redundant delete in the active block's control row is dropped.
- **Document-level undo** — a snapshot history of the whole content with an Undo button and ⌘/Ctrl+Z. Reorders, deletes, inserts, and type changes each get an entry; consecutive text edits to one block coalesce so undo steps by edit session rather than per keystroke.

## Notes
- Because the editor is a custom contentEditable, ⌘Z performs document-level undo (not native per-character undo) — one press rolls back the current block's editing session.

## Verification
- Offline `vite build` passes.
- Undo coalescing/structural classification reasoned through; interaction is best smoke-tested in a browser via the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkcN5t4hUJsmBHzUv5T2S)_