### PR TITLE
Add /curating: Are.na-backed gallery pages

### DIFF
--- a/curating/curating.md
+++ b/curating/curating.md
@@ -1,8 +1,0 @@
----
-layout: folder
-title: /curating
-permalink: /curating/
-pinned: true
----
-
-Coming soon... are.na

--- a/lexicons/is.dame.arena.channel.json
+++ b/lexicons/is.dame.arena.channel.json
@@ -1,0 +1,24 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.arena.channel",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "any",
+      "description": "Publishes an Are.na channel as a gallery on /curating. The record key is the site-facing slug (e.g. weird-dogs-only → /curating/weird-dogs-only).",
+      "record": {
+        "type": "object",
+        "required": ["arenaSlug", "createdAt"],
+        "properties": {
+          "arenaSlug":   { "type": "string", "description": "Are.na channel slug, from are.na/<user>/<slug>." },
+          "title":       { "type": "string", "description": "Optional title override; falls back to the channel title on are.na." },
+          "description": { "type": "string", "description": "Optional description override; falls back to the channel description." },
+          "order":       { "type": "integer", "default": 0, "description": "Sort order on the /curating index — lower sorts first." },
+          "enabled":     { "type": "boolean", "default": true, "description": "When false, the gallery is hidden from the site." },
+          "createdAt":   { "type": "string", "format": "datetime" },
+          "updatedAt":   { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -43,6 +43,12 @@ import {
 } from '../src/lib/atproto.js';
 import { VERB_REGISTRY } from '../src/lib/verbRegistry.js';
 import {
+  fetchChannelMeta,
+  fetchAllBlocks,
+  arenaChannelUrl,
+  arenaAccessToken,
+} from '../src/lib/arena.js';
+import {
   buildUnifiedFeed,
   backfillTimestamps,
   shouldWriteCombinedVerbFile,
@@ -145,6 +151,59 @@ async function main() {
     jobs: resumeJobs,
     education: resumeEducation,
   });
+
+  // --- Curating (is.dame.arena.channel → are.na gallery snapshots) ----------
+  // Guest tier is 30 req/min; an ARENA_ACCESS_TOKEN (read-only personal
+  // token, set in the Vercel env) unlocks the account tier, so the
+  // inter-request spacing adapts to whichever budget we have.
+  const arenaAuthed = Boolean(arenaAccessToken());
+  const arenaDelayMs = arenaAuthed ? 250 : 2100;
+  const arenaChannelRecords = await safe(
+    'listRecords:arenaChannel',
+    () => listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.arenaChannel, max: 100 }),
+    [],
+  );
+  const enabledGalleries = arenaChannelRecords
+    .map((r) => ({ rkey: String(r.uri || '').split('/').pop(), value: r.value || {} }))
+    .filter((g) => g.rkey && g.value.arenaSlug && g.value.enabled !== false)
+    .sort((a, b) => (a.value.order ?? 0) - (b.value.order ?? 0));
+  log(`arena: ${enabledGalleries.length} enabled channel(s), auth=${arenaAuthed}`);
+
+  const galleries = [];
+  for (const g of enabledGalleries) {
+    const snap = await safe(
+      `arena:${g.value.arenaSlug}`,
+      async () => {
+        const meta = await fetchChannelMeta(g.value.arenaSlug);
+        const { blocks, truncated } = await fetchAllBlocks(g.value.arenaSlug, {
+          delayMs: arenaDelayMs,
+        });
+        return { meta, blocks, truncated };
+      },
+      null,
+    );
+    if (!snap) continue; // channel fetch failed → skip it; the build proceeds
+
+    const gallery = {
+      slug: g.rkey,
+      arenaSlug: g.value.arenaSlug,
+      title: g.value.title || snap.meta?.title || g.rkey,
+      description: g.value.description || snap.meta?.description || '',
+      blockCount: snap.blocks.length,
+      arenaUrl: arenaChannelUrl(g.value.arenaSlug),
+      cover: snap.blocks[0]?.thumb || null,
+      order: g.value.order ?? 0,
+    };
+    galleries.push(gallery);
+    await writeJson(`curating-${g.rkey}`, {
+      builtAt: new Date().toISOString(),
+      gallery,
+      truncated: snap.truncated,
+      blocks: snap.blocks,
+    });
+  }
+  // Written even when empty so the index page's snapshot never 404s.
+  await writeJson('curating', { builtAt: new Date().toISOString(), galleries });
 
   // --- Registry-driven ingest (delegated to the shared builder) -------------
   const { unified, perCollection, perVerb, authorFeed, counts } = await buildUnifiedFeed({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import Blogging from './pages/Blogging.jsx';
 import BlogPost from './pages/BlogPost.jsx';
 import Creating from './pages/Creating.jsx';
 import CreatingWork from './pages/CreatingWork.jsx';
+import Curating from './pages/Curating.jsx';
+import CuratingChannel from './pages/CuratingChannel.jsx';
 import Resume from './pages/Resume.jsx';
 import Sharing from './pages/Sharing.jsx';
 import Record from './pages/Record.jsx';
@@ -97,6 +99,8 @@ export default function App() {
                   <Route path="/blogging/:slug" element={<BlogPost />} />
                   <Route path="/creating" element={<Creating />} />
                   <Route path="/creating/:slug" element={<CreatingWork />} />
+                  <Route path="/curating" element={<Curating />} />
+                  <Route path="/curating/:slug" element={<CuratingChannel />} />
                   <Route path="/resume" element={<Resume />} />
                   <Route path="/resume/:slug" element={<Resume />} />
                   <Route path="/sharing" element={<Sharing />} />

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -18,6 +18,7 @@ const ROUTES = [
   { to: '/listening', label: 'Listening' },
   { to: '/blogging', label: 'Blogging' },
   { to: '/creating', label: 'Creating' },
+  { to: '/curating', label: 'Curating' },
   { to: '/resume', label: 'Resume' },
   { to: '/sharing', label: 'Sharing' },
   { to: '/exploring', label: 'Exploring' },

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ const HERO_PHRASE_NSID = 'is.dame.hero.phrase';
 const RESUME_NSID = 'is.dame.resume';
 const RESUME_JOB_NSID = 'is.dame.resume.job';
 const RESUME_EDUCATION_NSID = 'is.dame.resume.education';
+const ARENA_CHANNEL_NSID = 'is.dame.arena.channel';
 
 /**
  * Legacy verb-or-shorthand → NSID lookup. Existing call sites
@@ -53,6 +54,7 @@ export const COLLECTIONS = {
   resume: RESUME_NSID,
   resumeJob: RESUME_JOB_NSID,
   resumeEducation: RESUME_EDUCATION_NSID,
+  arenaChannel: ARENA_CHANNEL_NSID,
 };
 
 /** Gerund verbs surfaced on the home feed. Sourced from the registry. */

--- a/src/lib/arena.js
+++ b/src/lib/arena.js
@@ -1,0 +1,111 @@
+// Tiny isomorphic Are.na v3 client. No SDK — just fetch + JSON, so it runs
+// in both `scripts/prefetch.mjs` (Node) and the browser.
+//
+// Public channels need no auth and the API sends `access-control-allow-origin:
+// *`, so the browser's live refresh works unauthenticated (guest tier,
+// 30 req/min — a gallery page view makes at most ~11 requests). At build time
+// an optional read-only personal access token (ARENA_ACCESS_TOKEN) raises the
+// rate ceiling to the account's tier (premium = 300/min). The env var is
+// deliberately not VITE_-prefixed so Vite can never inline it into the
+// client bundle.
+
+import { ME_HANDLE } from '../config.js';
+
+const ARENA_API = 'https://api.are.na/v3';
+
+/** Are.na profile slug used for "view on are.na" links. */
+export const ARENA_USER = ME_HANDLE.split('.')[0];
+
+export function arenaChannelUrl(arenaSlug) {
+  return `https://www.are.na/${ARENA_USER}/${encodeURIComponent(arenaSlug)}`;
+}
+
+/** Build-time only: undefined in the browser. */
+export function arenaAccessToken() {
+  return typeof process !== 'undefined' ? process.env?.ARENA_ACCESS_TOKEN : undefined;
+}
+
+async function arenaJson(path) {
+  const token = arenaAccessToken();
+  const res = await fetch(`${ARENA_API}${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!res.ok) {
+    const err = new Error(`are.na HTTP ${res.status} for ${path}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
+/** `GET /v3/channels/{slug}` — channel metadata (title, description, counts). */
+export function fetchChannelMeta(arenaSlug) {
+  return arenaJson(`/channels/${encodeURIComponent(arenaSlug)}`);
+}
+
+/** One contents page, in the channel's curated (position) order. */
+export function fetchChannelPage(arenaSlug, page = 1, per = 100) {
+  return arenaJson(
+    `/channels/${encodeURIComponent(arenaSlug)}/contents?page=${page}&per=${per}&sort=position_asc`,
+  );
+}
+
+/**
+ * Normalize an are.na block to the compact shape the gallery pages (and
+ * snapshots) use. Returns null for block types the gallery can't render —
+ * Text, Media, Attachment, nested Channels, and Links without a preview
+ * image.
+ */
+export function normalizeBlock(block) {
+  const img = block?.image;
+  if (!img?.src) return null;
+  if (block.type !== 'Image' && block.type !== 'Link') return null;
+  return {
+    id: block.id,
+    type: block.type.toLowerCase(), // 'image' | 'link'
+    title: block.title || '',
+    alt: img.alt_text || block.title || '',
+    thumb: {
+      src: img.small?.src || img.src,
+      src2x: img.small?.src_2x || null,
+      width: img.small?.width || img.width || null,
+      height: img.small?.height || img.height || null,
+    },
+    large: img.large?.src || img.src,
+    width: img.width || null,
+    height: img.height || null,
+    aspectRatio: img.aspect_ratio || null,
+    sourceUrl: block.source?.url || null,
+    position: block.connection?.position ?? null,
+    connectedAt: block.connection?.connected_at || null,
+  };
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetch a channel's contents (position order), normalized. `maxPages` caps
+ * depth (default 10 pages × 100 = 1000 blocks); `truncated` tells callers to
+ * point at are.na for the rest. `delayMs` spaces requests to respect the
+ * rate tier — only needed at build time when many channels queue up.
+ */
+export async function fetchAllBlocks(arenaSlug, { per = 100, maxPages = 10, delayMs = 0 } = {}) {
+  const blocks = [];
+  let page = 1;
+  let truncated = false;
+  for (;;) {
+    const res = await fetchChannelPage(arenaSlug, page, per);
+    for (const b of res?.data || []) {
+      const n = normalizeBlock(b);
+      if (n) blocks.push(n);
+    }
+    if (!res?.meta?.has_more_pages) break;
+    if (page >= maxPages) {
+      truncated = true;
+      break;
+    }
+    page += 1;
+    if (delayMs) await sleep(delayMs);
+  }
+  return { blocks, truncated };
+}

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -280,6 +280,27 @@ export const LEXICONS = {
     ],
   },
 
+  [COLLECTIONS.arenaChannel]: {
+    label: 'Are.na gallery',
+    summary:
+      'Publishes an Are.na channel as a gallery at /curating/<rkey>. The rkey is the site slug; arenaSlug points at the channel on are.na.',
+    rkeyMode: 'fixed',
+    rkeyPlaceholder: 'weird-dogs-only',
+    typeFieldValue: COLLECTIONS.arenaChannel,
+    fields: [
+      {
+        key: 'arenaSlug', label: 'Are.na channel slug', type: 'text', required: true,
+        placeholder: 'weird-dog-photos-only',
+        hint: 'The slug from are.na/<user>/<slug>. The record key is the site slug shown at /curating/<rkey>.',
+      },
+      { key: 'title', label: 'Title override', type: 'text', hint: 'Blank = channel title from are.na.' },
+      { key: 'description', label: 'Description override', type: 'textarea', hint: 'Blank = channel description from are.na.' },
+      { key: 'order', label: 'Order', type: 'number', default: 0, hint: 'Lower numbers sort first on /curating.' },
+      { key: 'enabled', label: 'Enabled (shown on the site)', type: 'boolean', default: true },
+      ...COMMON_TIMESTAMPS,
+    ],
+  },
+
   'app.bsky.feed.post': {
     label: 'Bluesky post',
     summary: 'Plain text posts. Embeds are out of scope for the templated editor — use raw JSON.',

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -50,6 +50,13 @@ export const PAGE_REGISTRY = {
     intro: 'Songs played, freshest first, grouped by day-of-life.',
     collection: COLLECTIONS.listen,
   },
+  curating: {
+    slug: 'curating',
+    label: 'Curating',
+    title: 'Curating',
+    intro: 'Galleries of images collected on Are.na.',
+    collection: COLLECTIONS.arenaChannel,
+  },
   sharing: {
     slug: 'sharing',
     label: 'Sharing',

--- a/src/pages/Curating.css
+++ b/src/pages/Curating.css
@@ -1,0 +1,55 @@
+.curating-channel-meta {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+  margin-bottom: var(--space-5);
+}
+
+/* Uniform square cells (are.na's own idiom) so the channel's curated
+   position order reads left-to-right and nothing shifts as images load. */
+.curating-block-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+  gap: var(--space-3);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.curating-block-button {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  aspect-ratio: 1;
+  padding: var(--space-2);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-3);
+  background: var(--page-edge);
+  cursor: zoom-in;
+  transition: transform 200ms ease, border-color 200ms ease;
+}
+
+.curating-block-button:hover {
+  border-color: var(--accent-soft);
+  transform: translateY(-2px);
+}
+
+.curating-block-button img {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  object-fit: contain;
+}
+
+.curating-block-domain {
+  display: block;
+  padding-top: var(--space-1);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.curating-truncated {
+  margin-top: var(--space-4);
+}

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -1,0 +1,121 @@
+import { Link } from 'react-router-dom';
+import PageShell from '../components/PageShell.jsx';
+import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
+import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
+import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
+import {
+  fetchChannelMeta,
+  fetchChannelPage,
+  normalizeBlock,
+  arenaChannelUrl,
+} from '../lib/arena.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
+import './Creating.css';
+import './Curating.css';
+
+/**
+ * Which galleries exist is an `is.dame.arena.channel` record per channel
+ * (rkey = site slug); the images themselves live on are.na. The live pass
+ * re-reads the records, refreshes each channel's title/description/count
+ * from the are.na API, and reuses the snapshot's cover so it costs one
+ * request per channel (plus one page fetch for channels added since the
+ * last build).
+ */
+async function loadGalleries() {
+  const pds = await resolvePds(ME_DID);
+  const records = await listRecords(pds, {
+    repo: ME_DID,
+    collection: COLLECTIONS.arenaChannel,
+    max: 100,
+  });
+  const enabled = records
+    .map((r) => ({ rkey: rkeyFromAtUri(r.uri), value: r.value || {} }))
+    .filter((g) => g.rkey && g.value.arenaSlug && g.value.enabled !== false)
+    .sort((a, b) => (a.value.order ?? 0) - (b.value.order ?? 0));
+
+  const snapCovers = await fetchSnapshot('curating')
+    .then((s) => new Map((s?.galleries || []).map((g) => [g.slug, g.cover])))
+    .catch(() => new Map());
+
+  const galleries = [];
+  for (const g of enabled) {
+    try {
+      const meta = await fetchChannelMeta(g.value.arenaSlug);
+      let cover = snapCovers.get(g.rkey) || null;
+      if (!cover) {
+        const page = await fetchChannelPage(g.value.arenaSlug, 1, 10);
+        cover = (page?.data || []).map(normalizeBlock).find(Boolean)?.thumb || null;
+      }
+      galleries.push({
+        slug: g.rkey,
+        arenaSlug: g.value.arenaSlug,
+        title: g.value.title || meta?.title || g.rkey,
+        description: g.value.description || meta?.description || '',
+        blockCount: meta?.counts?.blocks ?? null,
+        arenaUrl: arenaChannelUrl(g.value.arenaSlug),
+        cover,
+        order: g.value.order ?? 0,
+      });
+    } catch {
+      // A channel that fails live just keeps its snapshot presence (if any).
+    }
+  }
+  return { galleries };
+}
+
+export default function Curating() {
+  const { title, intro } = usePageContent('curating');
+
+  const { items: galleries, status } = useLiveFeed({
+    strategy: 'snapshot-first',
+    name: 'curating',
+    fetchLive: loadGalleries,
+    mapItems: (d) => (Array.isArray(d?.galleries) ? d.galleries : null),
+  });
+
+  const loading = status === 'loading';
+  const list = galleries || [];
+
+  return (
+    <PageShell
+      title={title}
+      intro={intro}
+      atUri={`at://${ME_DID}/is.dame.page/curating`}
+      headTitle="Curating — Dame is&hellip;"
+    >
+      {loading ? (
+        <CreatingGridSkeleton cells={6} />
+      ) : list.length === 0 ? (
+        <p className="feed-empty">No galleries yet.</p>
+      ) : (
+        <ul className="creating-grid reveal-stagger">
+          {list.map((g) => (
+            <li key={g.slug} className="creating-grid-cell">
+              <Link to={`/curating/${g.slug}`} className="creating-grid-link">
+                {g.cover?.src ? (
+                  <img
+                    src={g.cover.src}
+                    srcSet={g.cover.src2x ? `${g.cover.src2x} 2x` : undefined}
+                    alt=""
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="creating-grid-placeholder" aria-hidden="true">&#x273A;</div>
+                )}
+                <div className="creating-grid-meta">
+                  <span className="small-caps creating-grid-kind">are.na</span>
+                  <h3 className="creating-grid-title">{g.title}</h3>
+                  {g.blockCount != null && (
+                    <span className="gutter">{g.blockCount} blocks</span>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </PageShell>
+  );
+}

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import PageShell from '../components/PageShell.jsx';
+import Lightbox from '../components/Lightbox.jsx';
+import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
+import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { resolvePds, getRecord } from '../lib/atproto.js';
+import { fetchChannelMeta, fetchAllBlocks, arenaChannelUrl } from '../lib/arena.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
+import './Curating.css';
+
+// Live-fetch result for "this gallery does not exist / is disabled". A
+// sentinel (rather than null) so useLiveFeed treats it as a resolved value
+// and it replaces any stale snapshot render.
+const NOT_FOUND = { notFound: true };
+
+function hostname(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+export default function CuratingChannel() {
+  const { slug } = useParams();
+  const [lightbox, setLightbox] = useState(-1);
+
+  const { items, status } = useLiveFeed({
+    strategy: 'snapshot-first',
+    name: `curating-${slug}`,
+    fetchLive: async () => {
+      const pds = await resolvePds(ME_DID);
+      let record;
+      try {
+        record = await getRecord(pds, {
+          repo: ME_DID,
+          collection: COLLECTIONS.arenaChannel,
+          rkey: slug,
+        });
+      } catch (err) {
+        // The PDS answers 400 RecordNotFound for unknown rkeys; anything
+        // else (network, 5xx) should keep the snapshot render instead of
+        // flashing "not found".
+        if (err?.status === 400 || err?.status === 404) return NOT_FOUND;
+        throw err;
+      }
+      const v = record?.value || {};
+      if (!v.arenaSlug || v.enabled === false) return NOT_FOUND;
+      const meta = await fetchChannelMeta(v.arenaSlug);
+      const { blocks, truncated } = await fetchAllBlocks(v.arenaSlug);
+      return {
+        gallery: {
+          slug,
+          arenaSlug: v.arenaSlug,
+          title: v.title || meta?.title || slug,
+          description: v.description || meta?.description || '',
+          blockCount: blocks.length,
+          arenaUrl: arenaChannelUrl(v.arenaSlug),
+        },
+        truncated,
+        blocks,
+      };
+    },
+    mapItems: (d) => {
+      if (!d) return null;
+      if (d.notFound) return d;
+      if (!d.gallery) return null;
+      return { gallery: d.gallery, blocks: d.blocks || [], truncated: !!d.truncated };
+    },
+    deps: [slug],
+  });
+
+  if (status === 'loading') {
+    return (
+      <PageShell headTitle={`${slug} — Dame is…`}>
+        <CreatingGridSkeleton cells={9} />
+      </PageShell>
+    );
+  }
+
+  if (status === 'error' || !items || items.notFound) {
+    const missing = status !== 'error';
+    return (
+      <PageShell
+        title={missing ? 'Gallery not found' : 'Gallery unavailable'}
+        headTitle="Not found — Dame is…"
+      >
+        <p>
+          {missing ? (
+            <>No gallery with slug <code>{slug}</code>.{' '}</>
+          ) : (
+            <>Couldn&rsquo;t load this gallery right now.{' '}</>
+          )}
+          <Link to="/curating">Back to curating.</Link>
+        </p>
+      </PageShell>
+    );
+  }
+
+  const { gallery, blocks, truncated } = items;
+
+  return (
+    <PageShell
+      title={gallery.title}
+      intro={gallery.description || undefined}
+      headTitle={`${gallery.title} — Dame is…`}
+      eyebrow={
+        <Link to="/curating" className="page-back small-caps">
+          ← Curating
+        </Link>
+      }
+    >
+      <div className="curating-channel-meta gutter">
+        <span>{gallery.blockCount} blocks</span>
+        <span aria-hidden="true">·</span>
+        <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
+          view on are.na ↗
+        </a>
+      </div>
+
+      {blocks.length === 0 ? (
+        <p className="feed-empty">
+          No images in this channel yet.{' '}
+          <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
+            See it on are.na.
+          </a>
+        </p>
+      ) : (
+        <>
+          <ul className="curating-block-grid reveal-stagger">
+            {blocks.map((b, i) => {
+              const domain = b.type === 'link' && b.sourceUrl ? hostname(b.sourceUrl) : null;
+              return (
+                <li key={b.id} className="curating-block">
+                  <button
+                    type="button"
+                    className="curating-block-button"
+                    onClick={() => setLightbox(i)}
+                    aria-label={b.alt ? `View image: ${b.alt}` : `View image ${i + 1}`}
+                  >
+                    <img
+                      src={b.thumb.src}
+                      srcSet={b.thumb.src2x ? `${b.thumb.src2x} 2x` : undefined}
+                      alt={b.alt}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                    {domain && <span className="curating-block-domain gutter">{domain}</span>}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          {truncated && (
+            <p className="curating-truncated gutter">
+              Showing the first {blocks.length} blocks —{' '}
+              <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
+                see the rest on are.na
+              </a>
+              .
+            </p>
+          )}
+          <Lightbox
+            open={lightbox >= 0}
+            index={Math.max(0, lightbox)}
+            onClose={() => setLightbox(-1)}
+            images={blocks.map((b) => ({ src: b.large, alt: b.alt }))}
+          />
+        </>
+      )}
+    </PageShell>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,6 @@
     { "source": "/ethos", "destination": "/sharing", "permanent": true },
     { "source": "/skeet-tools", "destination": "https://cred.blue/resources", "permanent": true },
     { "source": "/ratingalttext", "destination": "https://cred.blue/alt-text", "permanent": true },
-    { "source": "/curating/:path*", "destination": "https://www.are.na/dame/:path*", "permanent": true },
     { "source": "/flushing", "destination": "https://flushes.app/profile/dame.is", "permanent": true }
   ]
 }


### PR DESCRIPTION
## What

Replaces the `/curating/*` → are.na redirect with a real section of the site:

- **`/curating`** — index of gallery cards (cover, title, block count)
- **`/curating/:slug`** — a gallery page rendering a channel's image blocks in a square-cell grid (curated position order preserved), with lightbox viewing and a "view on are.na" link

## How

- **New ATProto collection `is.dame.arena.channel`** (rkey = site slug, e.g. `weird-dogs-only`; `arenaSlug` points at the channel, e.g. `weird-dog-photos-only`; optional title/description overrides, `order`, `enabled`). Registered in `src/config.js`, `src/lib/lexicons.js` (which auto-generates the full admin CRUD UI — zero custom admin code), and documented in `lexicons/is.dame.arena.channel.json`.
- **`src/lib/arena.js`** — isomorphic Are.na v3 client (channel meta, paginated contents, block normalizer keeping Image blocks + Link blocks with preview images). Supports an optional `ARENA_ACCESS_TOKEN` env var (read-only personal token) at build time only — never bundled client-side — raising the rate tier from guest 30/min to the account tier.
- **`scripts/prefetch.mjs`** — snapshots each enabled channel to `public/data/curating.json` + `curating-<slug>.json` at build (and via the existing 6h cron). All fetches wrapped in `safe()` so an Are.na outage can never fail a deploy.
- **Pages** — `Curating.jsx` / `CuratingChannel.jsx` / `Curating.css`, using the standard snapshot-first `useLiveFeed` overlay, `PageShell`, `Lightbox`, and the `.creating-grid` card styles. Unknown/disabled slugs resolve to a not-found state; live network failure keeps the snapshot render.
- **Wiring** — routes in `App.jsx`, `pageRegistry` entry (editable page chrome), nav dock entry, removed the `vercel.json` redirect and the stale `curating/curating.md` placeholder.

## Verified

- `node scripts/prefetch.mjs` with no records: writes empty `curating.json`, exit 0
- Live fetch against the real `weird-dog-photos-only` channel (213 blocks) normalizes correctly
- `npm run build` passes
- Playwright against the built site: index card, 100-cell grid, lightbox open/arrow-navigate, unknown-slug not-found, zero console errors

## Post-merge setup

1. (Optional) add `ARENA_ACCESS_TOKEN` (read-only token from are.na/settings/personal-access-tokens) to the Vercel env
2. In `/admin` → "Are.na gallery", create a record per channel (rkey = site slug, arenaSlug = are.na slug)
3. Galleries appear immediately via live fetch; snapshots bake in on the next deploy/cron

Note: the removed redirect was permanent (308) — browsers that previously visited `/curating/*` may serve the cached redirect until a hard refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp)_