### PR TITLE
Mothing: drop filter chips, group observations into nightly sessions

### DIFF
--- a/lexicons/is.dame.mothing.json
+++ b/lexicons/is.dame.mothing.json
@@ -16,6 +16,7 @@
           "observationCount":  { "type": "integer" },
           "speciesCount":      { "type": "integer", "description": "Distinct species-rank taxa observed." },
           "distinctTaxaCount": { "type": "integer", "description": "Distinct taxa at any rank." },
+          "sessionCount":      { "type": "integer", "description": "Distinct mothing sessions (nights at the light, 8pm–3am)." },
           "qualityGrades": {
             "type": "object",
             "description": "Observation counts by iNaturalist quality grade.",

--- a/lexicons/is.dame.mothing.observation.json
+++ b/lexicons/is.dame.mothing.observation.json
@@ -13,7 +13,8 @@
           "inatId":       { "type": "integer", "description": "The iNaturalist observation id." },
           "uuid":         { "type": "string" },
           "url":          { "type": "string", "format": "uri", "description": "Canonical iNaturalist observation URL." },
-          "observedDate": { "type": "string", "description": "Date of observation (YYYY-MM-DD). Time-of-day and timezone are omitted by design." },
+          "observedDate": { "type": "string", "description": "Date of observation (YYYY-MM-DD)." },
+          "observedTime": { "type": "string", "description": "Local time of observation (HH:MM), timezone offset stripped by design so it reveals when-in-the-day but never where." },
           "qualityGrade": { "type": "string", "description": "iNaturalist quality grade: research | needs_id | casual." },
           "description":  { "type": "string", "maxLength": 5000 },
           "taxon": {

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -74,12 +74,25 @@ export function normalizeObservation(o) {
           attribution: p.attribution || null,
         }))
     : [];
+  // Local time-of-day only. iNaturalist's `time_observed_at` carries a tz
+  // offset (a coarse location hint) — we keep just the wall-clock "HH:MM"
+  // from it, which says *when* in the observer's day, never *where*.
+  const details = o.observed_on_details || {};
+  let observedHour = Number.isInteger(details.hour) ? details.hour : null;
+  let observedTime = null;
+  const wall = /T(\d{2}):(\d{2})/.exec(o.time_observed_at || '');
+  if (wall) {
+    observedTime = `${wall[1]}:${wall[2]}`;
+    if (observedHour == null) observedHour = Number(wall[1]);
+  }
   return {
     id: o.id,
     uuid: o.uuid || null,
     url: o.uri || (o.id ? `https://www.inaturalist.org/observations/${o.id}` : null),
     // Date only — never the tz-bearing `time_observed_at` / `created_at`.
     observedDate: o.observed_on_details?.date || o.observed_on || null,
+    observedTime, // local "HH:MM", offset stripped (or null)
+    observedHour, // local hour 0–23 (or null)
     qualityGrade: o.quality_grade || null,
     description: o.description || null,
     taxon: {
@@ -91,6 +104,110 @@ export function normalizeObservation(o) {
     },
     photos,
   };
+}
+
+/* ------------------------------------------------------------------ */
+/* Mothing sessions                                                   */
+/*                                                                    */
+/* A "mothing session" is one night at the light: observations whose  */
+/* local time falls in the 8pm→3am window count as the same session,  */
+/* keyed by the evening's date (an after-midnight obs belongs to the  */
+/* night that began the previous evening). Uses local time-of-day     */
+/* only, so it reveals nothing about location.                        */
+/* ------------------------------------------------------------------ */
+
+export const SESSION_START_HOUR = 20; // 8pm — a session opens
+export const SESSION_END_HOUR = 3; // 3am — and closes
+
+function previousDay(dateStr) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || ''));
+  if (!m) return null;
+  const d = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * The session date (the evening a night belongs to) for one observation, or
+ * `null` when it falls outside the night window or has no known time.
+ */
+export function sessionDateFor(observedDate, observedHour) {
+  if (!observedDate || observedHour == null) return null;
+  if (observedHour >= SESSION_START_HOUR) return observedDate; // evening
+  if (observedHour < SESSION_END_HOUR) return previousDay(observedDate); // after midnight
+  return null; // daytime — not a mothing session
+}
+
+/**
+ * Group observations into numbered mothing sessions (oldest night = #1).
+ * Returns `{ sessions, sessionCount, orphans }` where `sessions` is sorted
+ * newest-first for display and each carries its own little stat block.
+ * `orphans` are daytime / untimed observations that aren't part of a night.
+ */
+export function buildSessions(observations) {
+  const obs = Array.isArray(observations) ? observations : [];
+  const byDate = new Map(); // sessionDate -> observations[]
+  const orphans = [];
+  for (const o of obs) {
+    const key = sessionDateFor(o.observedDate, o.observedHour);
+    if (!key) {
+      orphans.push(o);
+      continue;
+    }
+    if (!byDate.has(key)) byDate.set(key, []);
+    byDate.get(key).push(o);
+  }
+
+  // Number sessions chronologically (oldest = 1) for a stable ordinal.
+  const ascendingDates = Array.from(byDate.keys()).sort();
+  const numberByDate = new Map(ascendingDates.map((d, i) => [d, i + 1]));
+
+  const sessions = ascendingDates
+    .map((date) => summarizeSession(date, numberByDate.get(date), byDate.get(date)))
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0)); // newest first
+
+  return { sessions, sessionCount: sessions.length, orphans };
+}
+
+function summarizeSession(date, number, observations) {
+  const items = observations
+    .slice()
+    // Within a night, order by local time (evening → after-midnight).
+    .sort((a, b) => nightMinutes(a) - nightMinutes(b));
+  const species = new Set();
+  let research = 0;
+  const timed = items.filter((o) => o.observedTime);
+  for (const o of items) {
+    if (o.taxon?.id != null && (o.taxon.rank === 'species' || o.taxon.rank === 'subspecies')) {
+      species.add(o.taxon.id);
+    }
+    if (o.qualityGrade === 'research') research += 1;
+  }
+  return {
+    number,
+    date, // the evening's date (YYYY-MM-DD)
+    observations: items,
+    observationCount: items.length,
+    speciesCount: species.size,
+    researchCount: research,
+    firstTime: timed[0]?.observedTime || null,
+    lastTime: timed[timed.length - 1]?.observedTime || null,
+  };
+}
+
+// Minutes since the session opened at 8pm, from the observation's local
+// time, so an evening time (20:00–23:59) sorts before an after-midnight one
+// (00:00–02:59) and same-hour observations order by minute.
+function nightMinutes(o) {
+  const m = /^(\d{2}):(\d{2})$/.exec(String(o?.observedTime || ''));
+  const minutesOfDay =
+    m != null
+      ? Number(m[1]) * 60 + Number(m[2])
+      : o?.observedHour != null
+        ? o.observedHour * 60
+        : null;
+  if (minutesOfDay == null) return Number.MAX_SAFE_INTEGER;
+  return (minutesOfDay - SESSION_START_HOUR * 60 + 1440) % 1440;
 }
 
 /**
@@ -167,11 +284,14 @@ export function computeStats(observations, { user = INATURALIST_USER } = {}) {
       count: e.count,
     }));
 
+  const { sessionCount } = buildSessions(obs);
+
   return {
     user,
     observationCount: obs.length,
     speciesCount: speciesIds.size,
     distinctTaxaCount: distinctTaxa.size,
+    sessionCount,
     withPhotos,
     qualityGrades: grades,
     earliestDate: earliest,
@@ -217,6 +337,7 @@ export function mothingSummaryValue(stats, { now, user = INATURALIST_USER } = {}
     observationCount: stats?.observationCount ?? 0,
     speciesCount: stats?.speciesCount ?? 0,
     distinctTaxaCount: stats?.distinctTaxaCount ?? 0,
+    sessionCount: stats?.sessionCount ?? undefined,
     qualityGrades: stats?.qualityGrades || undefined,
     earliestDate: stats?.earliestDate || undefined,
     latestDate: stats?.latestDate || undefined,
@@ -227,23 +348,24 @@ export function mothingSummaryValue(stats, { now, user = INATURALIST_USER } = {}
 }
 
 /**
- * Turn a plain 'YYYY-MM-DD' observation date into a stable, location-free
- * timestamp for `createdAt` — noon UTC, which reveals nothing about where.
- * Deriving from the observation date (not the mirror run) keeps the record
- * idempotent and lets the home feed order moths by when they were seen
- * instead of clumping them all at the last sync.
+ * Turn a plain observation date + local time into a stable, location-free
+ * timestamp for `createdAt`. The local wall-clock is labeled `Z` — it is not
+ * a true UTC instant (that would need the tz offset we deliberately drop),
+ * but it reveals nothing about where and gives the feed correct ordering,
+ * including within a single night. Deriving from the observation (not the
+ * mirror run) keeps the record idempotent across syncs.
  */
-export function observedTimestamp(observedDate) {
-  return /^\d{4}-\d{2}-\d{2}$/.test(String(observedDate || ''))
-    ? `${observedDate}T12:00:00.000Z`
-    : null;
+export function observedTimestamp(observedDate, observedTime) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(observedDate || ''))) return null;
+  const time = /^\d{2}:\d{2}$/.test(String(observedTime || '')) ? observedTime : '12:00';
+  return `${observedDate}T${time}:00.000Z`;
 }
 
 /** One `is.dame.mothing.observation/<inatId>` record value. */
 export function mothingObservationValue(obs, { now } = {}) {
-  // Stable timestamp from the observation date; fall back to the run time
-  // only for the rare observation with no date at all.
-  const ts = observedTimestamp(obs.observedDate) || now || new Date().toISOString();
+  // Stable timestamp from the observation date + local time; fall back to the
+  // run time only for the rare observation with no date at all.
+  const ts = observedTimestamp(obs.observedDate, obs.observedTime) || now || new Date().toISOString();
   const taxon = obs.taxon || {};
   return stripUndefined({
     $type: MOTHING_OBSERVATION_NSID,
@@ -251,6 +373,7 @@ export function mothingObservationValue(obs, { now } = {}) {
     uuid: obs.uuid || undefined,
     url: obs.url || undefined,
     observedDate: obs.observedDate || undefined,
+    observedTime: obs.observedTime || undefined,
     qualityGrade: obs.qualityGrade || undefined,
     description: obs.description || undefined,
     taxon: stripUndefined({

--- a/src/pages/Mothing.css
+++ b/src/pages/Mothing.css
@@ -51,33 +51,42 @@
   color: var(--rule-soft);
 }
 
-.mothing-filters {
+.mothing-sessions {
   display: flex;
-  gap: var(--space-2);
+  flex-direction: column;
+  gap: var(--space-7);
+}
+
+.mothing-session-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.mothing-session-headrow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
   flex-wrap: wrap;
-  margin-bottom: var(--space-5);
 }
 
-.mothing-filter {
-  font: inherit;
-  font-size: var(--text-xs);
-  letter-spacing: 0.04em;
-  padding: var(--space-1) var(--space-3);
-  border: 1px solid var(--rule-soft);
-  border-radius: var(--radius-pill, 999px);
-  background: transparent;
-  color: var(--ink);
-  cursor: pointer;
-  transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
-}
-
-.mothing-filter:hover {
-  border-color: var(--accent-soft);
-}
-
-.mothing-filter.is-active {
-  border-color: var(--accent);
+.mothing-session-num {
+  letter-spacing: 0.16em;
   color: var(--accent);
+  font-size: var(--text-xs);
+}
+
+.mothing-session-title {
+  font-family: var(--serif);
+  font-size: var(--text-xl);
+  margin: 0;
+}
+
+.mothing-session-stats {
+  font-size: var(--text-xs);
 }
 
 .mothing-grid {

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import PageShell from '../components/PageShell.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
-import { fetchMothData, photoUrl } from '../lib/inaturalist.js';
+import { fetchMothData, photoUrl, buildSessions } from '../lib/inaturalist.js';
 import { ME_DID, INATURALIST_USER } from '../config.js';
 import './Mothing.css';
 
@@ -17,11 +17,16 @@ function formatDate(d) {
   return `${MONTHS[Number(mo) - 1]} ${Number(day)}, ${y}`;
 }
 
-const QUALITY_LABEL = {
-  research: 'Research grade',
-  needs_id: 'Needs ID',
-  casual: 'Casual',
-};
+// Local 'HH:MM' → '8:47pm'. Wall-clock only; carries no location.
+function formatTime(hhmm) {
+  const m = /^(\d{2}):(\d{2})$/.exec(String(hhmm || ''));
+  if (!m) return '';
+  let h = Number(m[1]);
+  const min = m[2];
+  const ampm = h >= 12 ? 'pm' : 'am';
+  h = h % 12 || 12;
+  return `${h}:${min}${ampm}`;
+}
 
 function StatBlock({ value, label }) {
   if (value == null) return null;
@@ -41,14 +46,9 @@ function MothCard({ obs }) {
   const showSci = sci && sci !== title;
   return (
     <li className="mothing-cell">
-      <a
-        className="mothing-link"
-        href={obs.url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <a className="mothing-link" href={obs.url} target="_blank" rel="noopener noreferrer">
         {src ? (
-          <img src={src} alt={obs.taxon?.commonName || obs.taxon?.name || 'Moth observation'} loading="lazy" />
+          <img src={src} alt={title} loading="lazy" />
         ) : (
           <div className="mothing-placeholder" aria-hidden="true">&#x1F98B;</div>
         )}
@@ -56,7 +56,7 @@ function MothCard({ obs }) {
           <h3 className="mothing-name">{title}</h3>
           {showSci && <span className="mothing-sci">{sci}</span>}
           <span className="gutter mothing-sub">
-            {obs.observedDate ? formatDate(obs.observedDate) : ''}
+            {obs.observedTime ? formatTime(obs.observedTime) : formatDate(obs.observedDate)}
             {obs.qualityGrade === 'research' ? ' · Research grade' : ''}
           </span>
         </div>
@@ -65,9 +65,29 @@ function MothCard({ obs }) {
   );
 }
 
+function SessionHeader({ session }) {
+  const parts = [`${session.observationCount} moth${session.observationCount === 1 ? '' : 's'}`];
+  if (session.speciesCount) parts.push(`${session.speciesCount} species`);
+  if (session.firstTime) {
+    parts.push(
+      session.lastTime && session.lastTime !== session.firstTime
+        ? `${formatTime(session.firstTime)}–${formatTime(session.lastTime)}`
+        : formatTime(session.firstTime),
+    );
+  }
+  return (
+    <header className="mothing-session-head">
+      <div className="mothing-session-headrow">
+        <span className="small-caps mothing-session-num">Session #{session.number}</span>
+        <h2 className="mothing-session-title">Night of {formatDate(session.date)}</h2>
+      </div>
+      <span className="gutter mothing-session-stats">{parts.join(' · ')}</span>
+    </header>
+  );
+}
+
 export default function Mothing() {
   const { title, intro } = usePageContent('mothing');
-  const [gradeFilter, setGradeFilter] = useState('all');
 
   const { items, status } = useLiveFeed({
     name: 'mothing',
@@ -86,12 +106,7 @@ export default function Mothing() {
   const stats = items?.stats || null;
   const observations = items?.observations || [];
 
-  const filtered = useMemo(() => {
-    if (gradeFilter === 'all') return observations;
-    const want = gradeFilter === 'research' ? 'research' : gradeFilter === 'needsId' ? 'needs_id' : 'casual';
-    return observations.filter((o) => o.qualityGrade === want);
-  }, [observations, gradeFilter]);
-
+  const { sessions, orphans } = useMemo(() => buildSessions(observations), [observations]);
   const grades = stats?.qualityGrades || {};
 
   return (
@@ -103,6 +118,7 @@ export default function Mothing() {
     >
       {stats && (
         <section className="mothing-stats" aria-label="Mothing stats">
+          <StatBlock value={stats.sessionCount ?? sessions.length} label="sessions" />
           <StatBlock value={stats.observationCount} label="observations" />
           <StatBlock value={stats.speciesCount} label="species" />
           <StatBlock value={grades.research} label="research grade" />
@@ -130,40 +146,42 @@ export default function Mothing() {
         </p>
       )}
 
-      {observations.length > 0 && (
-        <div className="mothing-filters" role="group" aria-label="Filter by quality grade">
-          {[
-            { key: 'all', label: `All ${stats?.observationCount ? `(${stats.observationCount})` : ''}`.trim() },
-            { key: 'research', label: `Research${grades.research ? ` (${grades.research})` : ''}` },
-            { key: 'needsId', label: `Needs ID${grades.needsId ? ` (${grades.needsId})` : ''}` },
-            { key: 'casual', label: `Casual${grades.casual ? ` (${grades.casual})` : ''}` },
-          ].map((f) => (
-            <button
-              key={f.key}
-              type="button"
-              className={`mothing-filter${gradeFilter === f.key ? ' is-active' : ''}`}
-              onClick={() => setGradeFilter(f.key)}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-      )}
-
       {loading && observations.length === 0 ? (
         <p className="placeholder-card">Loading moths&hellip;</p>
-      ) : filtered.length === 0 ? (
-        <p className="feed-empty">
-          {observations.length === 0
-            ? 'No moth observations yet.'
-            : 'No observations match that filter.'}
-        </p>
+      ) : observations.length === 0 ? (
+        <p className="feed-empty">No moth observations yet.</p>
       ) : (
-        <ul className="mothing-grid reveal-stagger">
-          {filtered.map((obs) => (
-            <MothCard key={obs.id} obs={obs} />
+        <div className="mothing-sessions">
+          {sessions.map((session) => (
+            <section key={session.date} className="mothing-session">
+              <SessionHeader session={session} />
+              <ul className="mothing-grid reveal-stagger">
+                {session.observations.map((obs) => (
+                  <MothCard key={obs.id} obs={obs} />
+                ))}
+              </ul>
+            </section>
           ))}
-        </ul>
+
+          {orphans.length > 0 && (
+            <section className="mothing-session">
+              <header className="mothing-session-head">
+                <div className="mothing-session-headrow">
+                  <span className="small-caps mothing-session-num">Outside sessions</span>
+                  <h2 className="mothing-session-title">Daytime &amp; untimed</h2>
+                </div>
+                <span className="gutter mothing-session-stats">
+                  {orphans.length} observation{orphans.length === 1 ? '' : 's'}
+                </span>
+              </header>
+              <ul className="mothing-grid reveal-stagger">
+                {orphans.map((obs) => (
+                  <MothCard key={obs.id} obs={obs} />
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
       )}
 
       <p className="mothing-source gutter">
@@ -171,7 +189,7 @@ export default function Mothing() {
         <a href={stats?.profileUrl || `https://www.inaturalist.org/people/${INATURALIST_USER}`} target="_blank" rel="noopener noreferrer">
           iNaturalist
         </a>
-        . Location data is intentionally omitted.
+        . A mothing session is one night at the light (8pm&ndash;3am). Location data is intentionally omitted.
       </p>
     </PageShell>
   );


### PR DESCRIPTION
Follow-up to the `/mothing` page.

## Changes
- **Removed the quality-grade filter chips** (All / Research / Needs ID / Casual) from `/mothing`.
- **Mothing sessions** — a session is one night at the light, local **8pm→3am** (an after-midnight observation belongs to the night that began the prior evening). Sessions are numbered chronologically (oldest = #1).
  - Stats section gains a **sessions** count.
  - The observation list is now grouped under a per-session header: session number, night date, and the night's moth/species counts + local time span (correctly ordered across midnight). Daytime/untimed observations fall into a trailing "Outside sessions" group.

## Privacy
Sessions need time-of-day, so `inaturalist.js` now captures **local wall-clock time only** (`observedTime` "HH:MM" + `observedHour`) from iNaturalist's timestamp, with the timezone offset stripped — it reveals when-in-the-night, never where. Re-verified against the full fetched dataset: no coordinates, place names, place ids, or tz offsets. `is.dame.mothing.observation` gains `observedTime`; `is.dame.mothing` gains `sessionCount`. Observation record `createdAt` now carries the local time for correct in-night feed ordering.

Verified: 238 observations → 20 sessions (+7 daytime/untimed); build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t)_