### PR TITLE
Add /mothing page + iNaturalist mirror, surfaced in the home feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Schema-only documentation lives under [`lexicons/`](lexicons/):
   iNaturalist observation is keyed by its iNat id. **No location data is ever
   mirrored** — coordinates, place names, and timezone are stripped in
   [`src/lib/inaturalist.js`](src/lib/inaturalist.js). Sync with
-  [`scripts/mirror-inaturalist.mjs`](scripts/mirror-inaturalist.mjs).
+  [`scripts/mirror-inaturalist.mjs`](scripts/mirror-inaturalist.mjs). Once
+  mirrored, observations also appear in the home feed under the `mothing`
+  verb, ordered by observation date.
 
 Plus `fm.teal.alpha.feed.play` (teal.fm) for the now-playing signal.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,33 @@ Schema-only documentation lives under [`lexicons/`](lexicons/):
   from a LinkedIn/resume PDF with
   [`scripts/import-resume.mjs`](scripts/import-resume.mjs).
 - `is.dame.annotating` — stretch lexicon for book-style margin notes.
+- `is.dame.mothing` / `is.dame.mothing.observation` — a mirror of moth
+  observations from iNaturalist, rendered at `/mothing`. The summary singleton
+  lives at `at://{me}/is.dame.mothing/self`; one observation record per
+  iNaturalist observation is keyed by its iNat id. **No location data is ever
+  mirrored** — coordinates, place names, and timezone are stripped in
+  [`src/lib/inaturalist.js`](src/lib/inaturalist.js). Sync with
+  [`scripts/mirror-inaturalist.mjs`](scripts/mirror-inaturalist.mjs).
 
 Plus `fm.teal.alpha.feed.play` (teal.fm) for the now-playing signal.
+
+## Mothing / iNaturalist
+
+`/mothing` reads moth observations for the iNaturalist user configured in
+`src/config.js` (`INATURALIST_USER`), scoped to Lepidoptera minus butterflies.
+The page paints from the build-time `public/data/mothing.json` snapshot and
+refreshes live from the iNaturalist API in the browser.
+
+To also keep an owned copy on the PDS, run the mirror (idempotent):
+
+```sh
+BSKY_IDENTIFIER=dame.is BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+  node scripts/mirror-inaturalist.mjs           # add --prune to drop removed obs
+```
+
+A daily Vercel cron (`/api/mirror-mothing`, see `vercel.json`) does the same
+using `BSKY_APP_PASSWORD` (+ optional `BSKY_IDENTIFIER`) from the environment;
+set `CRON_SECRET` to lock the endpoint down.
 
 ## Local development
 

--- a/api/mirror-mothing.js
+++ b/api/mirror-mothing.js
@@ -1,0 +1,90 @@
+// Vercel serverless function: mirror moth observations from iNaturalist onto
+// the PDS. Wired into vercel.json as a daily cron; the same work can be run
+// locally with `node scripts/mirror-inaturalist.mjs`.
+//
+// Writes `is.dame.mothing/self` (summary) + one
+// `is.dame.mothing.observation/<inatId>` record per observation. Location
+// data is stripped upstream in `src/lib/inaturalist.js` and never reaches
+// the PDS.
+//
+// Auth: if CRON_SECRET is set, the request must carry
+// `Authorization: Bearer <CRON_SECRET>` (Vercel sends this automatically for
+// cron invocations). Requires BSKY_APP_PASSWORD (+ optional BSKY_IDENTIFIER).
+
+import { AtpAgent } from '@atproto/api';
+
+import { ME_HANDLE, INATURALIST_USER, MOTHING_NSID } from '../src/config.js';
+import { resolveIdentifier } from '../src/lib/atproto.js';
+import { fetchMothData, buildMirrorWrites } from '../src/lib/inaturalist.js';
+
+export const config = { maxDuration: 60 };
+
+async function pool(items, size, worker) {
+  let i = 0;
+  let ok = 0;
+  let fail = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(size, items.length) }, async () => {
+      while (i < items.length) {
+        const item = items[i++];
+        try {
+          await worker(item);
+          ok++;
+        } catch {
+          fail++;
+        }
+      }
+    }),
+  );
+  return { ok, fail };
+}
+
+export default async function handler(req, res) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = req.headers?.authorization || '';
+    if (auth !== `Bearer ${secret}`) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
+
+  const identifier = process.env.BSKY_IDENTIFIER || process.env.ATP_IDENTIFIER || ME_HANDLE;
+  const password = process.env.BSKY_APP_PASSWORD || process.env.ATP_APP_PASSWORD;
+  if (!password) {
+    return res.status(500).json({ error: 'BSKY_APP_PASSWORD is not configured.' });
+  }
+
+  try {
+    const { stats, observations } = await fetchMothData({ user: INATURALIST_USER });
+    const now = new Date().toISOString();
+    const { summary, records } = buildMirrorWrites({ observations, stats, now });
+    const writes = [summary, ...records];
+
+    const { did, pds } = await resolveIdentifier(identifier);
+    const agent = new AtpAgent({ service: pds });
+    await agent.login({ identifier, password });
+
+    const { ok, fail } = await pool(writes, 6, async (w) => {
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: w.collection,
+        rkey: w.rkey,
+        record: w.value,
+        validate: false,
+      });
+    });
+
+    return res.status(fail ? 207 : 200).json({
+      ok: true,
+      user: INATURALIST_USER,
+      observations: observations.length,
+      species: stats.speciesCount,
+      written: ok,
+      failed: fail,
+      summary: `at://${did}/${MOTHING_NSID}/self`,
+      at: now,
+    });
+  } catch (err) {
+    return res.status(502).json({ error: err?.message || 'mirror failed' });
+  }
+}

--- a/lexicons/is.dame.mothing.json
+++ b/lexicons/is.dame.mothing.json
@@ -1,0 +1,50 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.mothing",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "description": "A singleton summary of Dame's mothing (moth observation) activity, mirrored from iNaturalist. Contains no location data.",
+      "record": {
+        "type": "object",
+        "required": ["source", "updatedAt"],
+        "properties": {
+          "source":            { "type": "string", "description": "Origin of the mirrored data, e.g. 'inaturalist'." },
+          "user":              { "type": "string", "description": "The iNaturalist username the data was mirrored from." },
+          "profileUrl":        { "type": "string", "format": "uri" },
+          "observationCount":  { "type": "integer" },
+          "speciesCount":      { "type": "integer", "description": "Distinct species-rank taxa observed." },
+          "distinctTaxaCount": { "type": "integer", "description": "Distinct taxa at any rank." },
+          "qualityGrades": {
+            "type": "object",
+            "description": "Observation counts by iNaturalist quality grade.",
+            "properties": {
+              "research": { "type": "integer" },
+              "needsId":  { "type": "integer" },
+              "casual":   { "type": "integer" }
+            }
+          },
+          "earliestDate": { "type": "string", "description": "Date of the earliest observation (YYYY-MM-DD)." },
+          "latestDate":   { "type": "string", "description": "Date of the most recent observation (YYYY-MM-DD)." },
+          "topSpecies": {
+            "type": "array",
+            "description": "Most-observed taxa, most first.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "taxonId":    { "type": "integer" },
+                "name":       { "type": "string" },
+                "commonName": { "type": "string" },
+                "rank":       { "type": "string" },
+                "count":      { "type": "integer" }
+              }
+            }
+          },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "updatedAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/is.dame.mothing.observation.json
+++ b/lexicons/is.dame.mothing.observation.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.mothing.observation",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "any",
+      "description": "A single moth observation mirrored from iNaturalist, keyed by the iNaturalist observation id. Location data (coordinates, place names, timezone) is intentionally never stored.",
+      "record": {
+        "type": "object",
+        "required": ["inatId", "createdAt"],
+        "properties": {
+          "inatId":       { "type": "integer", "description": "The iNaturalist observation id." },
+          "uuid":         { "type": "string" },
+          "url":          { "type": "string", "format": "uri", "description": "Canonical iNaturalist observation URL." },
+          "observedDate": { "type": "string", "description": "Date of observation (YYYY-MM-DD). Time-of-day and timezone are omitted by design." },
+          "qualityGrade": { "type": "string", "description": "iNaturalist quality grade: research | needs_id | casual." },
+          "description":  { "type": "string", "maxLength": 5000 },
+          "taxon": {
+            "type": "object",
+            "properties": {
+              "id":          { "type": "integer" },
+              "name":        { "type": "string", "description": "Scientific name." },
+              "commonName":  { "type": "string" },
+              "rank":        { "type": "string" },
+              "iconicTaxon": { "type": "string" }
+            }
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["url"],
+              "properties": {
+                "id":          { "type": "integer" },
+                "url":         { "type": "string", "format": "uri", "description": "iNaturalist-hosted photo URL (square size; other sizes derived by swapping the size segment)." },
+                "licenseCode": { "type": "string" },
+                "attribution": { "type": "string" }
+              }
+            }
+          },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "updatedAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/mirror-inaturalist.mjs
+++ b/scripts/mirror-inaturalist.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Mirror moth observations from iNaturalist onto your PDS.
+//
+// Writes one `is.dame.mothing/self` summary record plus one
+// `is.dame.mothing.observation/<inatId>` record per observation, so your
+// moth log lives as first-class atproto data you own. Location is never
+// mirrored — `src/lib/inaturalist.js` strips coordinates, place names, and
+// timezone before anything is built.
+//
+// Idempotent: every record is written with `putRecord` keyed by its iNat id
+// (`rkey`), so re-running updates records in place. Pass `--prune` to also
+// delete observation records that no longer exist in iNaturalist.
+//
+// Usage:
+//   BSKY_IDENTIFIER=dame.is BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+//     node scripts/mirror-inaturalist.mjs [--dry-run] [--prune] [--max N] [--pds url]
+//
+//   --dry-run   Build + print every record without writing anything.
+//   --prune     Delete PDS observation records absent from the fresh pull.
+//   --max N     Cap how many observations to mirror (default: all).
+//   --pds URL   Override the PDS endpoint (default: resolved from your DID).
+//
+// Get an app password at https://bsky.app/settings/app-passwords. Never commit it.
+
+import { AtpAgent } from '@atproto/api';
+
+import {
+  ME_HANDLE,
+  INATURALIST_USER,
+  MOTHING_NSID,
+  MOTHING_OBSERVATION_NSID,
+} from '../src/config.js';
+import { resolveIdentifier, listRecords, rkeyFromAtUri } from '../src/lib/atproto.js';
+import { fetchMothData, buildMirrorWrites } from '../src/lib/inaturalist.js';
+
+const log = (...a) => console.log('[mirror-inat]', ...a);
+const die = (msg) => {
+  console.error('[mirror-inat] ERROR:', msg);
+  process.exit(1);
+};
+
+function parseArgs(argv) {
+  const args = { dryRun: false, prune: false, max: 1000, pds: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--prune') args.prune = true;
+    else if (a === '--max') args.max = Number(argv[++i]) || args.max;
+    else if (a === '--pds') args.pds = argv[++i];
+    else die(`unknown argument: ${a}`);
+  }
+  return args;
+}
+
+// Run `worker` over `items` with bounded concurrency; collect { ok, fail }.
+async function pool(items, size, worker) {
+  let i = 0;
+  let ok = 0;
+  let fail = 0;
+  const runners = Array.from({ length: Math.min(size, items.length) }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      try {
+        await worker(items[idx]);
+        ok++;
+      } catch (err) {
+        fail++;
+        console.error(`[mirror-inat] ✗ ${items[idx]?.collection}/${items[idx]?.rkey}: ${err.message}`);
+      }
+    }
+  });
+  await Promise.all(runners);
+  return { ok, fail };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  log(`fetching moths for iNaturalist user "${INATURALIST_USER}"…`);
+  const { stats, observations } = await fetchMothData({ user: INATURALIST_USER, max: args.max });
+  log(`fetched ${observations.length} observation(s), ${stats.speciesCount} species.`);
+
+  const now = new Date().toISOString();
+  const { summary, records } = buildMirrorWrites({ observations, stats, now });
+  const writes = [summary, ...records];
+
+  const identifier = process.env.BSKY_IDENTIFIER || process.env.ATP_IDENTIFIER || ME_HANDLE;
+  const password = process.env.BSKY_APP_PASSWORD || process.env.ATP_APP_PASSWORD;
+
+  let did;
+  let pds = args.pds;
+  try {
+    const ident = await resolveIdentifier(identifier);
+    did = ident.did;
+    if (!pds) pds = ident.pds;
+  } catch (err) {
+    return die(`could not resolve identity for "${identifier}": ${err.message}`);
+  }
+  log(`identity: ${identifier} → ${did}`);
+  log(`pds: ${pds}`);
+
+  if (args.dryRun) {
+    log('--dry-run: the following records would be written:\n');
+    console.log(`# at://${did}/${summary.collection}/${summary.rkey}`);
+    console.log(JSON.stringify(summary.value, null, 2));
+    console.log(`\n… and ${records.length} observation record(s), e.g.:\n`);
+    if (records[0]) {
+      console.log(`# at://${did}/${records[0].collection}/${records[0].rkey}`);
+      console.log(JSON.stringify(records[0].value, null, 2));
+    }
+    log(`dry run complete — ${writes.length} record(s) not written.`);
+    return;
+  }
+
+  if (!password) {
+    die(
+      'missing app password. Set BSKY_APP_PASSWORD (and optionally BSKY_IDENTIFIER). ' +
+        'Create one at https://bsky.app/settings/app-passwords. Use --dry-run to preview.',
+    );
+  }
+
+  const agent = new AtpAgent({ service: pds });
+  try {
+    await agent.login({ identifier, password });
+  } catch (err) {
+    return die(`login failed: ${err.message}`);
+  }
+  log(`signed in as ${agent.session?.handle || identifier}`);
+
+  const { ok, fail } = await pool(writes, 6, async (w) => {
+    await agent.com.atproto.repo.putRecord({
+      repo: did,
+      collection: w.collection,
+      rkey: w.rkey,
+      record: w.value,
+      validate: false, // is.dame.* lexicons aren't published to the PDS
+    });
+  });
+  log(`wrote ${ok}/${writes.length} record(s)${fail ? ` (${fail} failed)` : ''}.`);
+
+  if (args.prune) {
+    const keep = new Set(records.map((r) => r.rkey));
+    let existing = [];
+    try {
+      existing = await listRecords(pds, { repo: did, collection: MOTHING_OBSERVATION_NSID, max: 5000 });
+    } catch (err) {
+      log(`prune skipped — could not list existing records: ${err.message}`);
+    }
+    const stale = existing
+      .map((r) => rkeyFromAtUri(r.uri))
+      .filter((rk) => rk && !keep.has(rk));
+    if (stale.length) {
+      const res = await pool(
+        stale.map((rk) => ({ collection: MOTHING_OBSERVATION_NSID, rkey: rk })),
+        6,
+        async (d) => {
+          await agent.com.atproto.repo.deleteRecord({
+            repo: did,
+            collection: d.collection,
+            rkey: d.rkey,
+          });
+        },
+      );
+      log(`pruned ${res.ok}/${stale.length} stale observation record(s).`);
+    } else {
+      log('prune: nothing stale to remove.');
+    }
+  }
+
+  log(`done — summary at://${did}/${MOTHING_NSID}/self`);
+  if (fail) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error('[mirror-inat] fatal', err);
+  process.exitCode = 1;
+});

--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -34,13 +34,14 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ME_DID, COLLECTIONS, APPVIEW } from '../src/config.js';
+import { ME_DID, COLLECTIONS, APPVIEW, INATURALIST_USER } from '../src/config.js';
 import {
   resolvePds,
   getProfile,
   listRecords,
   getRecord,
 } from '../src/lib/atproto.js';
+import { fetchMothData } from '../src/lib/inaturalist.js';
 import { VERB_REGISTRY } from '../src/lib/verbRegistry.js';
 import {
   fetchChannelMeta,
@@ -204,6 +205,17 @@ async function main() {
   }
   // Written even when empty so the index page's snapshot never 404s.
   await writeJson('curating', { builtAt: new Date().toISOString(), galleries });
+
+  // --- Mothing (iNaturalist) ------------------------------------------------
+  // External API, not the PDS — but snapshotted the same way so /mothing
+  // paints instantly and has a fallback if iNaturalist is unreachable at
+  // runtime. Location data is stripped by `fetchMothData`.
+  const mothing = await safe(
+    'fetchMothData',
+    () => fetchMothData({ user: INATURALIST_USER }),
+    { user: INATURALIST_USER, stats: null, observations: [] },
+  );
+  await writeJson('mothing', { builtAt: new Date().toISOString(), ...mothing });
 
   // --- Registry-driven ingest (delegated to the shared builder) -------------
   const { unified, perCollection, perVerb, authorFeed, counts } = await buildUnifiedFeed({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Curating from './pages/Curating.jsx';
 import CuratingChannel from './pages/CuratingChannel.jsx';
 import Resume from './pages/Resume.jsx';
 import Sharing from './pages/Sharing.jsx';
+import Mothing from './pages/Mothing.jsx';
 import Record from './pages/Record.jsx';
 import NotFound from './pages/NotFound.jsx';
 import { VERB_REGISTRY } from './lib/verbRegistry.js';
@@ -104,6 +105,7 @@ export default function App() {
                   <Route path="/resume" element={<Resume />} />
                   <Route path="/resume/:slug" element={<Resume />} />
                   <Route path="/sharing" element={<Sharing />} />
+                  <Route path="/mothing" element={<Mothing />} />
                   {generatedRecordRoutes()}
                   <Route
                     path="/admin"

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -19,6 +19,7 @@ const ROUTES = [
   { to: '/blogging', label: 'Blogging' },
   { to: '/creating', label: 'Creating' },
   { to: '/curating', label: 'Curating' },
+  { to: '/mothing', label: 'Mothing' },
   { to: '/resume', label: 'Resume' },
   { to: '/sharing', label: 'Sharing' },
   { to: '/exploring', label: 'Exploring' },

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -589,6 +589,60 @@ a.post-card-author-link:focus-visible {
   max-width: var(--measure);
 }
 
+/* MothCard — mirrors CreatingCard's thumb + body layout. */
+.moth-card {
+  display: grid;
+  grid-template-columns: minmax(0, 9rem) 1fr;
+  gap: var(--space-4);
+}
+
+.moth-card:not(:has(.moth-card-thumb)) {
+  grid-template-columns: 1fr;
+}
+
+.moth-card-thumb {
+  display: block;
+}
+
+.moth-card-thumb img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: var(--radius-2);
+  border: 1px solid var(--rule-soft);
+  background: var(--page);
+}
+
+.moth-card-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.moth-card-title {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.moth-card-sci {
+  font-style: italic;
+  color: var(--ink-soft);
+}
+
+.moth-card-grade {
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  font-size: var(--text-xs);
+}
+
+.moth-card-desc {
+  margin: var(--space-1) 0 0;
+  color: var(--ink-soft);
+  max-width: var(--measure);
+}
+
 .feed-empty {
   color: var(--ink-muted);
   font-style: italic;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -7,6 +7,7 @@ import ListenRow from './ListenRow.jsx';
 import CreatingCard from './CreatingCard.jsx';
 import ReferenceCard from './ReferenceCard.jsx';
 import MediaCard from './cards/MediaCard.jsx';
+import MothCard from './cards/MothCard.jsx';
 import ListCard from './cards/ListCard.jsx';
 import GeneratorCard from './cards/GeneratorCard.jsx';
 import CommentCard from './cards/CommentCard.jsx';
@@ -38,6 +39,7 @@ const RENDERERS = {
   CreatingCard,
   ReferenceCard,
   MediaCard,
+  MothCard,
   ListCard,
   GeneratorCard,
   CommentCard,

--- a/src/components/VerbIcon.jsx
+++ b/src/components/VerbIcon.jsx
@@ -13,6 +13,7 @@ import {
   Vote,
   Camera,
   FileText,
+  Bug,
 } from 'lucide-react';
 import { verbConfig } from '../lib/verbRegistry.js';
 
@@ -36,6 +37,7 @@ const LUCIDE_BY_NAME = {
   Vote,
   Camera,
   FileText,
+  Bug,
 };
 
 /**

--- a/src/components/cards/MothCard.jsx
+++ b/src/components/cards/MothCard.jsx
@@ -1,0 +1,53 @@
+/**
+ * Renders a mothing observation (`is.dame.mothing.observation`) in the home
+ * feed. The record is mirrored from iNaturalist and carries no location — a
+ * thumbnail, the taxon name (common + scientific), and a link out to the
+ * iNaturalist observation. The feed row's own timestamp shows when it was
+ * observed (the record's `createdAt` is derived from the observation date).
+ */
+import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
+import { photoUrl } from '../../lib/inaturalist.js';
+
+export default function MothCard({ payload, atUri }) {
+  const obs = payload || {};
+  const photos = Array.isArray(obs.photos) ? obs.photos : [];
+  const first = photos[0];
+  const src = first ? photoUrl(first, 'medium') : null;
+  const common = obs.taxon?.commonName;
+  const sci = obs.taxon?.name;
+  const title = common || sci || 'Unidentified moth';
+  const showSci = sci && sci !== title;
+  const alt = common || sci || 'Moth observation';
+
+  return (
+    <article className="moth-card feed-card" data-at-uri={atUri}>
+      {src && (
+        <a
+          className="moth-card-thumb"
+          href={obs.url}
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label={`View ${alt} on iNaturalist`}
+        >
+          <img src={src} alt={alt} loading="lazy" decoding="async" />
+        </a>
+      )}
+      <div className="moth-card-body">
+        <h3 className="moth-card-title">
+          {obs.url ? (
+            <a href={obs.url} target="_blank" rel="noreferrer noopener">{title}</a>
+          ) : (
+            title
+          )}
+        </h3>
+        {showSci && <span className="moth-card-sci">{sci}</span>}
+        {obs.qualityGrade === 'research' && (
+          <span className="small-caps moth-card-grade">Research grade</span>
+        )}
+        {obs.description && (
+          <p className="moth-card-desc">{renderPlainTextWithTruncatedUrls(obs.description)}</p>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,18 @@ export const GITHUB_REPO = 'dame-is/dame.is';
 export const APPVIEW = 'https://public.api.bsky.app';
 export const PLC_DIRECTORY = 'https://plc.directory';
 
+// --- iNaturalist / mothing -------------------------------------------------
+// The /mothing page + PDS mirror pull moth observations from iNaturalist.
+// "Moths" = Lepidoptera (47157) minus butterflies (Papilionoidea, 47224),
+// since iNat has no single "moths" taxon. Location data is intentionally
+// never ingested — see src/lib/inaturalist.js.
+export const INATURALIST_USER = 'anisota';
+export const INATURALIST_API = 'https://api.inaturalist.org/v1';
+export const LEPIDOPTERA_TAXON_ID = 47157; // moths + butterflies
+export const BUTTERFLY_TAXON_ID = 47224; // Papilionoidea, excluded
+export const MOTHING_NSID = 'is.dame.mothing';
+export const MOTHING_OBSERVATION_NSID = 'is.dame.mothing.observation';
+
 /**
  * Creative works and blog posts are both `site.standard.document` records;
  * the publication they belong to (their `site` field) decides which surface

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -226,9 +226,24 @@ export function mothingSummaryValue(stats, { now, user = INATURALIST_USER } = {}
   });
 }
 
+/**
+ * Turn a plain 'YYYY-MM-DD' observation date into a stable, location-free
+ * timestamp for `createdAt` — noon UTC, which reveals nothing about where.
+ * Deriving from the observation date (not the mirror run) keeps the record
+ * idempotent and lets the home feed order moths by when they were seen
+ * instead of clumping them all at the last sync.
+ */
+export function observedTimestamp(observedDate) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(String(observedDate || ''))
+    ? `${observedDate}T12:00:00.000Z`
+    : null;
+}
+
 /** One `is.dame.mothing.observation/<inatId>` record value. */
 export function mothingObservationValue(obs, { now } = {}) {
-  const ts = now || new Date().toISOString();
+  // Stable timestamp from the observation date; fall back to the run time
+  // only for the rare observation with no date at all.
+  const ts = observedTimestamp(obs.observedDate) || now || new Date().toISOString();
   const taxon = obs.taxon || {};
   return stripUndefined({
     $type: MOTHING_OBSERVATION_NSID,

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -1,0 +1,282 @@
+// Isomorphic iNaturalist client for the /mothing surface.
+//
+// Runs in the browser (live refresh on the page), in Node (the build-time
+// prefetch snapshot), and inside the PDS mirror (CLI script + cron function).
+// No SDK — just `fetch` + JSON, mirroring `src/lib/atproto.js`.
+//
+// PRIVACY: this module is the single choke point where raw iNaturalist
+// observations are turned into the shape the rest of the site sees. It
+// deliberately DROPS every location signal — coordinates (`geojson`,
+// `location`), `place_guess`, `place_ids`, and the timezone-bearing
+// timestamps (a tz offset is a coarse location hint). Only the plain
+// observation *date* survives. Nothing downstream (snapshot, page, or PDS
+// record) ever receives a location, so there is nothing to accidentally leak.
+
+import {
+  INATURALIST_API,
+  INATURALIST_USER,
+  LEPIDOPTERA_TAXON_ID,
+  BUTTERFLY_TAXON_ID,
+  MOTHING_NSID,
+  MOTHING_OBSERVATION_NSID,
+} from '../config.js';
+
+const PER_PAGE = 200; // iNaturalist's max page size.
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`iNaturalist HTTP ${res.status} for ${url} :: ${text.slice(0, 160)}`);
+  }
+  return res.json();
+}
+
+/**
+ * The base query params that define "my moths": one user, Lepidoptera,
+ * butterflies excluded. Shared by every endpoint so the scope never drifts.
+ */
+function baseParams(user = INATURALIST_USER) {
+  return {
+    user_login: user,
+    taxon_id: String(LEPIDOPTERA_TAXON_ID),
+    without_taxon_id: String(BUTTERFLY_TAXON_ID),
+  };
+}
+
+/**
+ * Swap an iNaturalist photo URL's size segment. iNat serves the same photo
+ * at `.../photos/<id>/<size>.<ext>` where size ∈ square | small | medium |
+ * large | original. The API hands back `square`; we derive the rest.
+ */
+export function photoUrl(photo, size = 'medium') {
+  const url = photo?.url;
+  if (!url) return null;
+  return url.replace(/\/(square|small|medium|large|original)\.(jpe?g|png|gif|webp)/i, `/${size}.$2`);
+}
+
+/**
+ * Reduce a raw iNaturalist observation to the compact, location-free shape
+ * the site stores and renders. Returns `null` for observations with no
+ * usable taxon so callers can filter them out.
+ */
+export function normalizeObservation(o) {
+  if (!o) return null;
+  const t = o.taxon || {};
+  const photos = Array.isArray(o.photos)
+    ? o.photos
+        .filter((p) => p && p.url && !p.hidden)
+        .map((p) => ({
+          id: p.id,
+          // Store the square URL only; sizes are derived via `photoUrl`.
+          url: p.url,
+          licenseCode: p.license_code || null,
+          attribution: p.attribution || null,
+        }))
+    : [];
+  return {
+    id: o.id,
+    uuid: o.uuid || null,
+    url: o.uri || (o.id ? `https://www.inaturalist.org/observations/${o.id}` : null),
+    // Date only — never the tz-bearing `time_observed_at` / `created_at`.
+    observedDate: o.observed_on_details?.date || o.observed_on || null,
+    qualityGrade: o.quality_grade || null,
+    description: o.description || null,
+    taxon: {
+      id: t.id ?? null,
+      name: t.name || o.species_guess || null,
+      commonName: t.preferred_common_name || null,
+      rank: t.rank || null,
+      iconicTaxon: t.iconic_taxon_name || null,
+    },
+    photos,
+  };
+}
+
+/**
+ * Fetch every moth observation for a user, newest first, and normalize it.
+ * Auto-paginates up to `max`. Location is stripped by `normalizeObservation`.
+ */
+export async function fetchMothObservations({ user = INATURALIST_USER, max = 1000 } = {}) {
+  const out = [];
+  let page = 1;
+  while (out.length < max) {
+    const params = new URLSearchParams({
+      ...baseParams(user),
+      per_page: String(Math.min(PER_PAGE, max - out.length)),
+      page: String(page),
+      order: 'desc',
+      order_by: 'observed_on',
+    });
+    const data = await fetchJson(`${INATURALIST_API}/observations?${params}`);
+    const batch = Array.isArray(data?.results) ? data.results : [];
+    for (const o of batch) {
+      const n = normalizeObservation(o);
+      if (n) out.push(n);
+    }
+    const total = data?.total_results ?? out.length;
+    if (batch.length === 0 || out.length >= total) break;
+    page += 1;
+  }
+  return out;
+}
+
+/**
+ * Derive display stats from a normalized observation array — no extra API
+ * calls, no location. Species counts use species-rank taxa; distinct taxa
+ * also counts genus/family-level IDs.
+ */
+export function computeStats(observations, { user = INATURALIST_USER } = {}) {
+  const obs = Array.isArray(observations) ? observations : [];
+  const grades = { research: 0, needsId: 0, casual: 0 };
+  const speciesIds = new Set();
+  const distinctTaxa = new Set();
+  const speciesTally = new Map(); // taxonId -> { taxon, count }
+  let withPhotos = 0;
+  let earliest = null;
+  let latest = null;
+
+  for (const o of obs) {
+    if (o.qualityGrade === 'research') grades.research += 1;
+    else if (o.qualityGrade === 'needs_id') grades.needsId += 1;
+    else if (o.qualityGrade === 'casual') grades.casual += 1;
+
+    const t = o.taxon || {};
+    if (t.id != null) {
+      distinctTaxa.add(t.id);
+      if (t.rank === 'species' || t.rank === 'subspecies') speciesIds.add(t.id);
+      const prev = speciesTally.get(t.id);
+      if (prev) prev.count += 1;
+      else speciesTally.set(t.id, { taxon: t, count: 1 });
+    }
+    if (o.photos && o.photos.length) withPhotos += 1;
+    if (o.observedDate) {
+      if (!earliest || o.observedDate < earliest) earliest = o.observedDate;
+      if (!latest || o.observedDate > latest) latest = o.observedDate;
+    }
+  }
+
+  const topSpecies = Array.from(speciesTally.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 12)
+    .map((e) => ({
+      taxonId: e.taxon.id,
+      name: e.taxon.name || null,
+      commonName: e.taxon.commonName || e.taxon.preferred_common_name || null,
+      rank: e.taxon.rank || null,
+      count: e.count,
+    }));
+
+  return {
+    user,
+    observationCount: obs.length,
+    speciesCount: speciesIds.size,
+    distinctTaxaCount: distinctTaxa.size,
+    withPhotos,
+    qualityGrades: grades,
+    earliestDate: earliest,
+    latestDate: latest,
+    topSpecies,
+    profileUrl: `https://www.inaturalist.org/people/${user}`,
+    observationsUrl:
+      `https://www.inaturalist.org/observations?user_login=${user}` +
+      `&taxon_id=${LEPIDOPTERA_TAXON_ID}&without_taxon_id=${BUTTERFLY_TAXON_ID}`,
+  };
+}
+
+/**
+ * One-shot: fetch observations and derive stats together. Returns the exact
+ * shape written to `public/data/mothing.json` (minus `builtAt`, which the
+ * caller stamps).
+ */
+export async function fetchMothData({ user = INATURALIST_USER, max = 1000 } = {}) {
+  const observations = await fetchMothObservations({ user, max });
+  const stats = computeStats(observations, { user });
+  return { user, stats, observations };
+}
+
+/* ------------------------------------------------------------------ */
+/* PDS mirror record builders                                         */
+/*                                                                    */
+/* Pure shape helpers shared by the CLI mirror script and the cron    */
+/* serverless function. Output is location-free by construction — it  */
+/* only ever reads from already-normalized observations.              */
+/* ------------------------------------------------------------------ */
+
+const stripUndefined = (obj) =>
+  Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined));
+
+/** The `is.dame.mothing/self` summary record value. */
+export function mothingSummaryValue(stats, { now, user = INATURALIST_USER } = {}) {
+  const ts = now || new Date().toISOString();
+  return stripUndefined({
+    $type: MOTHING_NSID,
+    source: 'inaturalist',
+    user,
+    profileUrl: stats?.profileUrl || `https://www.inaturalist.org/people/${user}`,
+    observationCount: stats?.observationCount ?? 0,
+    speciesCount: stats?.speciesCount ?? 0,
+    distinctTaxaCount: stats?.distinctTaxaCount ?? 0,
+    qualityGrades: stats?.qualityGrades || undefined,
+    earliestDate: stats?.earliestDate || undefined,
+    latestDate: stats?.latestDate || undefined,
+    topSpecies: stats?.topSpecies?.length ? stats.topSpecies : undefined,
+    createdAt: ts,
+    updatedAt: ts,
+  });
+}
+
+/** One `is.dame.mothing.observation/<inatId>` record value. */
+export function mothingObservationValue(obs, { now } = {}) {
+  const ts = now || new Date().toISOString();
+  const taxon = obs.taxon || {};
+  return stripUndefined({
+    $type: MOTHING_OBSERVATION_NSID,
+    inatId: obs.id,
+    uuid: obs.uuid || undefined,
+    url: obs.url || undefined,
+    observedDate: obs.observedDate || undefined,
+    qualityGrade: obs.qualityGrade || undefined,
+    description: obs.description || undefined,
+    taxon: stripUndefined({
+      id: taxon.id ?? undefined,
+      name: taxon.name || undefined,
+      commonName: taxon.commonName || undefined,
+      rank: taxon.rank || undefined,
+      iconicTaxon: taxon.iconicTaxon || undefined,
+    }),
+    photos: (obs.photos || []).map((p) =>
+      stripUndefined({
+        id: p.id,
+        url: p.url,
+        licenseCode: p.licenseCode || undefined,
+        attribution: p.attribution || undefined,
+      }),
+    ),
+    createdAt: ts,
+    updatedAt: ts,
+  });
+}
+
+/**
+ * Build the full set of writes for a mirror run: the summary singleton plus
+ * one record per observation, keyed by iNaturalist id for idempotency.
+ * Returns `{ summary: {collection, rkey, value}, records: [...] }`.
+ */
+export function buildMirrorWrites({ observations, stats, now } = {}) {
+  const ts = now || new Date().toISOString();
+  return {
+    summary: {
+      collection: MOTHING_NSID,
+      rkey: 'self',
+      value: mothingSummaryValue(stats, { now: ts }),
+    },
+    records: (observations || [])
+      .filter((o) => o && o.id != null)
+      .map((o) => ({
+        collection: MOTHING_OBSERVATION_NSID,
+        rkey: String(o.id),
+        value: mothingObservationValue(o, { now: ts }),
+      })),
+  };
+}

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -64,6 +64,13 @@ export const PAGE_REGISTRY = {
     intro: 'Things worth handing off.',
     collection: null,
   },
+  mothing: {
+    slug: 'mothing',
+    label: 'Mothing',
+    title: 'Mothing',
+    intro: 'Moths I’ve found and photographed, pulled from iNaturalist. A running field notebook of the winged things drawn to the light.',
+    collection: null,
+  },
   resume: {
     slug: 'resume',
     label: 'Resume',

--- a/src/lib/verbRegistry.js
+++ b/src/lib/verbRegistry.js
@@ -106,6 +106,18 @@ export const VERB_REGISTRY = [
     ],
   },
   {
+    verb: 'mothing',
+    icon: 'Bug',
+    renderer: 'MothCard',
+    // Observation records are mirrored from iNaturalist onto the PDS by
+    // scripts/mirror-inaturalist.mjs; each carries its own iNat URL, so the
+    // feed links out there rather than to a bespoke record page.
+    pastTense: 'spotted',
+    collections: [
+      { nsid: 'is.dame.mothing.observation', source: 'inaturalist', kind: 'content', max: 500 },
+    ],
+  },
+  {
     verb: 'liking',
     icon: 'Heart',
     renderer: 'ReferenceCard',
@@ -209,6 +221,7 @@ export const DEFAULT_HOME_VERBS = [
   'listening',
   'creating',
   'photographing',
+  'mothing',
   'reposting',
   'following',
   'listing',
@@ -275,6 +288,7 @@ export const VERB_LABELS = {
   listening: 'a play',
   creating: 'a work',
   photographing: 'a photo',
+  mothing: 'a moth',
   liking: 'a like',
   reposting: 'a repost',
   following: 'a follow',

--- a/src/pages/Mothing.css
+++ b/src/pages/Mothing.css
@@ -1,0 +1,154 @@
+/* /mothing — iNaturalist moth showcase. Mirrors the Creating grid idiom. */
+
+.mothing-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5) var(--space-6);
+  margin-bottom: var(--space-4);
+}
+
+.mothing-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.mothing-stat-value {
+  font-family: var(--serif);
+  font-size: var(--text-2xl);
+  line-height: 1;
+  color: var(--ink);
+}
+
+.mothing-stat-dates {
+  font-size: var(--text-lg);
+}
+
+.mothing-stat-label {
+  letter-spacing: 0.16em;
+  font-size: var(--text-xs);
+  color: var(--accent);
+}
+
+.mothing-toplist {
+  margin: 0 0 var(--space-5);
+  color: var(--ink-soft, var(--ink));
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.mothing-toplist-lead {
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-right: var(--space-2);
+}
+
+.mothing-toplist-count {
+  color: var(--accent);
+}
+
+.mothing-toplist-sep {
+  color: var(--rule-soft);
+}
+
+.mothing-filters {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-5);
+}
+
+.mothing-filter {
+  font: inherit;
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-pill, 999px);
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
+}
+
+.mothing-filter:hover {
+  border-color: var(--accent-soft);
+}
+
+.mothing-filter.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.mothing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: var(--space-5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mothing-link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--ink);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-3);
+  overflow: hidden;
+  background: var(--page-edge);
+  height: 100%;
+  transition: transform 200ms ease, border-color 200ms ease;
+}
+
+.mothing-link:hover {
+  border-color: var(--accent-soft);
+  transform: translateY(-2px);
+}
+
+.mothing-link img {
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  object-fit: cover;
+  background: var(--page);
+  display: block;
+}
+
+.mothing-placeholder {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
+  background: var(--page);
+}
+
+.mothing-meta {
+  padding: var(--space-3) var(--space-4) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.mothing-name {
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  margin: 0;
+  line-height: 1.25;
+}
+
+.mothing-sci {
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--ink-soft, var(--ink));
+}
+
+.mothing-sub {
+  font-size: var(--text-xs);
+}
+
+.mothing-source {
+  margin-top: var(--space-6);
+  font-size: var(--text-xs);
+}

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react';
+import PageShell from '../components/PageShell.jsx';
+import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { usePageContent } from '../hooks/usePageContent.js';
+import { fetchMothData, photoUrl } from '../lib/inaturalist.js';
+import { ME_DID, INATURALIST_USER } from '../config.js';
+import './Mothing.css';
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Format a plain 'YYYY-MM-DD' date without touching Date() (no timezone math,
+// so a date can never shift across a day boundary — and never implies where).
+function formatDate(d) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(d || ''));
+  if (!m) return '';
+  const [, y, mo, day] = m;
+  return `${MONTHS[Number(mo) - 1]} ${Number(day)}, ${y}`;
+}
+
+const QUALITY_LABEL = {
+  research: 'Research grade',
+  needs_id: 'Needs ID',
+  casual: 'Casual',
+};
+
+function StatBlock({ value, label }) {
+  if (value == null) return null;
+  return (
+    <div className="mothing-stat">
+      <span className="mothing-stat-value">{value.toLocaleString()}</span>
+      <span className="mothing-stat-label small-caps">{label}</span>
+    </div>
+  );
+}
+
+function MothCard({ obs }) {
+  const photo = obs.photos?.[0];
+  const src = photo ? photoUrl(photo, 'medium') : null;
+  const title = obs.taxon?.commonName || obs.taxon?.name || 'Unidentified moth';
+  const sci = obs.taxon?.name;
+  const showSci = sci && sci !== title;
+  return (
+    <li className="mothing-cell">
+      <a
+        className="mothing-link"
+        href={obs.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {src ? (
+          <img src={src} alt={obs.taxon?.commonName || obs.taxon?.name || 'Moth observation'} loading="lazy" />
+        ) : (
+          <div className="mothing-placeholder" aria-hidden="true">&#x1F98B;</div>
+        )}
+        <div className="mothing-meta">
+          <h3 className="mothing-name">{title}</h3>
+          {showSci && <span className="mothing-sci">{sci}</span>}
+          <span className="gutter mothing-sub">
+            {obs.observedDate ? formatDate(obs.observedDate) : ''}
+            {obs.qualityGrade === 'research' ? ' · Research grade' : ''}
+          </span>
+        </div>
+      </a>
+    </li>
+  );
+}
+
+export default function Mothing() {
+  const { title, intro } = usePageContent('mothing');
+  const [gradeFilter, setGradeFilter] = useState('all');
+
+  const { items, status } = useLiveFeed({
+    name: 'mothing',
+    strategy: 'snapshot-first',
+    fetchLive: () => fetchMothData({ user: INATURALIST_USER }),
+    mapItems: (data) => {
+      if (!data) return null;
+      return {
+        stats: data.stats || null,
+        observations: Array.isArray(data.observations) ? data.observations : [],
+      };
+    },
+  });
+
+  const loading = status === 'loading';
+  const stats = items?.stats || null;
+  const observations = items?.observations || [];
+
+  const filtered = useMemo(() => {
+    if (gradeFilter === 'all') return observations;
+    const want = gradeFilter === 'research' ? 'research' : gradeFilter === 'needsId' ? 'needs_id' : 'casual';
+    return observations.filter((o) => o.qualityGrade === want);
+  }, [observations, gradeFilter]);
+
+  const grades = stats?.qualityGrades || {};
+
+  return (
+    <PageShell
+      title={title}
+      intro={intro}
+      atUri={`at://${ME_DID}/is.dame.page/mothing`}
+      headTitle="Mothing — Dame is&hellip;"
+    >
+      {stats && (
+        <section className="mothing-stats" aria-label="Mothing stats">
+          <StatBlock value={stats.observationCount} label="observations" />
+          <StatBlock value={stats.speciesCount} label="species" />
+          <StatBlock value={grades.research} label="research grade" />
+          {stats.earliestDate && (
+            <div className="mothing-stat mothing-stat-range">
+              <span className="mothing-stat-value mothing-stat-dates">
+                {formatDate(stats.earliestDate)} &ndash; {formatDate(stats.latestDate)}
+              </span>
+              <span className="mothing-stat-label small-caps">span</span>
+            </div>
+          )}
+        </section>
+      )}
+
+      {stats?.topSpecies?.length > 0 && (
+        <p className="mothing-toplist">
+          <span className="small-caps mothing-toplist-lead">Most seen</span>{' '}
+          {stats.topSpecies.slice(0, 6).map((s, i) => (
+            <span key={s.taxonId || i} className="mothing-toplist-item">
+              {s.commonName || s.name}
+              <span className="mothing-toplist-count"> {s.count}</span>
+              {i < Math.min(6, stats.topSpecies.length) - 1 ? <span className="mothing-toplist-sep"> · </span> : ''}
+            </span>
+          ))}
+        </p>
+      )}
+
+      {observations.length > 0 && (
+        <div className="mothing-filters" role="group" aria-label="Filter by quality grade">
+          {[
+            { key: 'all', label: `All ${stats?.observationCount ? `(${stats.observationCount})` : ''}`.trim() },
+            { key: 'research', label: `Research${grades.research ? ` (${grades.research})` : ''}` },
+            { key: 'needsId', label: `Needs ID${grades.needsId ? ` (${grades.needsId})` : ''}` },
+            { key: 'casual', label: `Casual${grades.casual ? ` (${grades.casual})` : ''}` },
+          ].map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              className={`mothing-filter${gradeFilter === f.key ? ' is-active' : ''}`}
+              onClick={() => setGradeFilter(f.key)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading && observations.length === 0 ? (
+        <p className="placeholder-card">Loading moths&hellip;</p>
+      ) : filtered.length === 0 ? (
+        <p className="feed-empty">
+          {observations.length === 0
+            ? 'No moth observations yet.'
+            : 'No observations match that filter.'}
+        </p>
+      ) : (
+        <ul className="mothing-grid reveal-stagger">
+          {filtered.map((obs) => (
+            <MothCard key={obs.id} obs={obs} />
+          ))}
+        </ul>
+      )}
+
+      <p className="mothing-source gutter">
+        Mirrored from{' '}
+        <a href={stats?.profileUrl || `https://www.inaturalist.org/people/${INATURALIST_USER}`} target="_blank" rel="noopener noreferrer">
+          iNaturalist
+        </a>
+        . Location data is intentionally omitted.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -6,6 +6,7 @@ import StatusEntry from '../components/StatusEntry.jsx';
 import ListenRow from '../components/ListenRow.jsx';
 import BlogCard from '../components/BlogCard.jsx';
 import CreatingCard from '../components/CreatingCard.jsx';
+import MothCard from '../components/cards/MothCard.jsx';
 import Comments from '../components/Comments.jsx';
 import ReferenceCard from '../components/ReferenceCard.jsx';
 import AtUriLink from '../components/AtUriLink.jsx';
@@ -248,6 +249,8 @@ function RecordBody({ verb, item, collection }) {
       return <BlogCard {...item} />;
     case 'creating':
       return <CreatingCard {...item} />;
+    case 'mothing':
+      return <MothCard {...item} />;
     default:
       return <GenericRecordBody verb={verb} item={item} collection={collection} />;
   }

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,8 @@
   "framework": "vite",
   "trailingSlash": false,
   "crons": [
-    { "path": "/api/rebuild", "schedule": "0 */6 * * *" }
+    { "path": "/api/rebuild", "schedule": "0 */6 * * *" },
+    { "path": "/api/mirror-mothing", "schedule": "30 5 * * *" }
   ],
   "rewrites": [
     { "source": "/oauth-client-metadata.json", "destination": "/api/client-metadata" },


### PR DESCRIPTION
Adds a `/mothing` page showcasing moth observations pulled from iNaturalist (user `anisota`, Lepidoptera minus butterflies), mirrors that data onto the PDS under two new lexicons, and surfaces observations in the home feed.

## What's included

**Page** — `/mothing` (linked in the Compass nav + page registry)
- Stats: observations, species, research-grade, date span
- "Most seen" list, quality-grade filter, and a photo grid linking out to each iNaturalist observation
- Paints from a build-time snapshot, then refreshes live from the iNaturalist API in the browser

**PDS mirror** — two new `is.dame.*` lexicons you own
- `is.dame.mothing/self` — summary singleton (counts, quality grades, span, top species)
- `is.dame.mothing.observation/<inatId>` — one record per observation, keyed by iNat id (idempotent)
- `scripts/mirror-inaturalist.mjs` — CLI mirror (`--dry-run`, `--prune`, `--max`)
- `api/mirror-mothing.js` + `vercel.json` — daily cron, guarded by `CRON_SECRET`, using `BSKY_APP_PASSWORD`

**Home feed** — new `mothing` verb in the registry (Bug icon, `MothCard` renderer, source `inaturalist`), on by default. Records surface once the mirror has populated the PDS, ordered by observation date.

**Shared lib** — `src/lib/inaturalist.js` is the single choke point that normalizes observations and strips **all** location data (coordinates, place names, place ids, and timezone-bearing timestamps). Only the plain observation date survives, so nothing downstream — snapshot, page, or PDS record — can leak a location. Observation record `createdAt` is derived from the observation date (noon UTC), keeping records idempotent and the feed ordered by when moths were seen.

## Notes for after merge
- Set `BSKY_APP_PASSWORD` (and optionally `BSKY_IDENTIFIER`, `CRON_SECRET`) in Vercel for the mirror/cron to write to the PDS. The page works without it (reads iNaturalist directly).
- "Moths" = Lepidoptera (47157) minus butterflies (47224); 238 of 327 iNat observations match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t)_