### PR TITLE
Restore the serif-only typeface toggle in the dock Tools row

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import RouteTransition from './components/RouteTransition.jsx';
 import { ActionDockProvider } from './hooks/useActionDock.jsx';
 import { ThemeProvider } from './hooks/useTheme.jsx';
 import { DensityProvider } from './hooks/useDensity.jsx';
+import { TypefaceProvider } from './hooks/useTypeface.jsx';
 import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
 import { FeedFilterProvider } from './hooks/useFeedFilter.jsx';
 import { AtprotoSessionProvider } from './hooks/useAtprotoSession.jsx';
@@ -76,6 +77,7 @@ export default function App() {
   return (
     <ThemeProvider>
       <DensityProvider>
+      <TypefaceProvider>
       <FilmGrainProvider>
       <ChromeBarProvider>
       <AtprotoSessionProvider>
@@ -142,6 +144,7 @@ export default function App() {
       </AtprotoSessionProvider>
       </ChromeBarProvider>
       </FilmGrainProvider>
+      </TypefaceProvider>
       </DensityProvider>
     </ThemeProvider>
   );

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -5,6 +5,7 @@ import { Bug, ChevronLeft, User } from 'lucide-react';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import Modal from './Modal.jsx';
 import DensityToggle from './DensityToggle.jsx';
+import TypefaceToggle from './TypefaceToggle.jsx';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
@@ -117,6 +118,7 @@ export default function ActionDock() {
                 <div className="dock-heading">Tools</div>
                 <div className="dock-display-row">
                   <DensityToggle />
+                  <TypefaceToggle />
                   <button
                     type="button"
                     className="dock-tool-icon"

--- a/src/components/DensityToggle.css
+++ b/src/components/DensityToggle.css
@@ -35,3 +35,16 @@
   width: 0.95rem;
   height: 0.95rem;
 }
+
+/* Typeface toggle reuses the density button group, but its options
+   render letterforms ("Aa") instead of SVG glyphs so each button
+   previews the font family it selects. Color inherits from the
+   button, so the is-active state flips the letters too. */
+.typeface-toggle-glyph {
+  display: inline-flex;
+  align-items: baseline;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.01em;
+}

--- a/src/components/TypefaceToggle.jsx
+++ b/src/components/TypefaceToggle.jsx
@@ -1,0 +1,55 @@
+import { useTypeface } from '../hooks/useTypeface.jsx';
+import './DensityToggle.css';
+
+const LABELS = {
+  combo: 'Typeface: serif + sans (default)',
+  serif: 'Typeface: serif only',
+  sans: 'Typeface: sans only',
+};
+
+// Each option previews itself: the "Aa" renders in the family the
+// option selects, so the button literally shows the typeface. "combo"
+// mixes a serif "A" with a sans "a" to signal the default split.
+// These reference the raw --font-* stacks (not --serif/--sans, which
+// the data-typeface mode rewrites) so each preview stays fixed.
+const GLYPHS = {
+  combo: [
+    { ch: 'A', family: 'var(--font-crimson)' },
+    { ch: 'a', family: 'var(--font-atkinson)' },
+  ],
+  serif: [
+    { ch: 'A', family: 'var(--font-crimson)' },
+    { ch: 'a', family: 'var(--font-crimson)' },
+  ],
+  sans: [
+    { ch: 'A', family: 'var(--font-atkinson)' },
+    { ch: 'a', family: 'var(--font-atkinson)' },
+  ],
+};
+
+export default function TypefaceToggle() {
+  const { typeface, setTypeface, options } = useTypeface();
+  return (
+    <div className="density-toggle-options" role="group" aria-label="Typeface">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          className={`density-toggle-option ${typeface === opt ? 'is-active' : ''}`}
+          onClick={() => setTypeface(opt)}
+          aria-pressed={typeface === opt}
+          aria-label={LABELS[opt]}
+          title={LABELS[opt]}
+        >
+          <span className="typeface-toggle-glyph" aria-hidden="true">
+            {GLYPHS[opt].map((g, i) => (
+              <span key={i} style={{ fontFamily: g.family }}>
+                {g.ch}
+              </span>
+            ))}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useTypeface.jsx
+++ b/src/hooks/useTypeface.jsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const TypefaceContext = createContext(null);
+const STORAGE_KEY = 'dame.typeface';
+// Mirrors the [data-typeface] modes in theme.css: "combo" (default)
+// keeps the serif/sans split; "serif" and "sans" collapse both stacks
+// to a single family for a unified voice.
+const VALID = ['combo', 'serif', 'sans'];
+const DEFAULT = 'combo';
+
+function applyTypeface(typeface) {
+  document.documentElement.setAttribute('data-typeface', typeface);
+}
+
+function readInitial() {
+  if (typeof localStorage === 'undefined') return DEFAULT;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return VALID.includes(stored) ? stored : DEFAULT;
+}
+
+export function TypefaceProvider({ children }) {
+  const [typeface, setTypefaceState] = useState(readInitial);
+
+  useEffect(() => {
+    applyTypeface(typeface);
+    try {
+      localStorage.setItem(STORAGE_KEY, typeface);
+    } catch {}
+  }, [typeface]);
+
+  const setTypeface = useCallback((next) => {
+    if (!VALID.includes(next)) return;
+    setTypefaceState(next);
+  }, []);
+
+  const cycle = useCallback(() => {
+    setTypefaceState((prev) => {
+      const idx = VALID.indexOf(prev);
+      return VALID[(idx + 1) % VALID.length];
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ typeface, setTypeface, cycle, options: VALID }),
+    [typeface, setTypeface, cycle],
+  );
+  return <TypefaceContext.Provider value={value}>{children}</TypefaceContext.Provider>;
+}
+
+export function useTypeface() {
+  const ctx = useContext(TypefaceContext);
+  if (!ctx) throw new Error('useTypeface must be used inside <TypefaceProvider>');
+  return ctx;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -30,7 +30,14 @@ themeColorMeta.setAttribute('name', 'theme-color');
 themeColorMeta.setAttribute('content', THEME_COLORS[initialTheme]);
 document.head.appendChild(themeColorMeta);
 
-document.documentElement.setAttribute('data-typeface', 'combo');
+// Typeface: apply the saved preference before React mounts so the first
+// paint uses the chosen family instead of flashing the default "combo"
+// (serif/sans split) until <TypefaceProvider> hydrates. Keep VALID_TYPEFACE
+// + the default in sync with useTypeface.jsx.
+const VALID_TYPEFACE = ['combo', 'serif', 'sans'];
+let storedTypeface = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.typeface') : null;
+if (!VALID_TYPEFACE.includes(storedTypeface)) storedTypeface = 'combo';
+document.documentElement.setAttribute('data-typeface', storedTypeface);
 
 // Density: read the new tri-state key first, fall back to the legacy
 // boolean `dame.compact` so users with the old setting don't lose it.


### PR DESCRIPTION
Re-adds the typeface setting under **Tools** in the nav menu, letting visitors switch the site to serif only.

## Background
The `[data-typeface]` CSS modes (`combo` / `serif` / `sans`) already existed in `theme.css`, but nothing drove them — `main.jsx` hardcoded `combo` and the UI control had been removed (a stale comment in `ActionDock.css` still referenced "the theme + typeface button groups"). This reconnects the control to that existing infrastructure.

## Changes
- **`src/hooks/useTypeface.jsx`** — new provider/hook mirroring `useDensity`; persists to `localStorage['dame.typeface']` and reflects the choice on `<html data-typeface>`.
- **`src/components/TypefaceToggle.jsx`** — segmented control in the Tools row beside the density toggle. Each option previews itself ("Aa" in the family it selects; `combo` mixes a serif "A" with a sans "a").
- **`src/styles/DensityToggle.css`** — glyph styling for the letterform buttons (reuses the existing toggle button group).
- **`src/App.jsx`** — wraps the tree in `TypefaceProvider`.
- **`src/main.jsx`** — reads the saved preference before React mounts so the chosen family paints on the first frame instead of flashing the default split.

## Verification
`npm run build:offline` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0152J9DjJr1rHXFLE1CVxAU9)_