### PR TITLE
Attach the lightbox caption bar and skip redundant Are.na fetches

### DIFF
--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -192,6 +192,9 @@ async function main() {
       blockCount: snap.blocks.length,
       cover: snap.blocks[0]?.thumb || null,
       order: g.value.order ?? 0,
+      // Channel-level change marker: lets the client skip re-paginating
+      // contents when the channel hasn't changed since this snapshot.
+      updatedAt: snap.meta?.updated_at || null,
     };
     galleries.push(gallery);
     await writeJson(`curating-${g.rkey}`, {

--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -39,16 +39,34 @@
   width: 100%;
   max-height: 100%;
   min-height: 0;
+  /* Height budget for the image: leave headroom for the footer (close
+     button) underneath so it doesn't get pushed off-screen on short
+     viewports. A variable because entries with known dimensions also use
+     it to reserve the frame width inline before the image loads. */
+  --lightbox-maxh: calc(100dvh - 8rem);
+}
+
+/* Wrapper around the image and its optional attached caption bar, so the
+   two share a width, radius, and shadow and read as one surface. */
+.lightbox-frame {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 100%;
+  min-height: 0;
+}
+
+.lightbox-frame.has-caption {
+  align-items: stretch;
+  border-radius: var(--radius-2);
+  box-shadow: 0 16px 40px var(--shadow);
+  /* Reserved by the frame-width calc so image + caption stay in budget. */
+  --lightbox-caption-h: 2.5rem;
 }
 
 .lightbox-image {
   display: block;
   max-width: 100%;
-  /* Leave headroom for the footer (close button) underneath so it
-     doesn't get pushed off-screen on short viewports. The budget is a
-     variable because entries with known dimensions also use it to
-     reserve the display box inline before the image loads. */
-  --lightbox-maxh: calc(100dvh - 8rem);
   max-height: var(--lightbox-maxh);
   width: auto;
   height: auto;
@@ -59,18 +77,27 @@
   box-shadow: 0 16px 40px var(--shadow);
 }
 
-/* Optional caption row directly under the image — source / reverse-image
-   search links for the current photo. Same scrim-friendly chrome as the
-   footer text so it reads as part of the control cluster. */
+.lightbox-frame.has-caption .lightbox-image {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-shadow: none;
+}
+
+/* Caption bar attached beneath the image — source / reverse-image search
+   links for the current photo. Continues the image's border and rounds
+   off its bottom corners. */
 .lightbox-caption {
   display: flex;
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: var(--space-3);
-  width: 100%;
-  margin-top: var(--space-2);
-  padding: 0 var(--space-2);
+  gap: var(--space-4);
+  min-height: 2.5rem;
+  padding: var(--space-1) var(--space-3);
+  background: var(--page-edge);
+  border: 1px solid var(--rule);
+  border-top: 1px solid var(--rule-soft);
+  border-radius: 0 0 var(--radius-2) var(--radius-2);
 }
 
 .lightbox-caption-link {
@@ -78,9 +105,8 @@
   font-size: var(--text-xs);
   letter-spacing: 0.06em;
   text-transform: lowercase;
-  color: var(--ink-on-scrim, #fff);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-  opacity: 0.8;
+  color: var(--ink);
+  opacity: 0.75;
   text-decoration: underline;
   text-underline-offset: 0.2em;
 }
@@ -175,7 +201,7 @@
 }
 
 @media (max-width: 540px) {
-  .lightbox-image {
+  .lightbox-figure {
     --lightbox-maxh: calc(100dvh - 7rem);
   }
 }

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -65,17 +65,18 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
   if (count === 0) return null;
   const current = list[active] || list[0];
   const alt = current.alt || '';
-  // With intrinsic dimensions we can size the box before the file arrives:
-  // natural width, clamped by the panel width and by the viewport-height
-  // budget (transferred through the aspect ratio). Without them the image
-  // sizes itself on load, as before.
+  const hasCaption = Boolean(current.sourceUrl || current.searchUrl);
+  // With intrinsic dimensions we can size the frame before the file
+  // arrives: natural width, clamped by the panel width and by the
+  // viewport-height budget (transferred through the aspect ratio, minus
+  // the caption bar when there is one). Without them the image sizes
+  // itself on load, as before.
   const ratio = current.width > 0 && current.height > 0 ? current.width / current.height : null;
-  const reserveStyle = ratio
+  const frameStyle = ratio
     ? {
-        width: `min(${current.width}px, 100%, calc(var(--lightbox-maxh) * ${ratio.toFixed(5)}))`,
-        aspectRatio: `${current.width} / ${current.height}`,
+        width: `min(${current.width}px, 100%, calc((var(--lightbox-maxh) - var(--lightbox-caption-h, 0rem)) * ${ratio.toFixed(5)}))`,
       }
-    : null;
+    : undefined;
   const placeholderStyle =
     current.thumb && !loadedSrcs.has(current.src)
       ? {
@@ -84,6 +85,13 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
           backgroundPosition: 'center',
         }
       : null;
+  const imageStyle = ratio
+    ? {
+        width: '100%',
+        aspectRatio: `${current.width} / ${current.height}`,
+        ...placeholderStyle,
+      }
+    : placeholderStyle || undefined;
   const label = alt
     ? `Image: ${alt}`
     : count > 1
@@ -101,46 +109,51 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
       scrimLabel="Close image"
     >
       <figure className="lightbox-figure">
-        <img
-          key={current.src}
-          src={current.src}
-          alt={alt}
-          width={current.width || undefined}
-          height={current.height || undefined}
-          className="lightbox-image"
-          decoding="async"
-          onLoad={() => markLoaded(current.src)}
-          ref={(el) => {
-            // onLoad can be missed for cache hits that complete before
-            // React attaches the handler; the ref callback catches those.
-            if (el?.complete && el.naturalWidth) markLoaded(current.src);
-          }}
-          style={reserveStyle || placeholderStyle ? { ...reserveStyle, ...placeholderStyle } : undefined}
-        />
-        {(current.sourceUrl || current.searchUrl) && (
-          <figcaption className="lightbox-caption">
-            {current.sourceUrl && (
-              <a
-                href={current.sourceUrl}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="lightbox-caption-link"
-              >
-                source ↗
-              </a>
-            )}
-            {current.searchUrl && (
-              <a
-                href={current.searchUrl}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="lightbox-caption-link"
-              >
-                reverse image search ↗
-              </a>
-            )}
-          </figcaption>
-        )}
+        <div
+          className={`lightbox-frame${hasCaption ? ' has-caption' : ''}`}
+          style={frameStyle}
+        >
+          <img
+            key={current.src}
+            src={current.src}
+            alt={alt}
+            width={current.width || undefined}
+            height={current.height || undefined}
+            className="lightbox-image"
+            decoding="async"
+            onLoad={() => markLoaded(current.src)}
+            ref={(el) => {
+              // onLoad can be missed for cache hits that complete before
+              // React attaches the handler; the ref callback catches those.
+              if (el?.complete && el.naturalWidth) markLoaded(current.src);
+            }}
+            style={imageStyle}
+          />
+          {hasCaption && (
+            <div className="lightbox-caption">
+              {current.sourceUrl && (
+                <a
+                  href={current.sourceUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="lightbox-caption-link"
+                >
+                  source
+                </a>
+              )}
+              {current.searchUrl && (
+                <a
+                  href={current.searchUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="lightbox-caption-link"
+                >
+                  reverse image search
+                </a>
+              )}
+            </div>
+          )}
+        </div>
       </figure>
       <footer className="lightbox-footer">
         {count > 1 && (

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -51,6 +51,7 @@ async function loadGalleries() {
         blockCount: meta?.counts?.blocks ?? null,
         cover,
         order: g.value.order ?? 0,
+        updatedAt: meta?.updated_at || null,
       });
     } catch {
       // A channel that fails live just keeps its snapshot presence (if any).

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import Lightbox from '../components/Lightbox.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, getRecord } from '../lib/atproto.js';
 import { fetchChannelMeta, fetchAllBlocks } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -52,7 +53,17 @@ export default function CuratingChannel() {
       const v = record?.value || {};
       if (!v.arenaSlug || v.enabled === false) return NOT_FOUND;
       const meta = await fetchChannelMeta(v.arenaSlug);
-      const { blocks, truncated } = await fetchAllBlocks(v.arenaSlug);
+      // The meta call carries the channel's updated_at; when it matches
+      // the snapshot we already painted from, reuse those blocks instead
+      // of re-paginating the whole channel (the expensive part).
+      const snap = await fetchSnapshot(`curating-${slug}`).catch(() => null);
+      const snapIsCurrent =
+        snap?.gallery?.arenaSlug === v.arenaSlug &&
+        Boolean(snap?.gallery?.updatedAt) &&
+        snap.gallery.updatedAt === meta?.updated_at;
+      const { blocks, truncated } = snapIsCurrent
+        ? { blocks: snap.blocks || [], truncated: !!snap.truncated }
+        : await fetchAllBlocks(v.arenaSlug);
       return {
         gallery: {
           slug,
@@ -60,6 +71,7 @@ export default function CuratingChannel() {
           title: v.title || meta?.title || slug,
           description: v.description || meta?.description || '',
           blockCount: blocks.length,
+          updatedAt: meta?.updated_at || null,
         },
         truncated,
         blocks,


### PR DESCRIPTION
## What

Two follow-ups to #63:

- **Attached caption bar**: the lightbox's source / reverse-image-search links now live in a bar visually connected to the image — same width, continued border, page-edge background, shared shadow via a common frame wrapper — instead of floating as bare text over the scrim. Arrow glyphs dropped from the link labels. The pre-load size reservation subtracts the caption bar's height so image plus caption stay within the viewport budget.
- **Fetch skipping**: snapshots now record each channel's are.na `updated_at`. The gallery page's live refresh makes one cheap meta request and, when `updated_at` matches the snapshot it just painted from, reuses the snapshot's blocks instead of re-paginating the entire channel contents on every visit. A changed channel (or a snapshot missing the marker) falls through to the full fetch as before.

## Verified

- `npx vite build` passes
- Playwright: caption bar width exactly matches the image (before and after arrow-key navigation), flush attachment with background and 1px border, plain-text labels, no page errors
- Node check of the freshness comparison against the live channel: matching `updated_at` skips pagination, stale timestamp falls through to a full fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkkbMwkSgb2tQZsn9fCicp)_