### PR TITLE
White-label /curating and improve the lightbox loading experience

### DIFF
--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -46,7 +46,6 @@ import { VERB_REGISTRY } from '../src/lib/verbRegistry.js';
 import {
   fetchChannelMeta,
   fetchAllBlocks,
-  arenaChannelUrl,
   arenaAccessToken,
 } from '../src/lib/arena.js';
 import {
@@ -191,7 +190,6 @@ async function main() {
       title: g.value.title || snap.meta?.title || g.rkey,
       description: g.value.description || snap.meta?.description || '',
       blockCount: snap.blocks.length,
-      arenaUrl: arenaChannelUrl(g.value.arenaSlug),
       cover: snap.blocks[0]?.thumb || null,
       order: g.value.order ?? 0,
     };

--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -45,8 +45,11 @@
   display: block;
   max-width: 100%;
   /* Leave headroom for the footer (close button) underneath so it
-     doesn't get pushed off-screen on short viewports. */
-  max-height: calc(100dvh - 8rem);
+     doesn't get pushed off-screen on short viewports. The budget is a
+     variable because entries with known dimensions also use it to
+     reserve the display box inline before the image loads. */
+  --lightbox-maxh: calc(100dvh - 8rem);
+  max-height: var(--lightbox-maxh);
   width: auto;
   height: auto;
   object-fit: contain;
@@ -54,6 +57,37 @@
   border-radius: var(--radius-2);
   background: var(--page-edge);
   box-shadow: 0 16px 40px var(--shadow);
+}
+
+/* Optional caption row directly under the image — source / reverse-image
+   search links for the current photo. Same scrim-friendly chrome as the
+   footer text so it reads as part of the control cluster. */
+.lightbox-caption {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  width: 100%;
+  margin-top: var(--space-2);
+  padding: 0 var(--space-2);
+}
+
+.lightbox-caption-link {
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  color: var(--ink-on-scrim, #fff);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  opacity: 0.8;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.lightbox-caption-link:hover,
+.lightbox-caption-link:focus-visible {
+  opacity: 1;
 }
 
 /* Footer beneath the image — holds the close button and (for
@@ -142,6 +176,6 @@
 
 @media (max-width: 540px) {
   .lightbox-image {
-    max-height: calc(100dvh - 7rem);
+    --lightbox-maxh: calc(100dvh - 7rem);
   }
 }

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -12,11 +12,24 @@ import './Lightbox.css';
  * appear. The image itself doesn't dismiss on click so the reader can
  * actually rest their eyes on it; close happens via scrim, Escape, or
  * the explicit close button.
+ *
+ * Each entry is `{ src, alt }` plus optional extras:
+ *   - `width` / `height`: intrinsic dimensions. Passed through as <img>
+ *     attributes so the browser reserves the final display box before the
+ *     file arrives — without them the image pops from a dot to full size.
+ *   - `thumb`: a small already-cached variant painted behind the full image
+ *     while it loads (grid thumbnails are ideal).
+ *   - `sourceUrl` / `searchUrl`: render a caption row under the image with
+ *     a link to the original source and/or a reverse-image search.
  */
 export default function Lightbox({ open, onClose, images, index = 0 }) {
   const list = Array.isArray(images) ? images.filter((im) => im?.src) : [];
   const count = list.length;
   const [active, setActive] = useState(index);
+  const [loadedSrcs, setLoadedSrcs] = useState(() => new Set());
+  const markLoaded = useCallback((src) => {
+    setLoadedSrcs((prev) => (prev.has(src) ? prev : new Set(prev).add(src)));
+  }, []);
 
   // Sync external index changes (e.g. opening to a different starting
   // image without unmounting). Also re-clamp when the source list shrinks.
@@ -52,6 +65,25 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
   if (count === 0) return null;
   const current = list[active] || list[0];
   const alt = current.alt || '';
+  // With intrinsic dimensions we can size the box before the file arrives:
+  // natural width, clamped by the panel width and by the viewport-height
+  // budget (transferred through the aspect ratio). Without them the image
+  // sizes itself on load, as before.
+  const ratio = current.width > 0 && current.height > 0 ? current.width / current.height : null;
+  const reserveStyle = ratio
+    ? {
+        width: `min(${current.width}px, 100%, calc(var(--lightbox-maxh) * ${ratio.toFixed(5)}))`,
+        aspectRatio: `${current.width} / ${current.height}`,
+      }
+    : null;
+  const placeholderStyle =
+    current.thumb && !loadedSrcs.has(current.src)
+      ? {
+          backgroundImage: `url(${current.thumb})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }
+      : null;
   const label = alt
     ? `Image: ${alt}`
     : count > 1
@@ -73,9 +105,42 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
           key={current.src}
           src={current.src}
           alt={alt}
+          width={current.width || undefined}
+          height={current.height || undefined}
           className="lightbox-image"
           decoding="async"
+          onLoad={() => markLoaded(current.src)}
+          ref={(el) => {
+            // onLoad can be missed for cache hits that complete before
+            // React attaches the handler; the ref callback catches those.
+            if (el?.complete && el.naturalWidth) markLoaded(current.src);
+          }}
+          style={reserveStyle || placeholderStyle ? { ...reserveStyle, ...placeholderStyle } : undefined}
         />
+        {(current.sourceUrl || current.searchUrl) && (
+          <figcaption className="lightbox-caption">
+            {current.sourceUrl && (
+              <a
+                href={current.sourceUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="lightbox-caption-link"
+              >
+                source ↗
+              </a>
+            )}
+            {current.searchUrl && (
+              <a
+                href={current.searchUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="lightbox-caption-link"
+              >
+                reverse image search ↗
+              </a>
+            )}
+          </figcaption>
+        )}
       </figure>
       <footer className="lightbox-footer">
         {count > 1 && (

--- a/src/lib/arena.js
+++ b/src/lib/arena.js
@@ -9,16 +9,7 @@
 // deliberately not VITE_-prefixed so Vite can never inline it into the
 // client bundle.
 
-import { ME_HANDLE } from '../config.js';
-
 const ARENA_API = 'https://api.are.na/v3';
-
-/** Are.na profile slug used for "view on are.na" links. */
-export const ARENA_USER = ME_HANDLE.split('.')[0];
-
-export function arenaChannelUrl(arenaSlug) {
-  return `https://www.are.na/${ARENA_USER}/${encodeURIComponent(arenaSlug)}`;
-}
 
 /** Build-time only: undefined in the browser. */
 export function arenaAccessToken() {

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -54,7 +54,7 @@ export const PAGE_REGISTRY = {
     slug: 'curating',
     label: 'Curating',
     title: 'Curating',
-    intro: 'Galleries of images collected on Are.na.',
+    intro: 'Galleries of images I’ve been collecting.',
     collection: COLLECTIONS.arenaChannel,
   },
   sharing: {

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -5,12 +5,7 @@ import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
-import {
-  fetchChannelMeta,
-  fetchChannelPage,
-  normalizeBlock,
-  arenaChannelUrl,
-} from '../lib/arena.js';
+import { fetchChannelMeta, fetchChannelPage, normalizeBlock } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Curating.css';
@@ -54,7 +49,6 @@ async function loadGalleries() {
         title: g.value.title || meta?.title || g.rkey,
         description: g.value.description || meta?.description || '',
         blockCount: meta?.counts?.blocks ?? null,
-        arenaUrl: arenaChannelUrl(g.value.arenaSlug),
         cover,
         order: g.value.order ?? 0,
       });
@@ -105,10 +99,9 @@ export default function Curating() {
                   <div className="creating-grid-placeholder" aria-hidden="true">&#x273A;</div>
                 )}
                 <div className="creating-grid-meta">
-                  <span className="small-caps creating-grid-kind">are.na</span>
                   <h3 className="creating-grid-title">{g.title}</h3>
                   {g.blockCount != null && (
-                    <span className="gutter">{g.blockCount} blocks</span>
+                    <span className="gutter">{g.blockCount} images</span>
                   )}
                 </div>
               </Link>

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -5,7 +5,7 @@ import Lightbox from '../components/Lightbox.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { resolvePds, getRecord } from '../lib/atproto.js';
-import { fetchChannelMeta, fetchAllBlocks, arenaChannelUrl } from '../lib/arena.js';
+import { fetchChannelMeta, fetchAllBlocks } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Curating.css';
 
@@ -20,6 +20,10 @@ function hostname(url) {
   } catch {
     return null;
   }
+}
+
+function reverseSearchUrl(imageUrl) {
+  return `https://lens.google.com/uploadbyurl?url=${encodeURIComponent(imageUrl)}`;
 }
 
 export default function CuratingChannel() {
@@ -56,7 +60,6 @@ export default function CuratingChannel() {
           title: v.title || meta?.title || slug,
           description: v.description || meta?.description || '',
           blockCount: blocks.length,
-          arenaUrl: arenaChannelUrl(v.arenaSlug),
         },
         truncated,
         blocks,
@@ -112,20 +115,11 @@ export default function CuratingChannel() {
       }
     >
       <div className="curating-channel-meta gutter">
-        <span>{gallery.blockCount} blocks</span>
-        <span aria-hidden="true">·</span>
-        <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
-          view on are.na ↗
-        </a>
+        <span>{gallery.blockCount} images</span>
       </div>
 
       {blocks.length === 0 ? (
-        <p className="feed-empty">
-          No images in this channel yet.{' '}
-          <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
-            See it on are.na.
-          </a>
-        </p>
+        <p className="feed-empty">No images in this gallery yet.</p>
       ) : (
         <>
           <ul className="curating-block-grid reveal-stagger">
@@ -154,18 +148,22 @@ export default function CuratingChannel() {
           </ul>
           {truncated && (
             <p className="curating-truncated gutter">
-              Showing the first {blocks.length} blocks —{' '}
-              <a href={gallery.arenaUrl} target="_blank" rel="noreferrer noopener">
-                see the rest on are.na
-              </a>
-              .
+              Showing the first {blocks.length} images.
             </p>
           )}
           <Lightbox
             open={lightbox >= 0}
             index={Math.max(0, lightbox)}
             onClose={() => setLightbox(-1)}
-            images={blocks.map((b) => ({ src: b.large, alt: b.alt }))}
+            images={blocks.map((b) => ({
+              src: b.large,
+              alt: b.alt,
+              width: b.width || undefined,
+              height: b.height || undefined,
+              thumb: b.thumb?.src || undefined,
+              sourceUrl: b.sourceUrl || undefined,
+              searchUrl: reverseSearchUrl(b.large),
+            }))}
           />
         </>
       )}


### PR DESCRIPTION
## What

Follow-up to #60, three changes to the /curating galleries:

- **White-label**: removes all are.na branding and outbound links from the public pages — the "are.na" tag on index cards, the "view on are.na" header link, and the are.na links in the empty/truncated states. The default page intro no longer mentions Are.na. Are.na remains purely the backend data source (the unused `arenaUrl` field and `arenaChannelUrl` helper were dropped from the snapshot/client plumbing).
- **Lightbox pop-in fix**: the modal image used to render as a tiny dot that jumped to full size once loaded. Each gallery block's known intrinsic dimensions now reserve the exact final display box before the file arrives (explicit `width`/`aspect-ratio` inline sizing clamped by the viewport budget, which the stylesheet exposes as `--lightbox-maxh`), and the already-cached grid thumbnail paints behind the full image as an instant placeholder until it loads.
- **Caption row**: the lightbox gains a footer attached to the image with "source ↗" (the block's original source URL, when present) and "reverse image search ↗" (Google Lens on the full-size image).

All Lightbox changes are opt-in per image entry, so the other consumers (post embeds, media cards, record pages) are unaffected.

## Verified

- `npx vite build` passes
- Playwright against the built site: no "are.na" text on either page; an unloaded lightbox image measures its correct final box (433×573 for a 1937×2560 portrait) instead of collapsing; thumbnail placeholder applied; both caption links render with correct hrefs; zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp)_