### PR TITLE
Mothing: identify to iNaturalist, skip redundant fetches, incremental mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,25 @@ Plus `fm.teal.alpha.feed.play` (teal.fm) for the now-playing signal.
 The page paints from the build-time `public/data/mothing.json` snapshot and
 refreshes live from the iNaturalist API in the browser.
 
-To also keep an owned copy on the PDS, run the mirror (idempotent):
+To also keep an owned copy on the PDS, run the mirror:
 
 ```sh
 BSKY_IDENTIFIER=dame.is BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
-  node scripts/mirror-inaturalist.mjs           # add --prune to drop removed obs
+  node scripts/mirror-inaturalist.mjs           # --full to force a complete resync
 ```
 
-A daily Vercel cron (`/api/mirror-mothing`, see `vercel.json`) does the same
-using `BSKY_APP_PASSWORD` (+ optional `BSKY_IDENTIFIER`) from the environment;
-set `CRON_SECRET` to lock the endpoint down.
+The mirror is incremental: a cheap freshness check (one small request) skips
+the run entirely when nothing changed; otherwise it re-pulls only observations
+changed since the last sync (via iNaturalist's `updated_since`), writes just
+those plus the refreshed summary, and deletes records for observations removed
+upstream. `--dry-run` plans without writing; `--full` ignores the freshness
+marker. A daily Vercel cron (`/api/mirror-mothing`, see `vercel.json`) runs the
+same sync using `BSKY_APP_PASSWORD` (+ optional `BSKY_IDENTIFIER`); set
+`CRON_SECRET` to lock the endpoint down.
+
+The `/mothing` page applies the same freshness check in the browser: it paints
+from the snapshot and only re-pulls the full observation set from iNaturalist
+when the cheap signature says something actually changed.
 
 ## Local development
 

--- a/api/mirror-mothing.js
+++ b/api/mirror-mothing.js
@@ -2,10 +2,10 @@
 // the PDS. Wired into vercel.json as a daily cron; the same work can be run
 // locally with `node scripts/mirror-inaturalist.mjs`.
 //
-// Writes `is.dame.mothing/self` (summary) + one
-// `is.dame.mothing.observation/<inatId>` record per observation. Location
-// data is stripped upstream in `src/lib/inaturalist.js` and never reaches
-// the PDS.
+// Incremental: a cheap freshness check skips the run when nothing changed;
+// otherwise only changed/new observations are re-pulled and written, and
+// removed ones are deleted. Location data is stripped upstream in
+// `src/lib/inaturalist.js` and never reaches the PDS.
 //
 // Auth: if CRON_SECRET is set, the request must carry
 // `Authorization: Bearer <CRON_SECRET>` (Vercel sends this automatically for
@@ -15,29 +15,9 @@ import { AtpAgent } from '@atproto/api';
 
 import { ME_HANDLE, INATURALIST_USER, MOTHING_NSID } from '../src/config.js';
 import { resolveIdentifier } from '../src/lib/atproto.js';
-import { fetchMothData, buildMirrorWrites } from '../src/lib/inaturalist.js';
+import { syncMothingMirror } from '../src/lib/mothingMirror.js';
 
 export const config = { maxDuration: 60 };
-
-async function pool(items, size, worker) {
-  let i = 0;
-  let ok = 0;
-  let fail = 0;
-  await Promise.all(
-    Array.from({ length: Math.min(size, items.length) }, async () => {
-      while (i < items.length) {
-        const item = items[i++];
-        try {
-          await worker(item);
-          ok++;
-        } catch {
-          fail++;
-        }
-      }
-    }),
-  );
-  return { ok, fail };
-}
 
 export default async function handler(req, res) {
   const secret = process.env.CRON_SECRET;
@@ -55,34 +35,29 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { stats, observations } = await fetchMothData({ user: INATURALIST_USER });
-    const now = new Date().toISOString();
-    const { summary, records } = buildMirrorWrites({ observations, stats, now });
-    const writes = [summary, ...records];
-
     const { did, pds } = await resolveIdentifier(identifier);
     const agent = new AtpAgent({ service: pds });
     await agent.login({ identifier, password });
 
-    const { ok, fail } = await pool(writes, 6, async (w) => {
-      await agent.com.atproto.repo.putRecord({
-        repo: did,
-        collection: w.collection,
-        rkey: w.rkey,
-        record: w.value,
-        validate: false,
-      });
+    const report = await syncMothingMirror({
+      agent,
+      did,
+      user: INATURALIST_USER,
+      log: (...a) => console.log('[mirror-mothing]', ...a),
     });
 
-    return res.status(fail ? 207 : 200).json({
+    return res.status(report.failed ? 207 : 200).json({
       ok: true,
       user: INATURALIST_USER,
-      observations: observations.length,
-      species: stats.speciesCount,
-      written: ok,
-      failed: fail,
+      noop: Boolean(report.noop),
+      changed: report.changed ?? 0,
+      written: report.written ?? 0,
+      deleted: report.deleted ?? 0,
+      failed: report.failed ?? 0,
+      observations: report.observations,
+      species: report.species,
       summary: `at://${did}/${MOTHING_NSID}/self`,
-      at: now,
+      at: new Date().toISOString(),
     });
   } catch (err) {
     return res.status(502).json({ error: err?.message || 'mirror failed' });

--- a/lexicons/is.dame.mothing.json
+++ b/lexicons/is.dame.mothing.json
@@ -28,6 +28,7 @@
           },
           "earliestDate": { "type": "string", "description": "Date of the earliest observation (YYYY-MM-DD)." },
           "latestDate":   { "type": "string", "description": "Date of the most recent observation (YYYY-MM-DD)." },
+          "lastSyncedAt": { "type": "string", "format": "datetime", "description": "UTC instant of the most recent upstream edit seen; the incremental mirror's freshness marker." },
           "topSpecies": {
             "type": "array",
             "description": "Most-observed taxa, most first.",

--- a/scripts/mirror-inaturalist.mjs
+++ b/scripts/mirror-inaturalist.mjs
@@ -7,31 +7,27 @@
 // mirrored — `src/lib/inaturalist.js` strips coordinates, place names, and
 // timezone before anything is built.
 //
-// Idempotent: every record is written with `putRecord` keyed by its iNat id
-// (`rkey`), so re-running updates records in place. Pass `--prune` to also
-// delete observation records that no longer exist in iNaturalist.
+// Incremental by default: a cheap freshness check skips the run entirely when
+// nothing changed; otherwise it re-pulls only observations changed since the
+// last sync, writes just those (plus the refreshed summary), and deletes
+// records for observations removed upstream. Pass `--full` to force a
+// complete resync.
 //
 // Usage:
 //   BSKY_IDENTIFIER=dame.is BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
-//     node scripts/mirror-inaturalist.mjs [--dry-run] [--prune] [--max N] [--pds url]
+//     node scripts/mirror-inaturalist.mjs [--dry-run] [--full] [--pds url]
 //
-//   --dry-run   Build + print every record without writing anything.
-//   --prune     Delete PDS observation records absent from the fresh pull.
-//   --max N     Cap how many observations to mirror (default: all).
+//   --dry-run   Plan the sync and print what would change, writing nothing.
+//   --full      Ignore the freshness marker and resync every observation.
 //   --pds URL   Override the PDS endpoint (default: resolved from your DID).
 //
 // Get an app password at https://bsky.app/settings/app-passwords. Never commit it.
 
 import { AtpAgent } from '@atproto/api';
 
-import {
-  ME_HANDLE,
-  INATURALIST_USER,
-  MOTHING_NSID,
-  MOTHING_OBSERVATION_NSID,
-} from '../src/config.js';
-import { resolveIdentifier, listRecords, rkeyFromAtUri } from '../src/lib/atproto.js';
-import { fetchMothData, buildMirrorWrites } from '../src/lib/inaturalist.js';
+import { ME_HANDLE, INATURALIST_USER, MOTHING_NSID } from '../src/config.js';
+import { resolveIdentifier } from '../src/lib/atproto.js';
+import { syncMothingMirror } from '../src/lib/mothingMirror.js';
 
 const log = (...a) => console.log('[mirror-inat]', ...a);
 const die = (msg) => {
@@ -40,49 +36,19 @@ const die = (msg) => {
 };
 
 function parseArgs(argv) {
-  const args = { dryRun: false, prune: false, max: 1000, pds: null };
+  const args = { dryRun: false, full: false, pds: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--dry-run') args.dryRun = true;
-    else if (a === '--prune') args.prune = true;
-    else if (a === '--max') args.max = Number(argv[++i]) || args.max;
+    else if (a === '--full') args.full = true;
     else if (a === '--pds') args.pds = argv[++i];
     else die(`unknown argument: ${a}`);
   }
   return args;
 }
 
-// Run `worker` over `items` with bounded concurrency; collect { ok, fail }.
-async function pool(items, size, worker) {
-  let i = 0;
-  let ok = 0;
-  let fail = 0;
-  const runners = Array.from({ length: Math.min(size, items.length) }, async () => {
-    while (i < items.length) {
-      const idx = i++;
-      try {
-        await worker(items[idx]);
-        ok++;
-      } catch (err) {
-        fail++;
-        console.error(`[mirror-inat] ✗ ${items[idx]?.collection}/${items[idx]?.rkey}: ${err.message}`);
-      }
-    }
-  });
-  await Promise.all(runners);
-  return { ok, fail };
-}
-
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-
-  log(`fetching moths for iNaturalist user "${INATURALIST_USER}"…`);
-  const { stats, observations } = await fetchMothData({ user: INATURALIST_USER, max: args.max });
-  log(`fetched ${observations.length} observation(s), ${stats.speciesCount} species.`);
-
-  const now = new Date().toISOString();
-  const { summary, records } = buildMirrorWrites({ observations, stats, now });
-  const writes = [summary, ...records];
 
   const identifier = process.env.BSKY_IDENTIFIER || process.env.ATP_IDENTIFIER || ME_HANDLE;
   const password = process.env.BSKY_APP_PASSWORD || process.env.ATP_APP_PASSWORD;
@@ -99,20 +65,7 @@ async function main() {
   log(`identity: ${identifier} → ${did}`);
   log(`pds: ${pds}`);
 
-  if (args.dryRun) {
-    log('--dry-run: the following records would be written:\n');
-    console.log(`# at://${did}/${summary.collection}/${summary.rkey}`);
-    console.log(JSON.stringify(summary.value, null, 2));
-    console.log(`\n… and ${records.length} observation record(s), e.g.:\n`);
-    if (records[0]) {
-      console.log(`# at://${did}/${records[0].collection}/${records[0].rkey}`);
-      console.log(JSON.stringify(records[0].value, null, 2));
-    }
-    log(`dry run complete — ${writes.length} record(s) not written.`);
-    return;
-  }
-
-  if (!password) {
+  if (!password && !args.dryRun) {
     die(
       'missing app password. Set BSKY_APP_PASSWORD (and optionally BSKY_IDENTIFIER). ' +
         'Create one at https://bsky.app/settings/app-passwords. Use --dry-run to preview.',
@@ -120,55 +73,34 @@ async function main() {
   }
 
   const agent = new AtpAgent({ service: pds });
-  try {
-    await agent.login({ identifier, password });
-  } catch (err) {
-    return die(`login failed: ${err.message}`);
-  }
-  log(`signed in as ${agent.session?.handle || identifier}`);
-
-  const { ok, fail } = await pool(writes, 6, async (w) => {
-    await agent.com.atproto.repo.putRecord({
-      repo: did,
-      collection: w.collection,
-      rkey: w.rkey,
-      record: w.value,
-      validate: false, // is.dame.* lexicons aren't published to the PDS
-    });
-  });
-  log(`wrote ${ok}/${writes.length} record(s)${fail ? ` (${fail} failed)` : ''}.`);
-
-  if (args.prune) {
-    const keep = new Set(records.map((r) => r.rkey));
-    let existing = [];
+  if (password) {
     try {
-      existing = await listRecords(pds, { repo: did, collection: MOTHING_OBSERVATION_NSID, max: 5000 });
+      await agent.login({ identifier, password });
+      log(`signed in as ${agent.session?.handle || identifier}`);
     } catch (err) {
-      log(`prune skipped — could not list existing records: ${err.message}`);
+      return die(`login failed: ${err.message}`);
     }
-    const stale = existing
-      .map((r) => rkeyFromAtUri(r.uri))
-      .filter((rk) => rk && !keep.has(rk));
-    if (stale.length) {
-      const res = await pool(
-        stale.map((rk) => ({ collection: MOTHING_OBSERVATION_NSID, rkey: rk })),
-        6,
-        async (d) => {
-          await agent.com.atproto.repo.deleteRecord({
-            repo: did,
-            collection: d.collection,
-            rkey: d.rkey,
-          });
-        },
-      );
-      log(`pruned ${res.ok}/${stale.length} stale observation record(s).`);
-    } else {
-      log('prune: nothing stale to remove.');
-    }
+  } else {
+    // --dry-run without credentials: the summary/record reads are public, so
+    // an unauthenticated agent can still plan the sync.
+    log('no app password — dry-run planning with public reads only.');
   }
 
-  log(`done — summary at://${did}/${MOTHING_NSID}/self`);
-  if (fail) process.exitCode = 1;
+  const report = await syncMothingMirror({
+    agent,
+    did,
+    user: INATURALIST_USER,
+    full: args.full,
+    dryRun: args.dryRun,
+    log,
+  });
+
+  if (report.noop) {
+    log('up to date — nothing to do.');
+  } else {
+    log(`done — summary at://${did}/${MOTHING_NSID}/self`);
+  }
+  if (report.failed) process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -23,13 +23,31 @@ import {
 
 const PER_PAGE = 200; // iNaturalist's max page size.
 
+// iNaturalist asks API consumers to identify themselves. Sent from Node
+// (prefetch / mirror / cron); browsers forbid setting User-Agent and silently
+// drop it, which is fine — this is politeness for the server-side callers.
+const USER_AGENT = 'dame.is-mothing/1.0 (+https://dame.is/mothing; iNaturalist mirror)';
+
 async function fetchJson(url) {
-  const res = await fetch(url);
+  const res = await fetch(url, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`iNaturalist HTTP ${res.status} for ${url} :: ${text.slice(0, 160)}`);
   }
   return res.json();
+}
+
+/**
+ * Normalize an iNaturalist `updated_at` (which carries a tz offset — a coarse
+ * location hint) to a UTC instant string. Used only as an opaque freshness
+ * signature; never persisted to a PDS record.
+ */
+export function toUtcInstant(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
 /**
@@ -211,10 +229,13 @@ function nightMinutes(o) {
 }
 
 /**
- * Fetch every moth observation for a user, newest first, and normalize it.
- * Auto-paginates up to `max`. Location is stripped by `normalizeObservation`.
+ * Fetch moth observations for a user, newest first, and normalize them.
+ * Auto-paginates up to `max`. Pass `since` (an ISO instant) to fetch only
+ * observations changed since then via iNaturalist's `updated_since` — the
+ * incremental path the mirror uses so it re-pulls only what actually moved.
+ * Location is stripped by `normalizeObservation`.
  */
-export async function fetchMothObservations({ user = INATURALIST_USER, max = 1000 } = {}) {
+export async function fetchMothObservations({ user = INATURALIST_USER, max = 1000, since = null } = {}) {
   const out = [];
   let page = 1;
   while (out.length < max) {
@@ -225,6 +246,7 @@ export async function fetchMothObservations({ user = INATURALIST_USER, max = 100
       order: 'desc',
       order_by: 'observed_on',
     });
+    if (since) params.set('updated_since', since);
     const data = await fetchJson(`${INATURALIST_API}/observations?${params}`);
     const batch = Array.isArray(data?.results) ? data.results : [];
     for (const o of batch) {
@@ -236,6 +258,95 @@ export async function fetchMothObservations({ user = INATURALIST_USER, max = 100
     page += 1;
   }
   return out;
+}
+
+/**
+ * A cheap freshness signature for the moth set: one tiny request that returns
+ * the total count plus the most-recent edit instant (in UTC). Comparing this
+ * against a stored signature tells us whether a full pull is even needed —
+ * without downloading every observation.
+ */
+export async function fetchMothSignature({ user = INATURALIST_USER } = {}) {
+  const params = new URLSearchParams({
+    ...baseParams(user),
+    per_page: '1',
+    order: 'desc',
+    order_by: 'updated_at',
+  });
+  const data = await fetchJson(`${INATURALIST_API}/observations?${params}`);
+  return {
+    count: data?.total_results ?? 0,
+    latestUpdatedAt: toUtcInstant(data?.results?.[0]?.updated_at) || null,
+  };
+}
+
+/**
+ * Fetch just the current observation ids (authoritative set). Used by the
+ * mirror to reconcile deletions — iNaturalist's `updated_since` never reports
+ * removals, so when counts disagree we diff against the live id list.
+ */
+export async function fetchMothIds({ user = INATURALIST_USER, max = 10000 } = {}) {
+  const ids = [];
+  let page = 1;
+  while (ids.length < max) {
+    const params = new URLSearchParams({
+      ...baseParams(user),
+      per_page: String(PER_PAGE),
+      page: String(page),
+      order: 'asc',
+      order_by: 'id',
+      only_id: 'true',
+    });
+    const data = await fetchJson(`${INATURALIST_API}/observations?${params}`);
+    const batch = Array.isArray(data?.results) ? data.results : [];
+    for (const o of batch) if (o?.id != null) ids.push(o.id);
+    const total = data?.total_results ?? ids.length;
+    if (batch.length === 0 || ids.length >= total) break;
+    page += 1;
+  }
+  return ids;
+}
+
+/**
+ * Reconstruct a normalized observation from a stored
+ * `is.dame.mothing.observation` record value. Lets the mirror rebuild the
+ * full set from the PDS copy and overlay only the changed observations,
+ * instead of re-downloading everything from iNaturalist.
+ */
+export function observationFromRecord(v) {
+  if (!v) return null;
+  const observedTime = v.observedTime || null;
+  const observedHour = observedTime
+    ? Number(observedTime.slice(0, 2))
+    : Number.isInteger(v.observedHour)
+      ? v.observedHour
+      : null;
+  const t = v.taxon || {};
+  return {
+    id: v.inatId,
+    uuid: v.uuid || null,
+    url: v.url || null,
+    observedDate: v.observedDate || null,
+    observedTime,
+    observedHour,
+    qualityGrade: v.qualityGrade || null,
+    description: v.description || null,
+    taxon: {
+      id: t.id ?? null,
+      name: t.name || null,
+      commonName: t.commonName || null,
+      rank: t.rank || null,
+      iconicTaxon: t.iconicTaxon || null,
+    },
+    photos: Array.isArray(v.photos)
+      ? v.photos.map((p) => ({
+          id: p.id,
+          url: p.url,
+          licenseCode: p.licenseCode || null,
+          attribution: p.attribution || null,
+        }))
+      : [],
+  };
 }
 
 /**
@@ -310,9 +421,12 @@ export function computeStats(observations, { user = INATURALIST_USER } = {}) {
  * caller stamps).
  */
 export async function fetchMothData({ user = INATURALIST_USER, max = 1000 } = {}) {
+  // Signature first, so a change during pagination trips the next comparison
+  // (self-healing) rather than being silently baked into a stale snapshot.
+  const sync = await fetchMothSignature({ user }).catch(() => null);
   const observations = await fetchMothObservations({ user, max });
   const stats = computeStats(observations, { user });
-  return { user, stats, observations };
+  return { user, stats, observations, sync };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/mothingMirror.js
+++ b/src/lib/mothingMirror.js
@@ -1,0 +1,199 @@
+// Incremental iNaturalist → PDS mirror, shared by the CLI script
+// (`scripts/mirror-inaturalist.mjs`) and the cron function
+// (`api/mirror-mothing.js`).
+//
+// The old mirror re-fetched every observation and re-wrote all ~240 records
+// on every run. This one:
+//   1. Takes a cheap freshness signature (1 tiny request). If it matches the
+//      marker stored on the summary record, nothing changed → no-op.
+//   2. Otherwise reconstructs the full set from the PDS copy and overlays
+//      only the observations iNaturalist reports as changed since the last
+//      sync (`updated_since`), so we re-download just what moved.
+//   3. Writes only the changed/new observation records + the refreshed
+//      summary, and deletes records for observations removed upstream.
+//
+// It never stores location: it only ever handles already-normalized,
+// location-free observations (and reconstructs them from location-free
+// records).
+
+import {
+  fetchMothSignature,
+  fetchMothObservations,
+  fetchMothIds,
+  observationFromRecord,
+  computeStats,
+  buildMirrorWrites,
+} from './inaturalist.js';
+import { rkeyFromAtUri } from './atproto.js';
+import { INATURALIST_USER, MOTHING_NSID, MOTHING_OBSERVATION_NSID } from '../config.js';
+
+async function pool(items, size, worker) {
+  let i = 0;
+  let ok = 0;
+  let fail = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(size, items.length) }, async () => {
+      while (i < items.length) {
+        const item = items[i++];
+        try {
+          await worker(item);
+          ok++;
+        } catch (err) {
+          fail++;
+          if (item?._onError) item._onError(err);
+        }
+      }
+    }),
+  );
+  return { ok, fail };
+}
+
+async function readSummary(agent, did) {
+  try {
+    const res = await agent.com.atproto.repo.getRecord({
+      repo: did,
+      collection: MOTHING_NSID,
+      rkey: 'self',
+    });
+    return res?.data?.value || null;
+  } catch {
+    return null; // no summary yet → first run
+  }
+}
+
+async function listObservationRecords(agent, did) {
+  const out = [];
+  let cursor;
+  do {
+    const res = await agent.com.atproto.repo.listRecords({
+      repo: did,
+      collection: MOTHING_OBSERVATION_NSID,
+      limit: 100,
+      cursor,
+    });
+    const records = res?.data?.records || [];
+    for (const r of records) out.push({ rkey: rkeyFromAtUri(r.uri), value: r.value });
+    cursor = res?.data?.cursor;
+    if (!records.length) break;
+  } while (cursor);
+  return out;
+}
+
+/**
+ * Run one mirror sync. `agent` must be a logged-in AtpAgent for `did`.
+ * Returns a small report; with `dryRun` it plans without writing.
+ */
+export async function syncMothingMirror({
+  agent,
+  did,
+  user = INATURALIST_USER,
+  now,
+  full = false,
+  dryRun = false,
+  log = () => {},
+}) {
+  const ts = now || new Date().toISOString();
+
+  const signature = await fetchMothSignature({ user });
+  const summary = await readSummary(agent, did);
+
+  const unchanged =
+    !full &&
+    summary &&
+    signature.count === summary.observationCount &&
+    signature.latestUpdatedAt &&
+    signature.latestUpdatedAt === summary.lastSyncedAt;
+  if (unchanged) {
+    log(`no changes (count=${signature.count}, latest=${signature.latestUpdatedAt}) — skipping.`);
+    return { noop: true, signature, written: 0, deleted: 0, changed: 0 };
+  }
+
+  const existing = await listObservationRecords(agent, did);
+  const existingRkeys = existing.map((r) => r.rkey).filter(Boolean);
+
+  // Incremental unless forced or first-run: only re-pull what changed.
+  const since = full ? null : summary?.lastSyncedAt || null;
+  const changed = await fetchMothObservations({ user, since });
+  log(since ? `changed since ${since}: ${changed.length}` : `full pull: ${changed.length}`);
+
+  // Rebuild the full set from the PDS copy, then overlay the changed ones.
+  const merged = new Map();
+  for (const r of existing) {
+    const obs = observationFromRecord(r.value);
+    if (obs?.id != null) merged.set(String(obs.id), obs);
+  }
+  for (const o of changed) merged.set(String(o.id), o);
+
+  // Deletions never show up in `updated_since`; when the merged size disagrees
+  // with iNaturalist's authoritative count, diff against the live id list.
+  if (merged.size !== signature.count) {
+    const liveIds = new Set((await fetchMothIds({ user })).map(String));
+    for (const id of Array.from(merged.keys())) if (!liveIds.has(id)) merged.delete(id);
+  }
+  const mergedIds = new Set(merged.keys());
+  const deletes = existingRkeys.filter((rk) => !mergedIds.has(rk));
+
+  // Recompute aggregates from the full merged set so the summary stays exact.
+  const observations = Array.from(merged.values());
+  const stats = computeStats(observations, { user });
+  const { summary: summaryWrite, records } = buildMirrorWrites({ observations, stats, now: ts });
+  summaryWrite.value.lastSyncedAt = signature.latestUpdatedAt || ts;
+
+  // Write only the observations that actually changed (or, on a full/first
+  // run, `changed` is the whole set).
+  const changedIds = new Set(changed.map((o) => String(o.id)));
+  const recordWrites = records.filter((r) => changedIds.has(String(r.rkey)));
+  const writes = [summaryWrite, ...recordWrites];
+
+  if (dryRun) {
+    log(
+      `dry run — would write ${writes.length} record(s) ` +
+        `(${recordWrites.length} observation(s) + summary), delete ${deletes.length}.`,
+    );
+    return {
+      dryRun: true,
+      signature,
+      observations: observations.length,
+      species: stats.speciesCount,
+      wouldWrite: writes.length,
+      wouldDelete: deletes.length,
+      changed: changed.length,
+    };
+  }
+
+  const putResult = await pool(writes, 6, async (w) => {
+    await agent.com.atproto.repo.putRecord({
+      repo: did,
+      collection: w.collection,
+      rkey: w.rkey,
+      record: w.value,
+      validate: false, // is.dame.* lexicons aren't published to the PDS
+    });
+  });
+
+  let delResult = { ok: 0, fail: 0 };
+  if (deletes.length) {
+    delResult = await pool(deletes, 6, async (rkey) => {
+      await agent.com.atproto.repo.deleteRecord({
+        repo: did,
+        collection: MOTHING_OBSERVATION_NSID,
+        rkey,
+      });
+    });
+  }
+
+  log(
+    `wrote ${putResult.ok}/${writes.length}, deleted ${delResult.ok}/${deletes.length}` +
+      `${putResult.fail || delResult.fail ? ` (${putResult.fail + delResult.fail} failed)` : ''}.`,
+  );
+
+  return {
+    signature,
+    observations: observations.length,
+    species: stats.speciesCount,
+    written: putResult.ok,
+    deleted: delResult.ok,
+    failed: putResult.fail + delResult.fail,
+    changed: changed.length,
+  };
+}

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 import PageShell from '../components/PageShell.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
-import { fetchMothData, photoUrl, buildSessions } from '../lib/inaturalist.js';
+import { fetchMothData, fetchMothSignature, photoUrl, buildSessions } from '../lib/inaturalist.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
 import { ME_DID, INATURALIST_USER } from '../config.js';
 import './Mothing.css';
 
@@ -92,7 +93,23 @@ export default function Mothing() {
   const { items, status } = useLiveFeed({
     name: 'mothing',
     strategy: 'snapshot-first',
-    fetchLive: () => fetchMothData({ user: INATURALIST_USER }),
+    // The snapshot is refreshed on every build (≤6h old). Before re-pulling
+    // all observations, take a cheap signature and, if it matches the
+    // snapshot's, reuse the snapshot instead of downloading everything again.
+    fetchLive: async () => {
+      const snap = await fetchSnapshot('mothing');
+      if (snap?.sync?.latestUpdatedAt) {
+        try {
+          const sig = await fetchMothSignature({ user: INATURALIST_USER });
+          if (sig.count === snap.sync.count && sig.latestUpdatedAt === snap.sync.latestUpdatedAt) {
+            return snap; // nothing changed upstream — no full pull needed
+          }
+        } catch {
+          // Signature check failed — fall through to a normal full fetch.
+        }
+      }
+      return fetchMothData({ user: INATURALIST_USER });
+    },
     mapItems: (data) => {
       if (!data) return null;
       return {


### PR DESCRIPTION
Efficiency pass on how `/mothing` talks to iNaturalist — stop re-fetching data we already have.

## Changes
1. **User-Agent** — `fetchJson` now identifies itself to iNaturalist (applied by the Node callers; browsers drop it, which is fine).
2. **Conditional live-refresh** — the snapshot carries a cheap freshness signature `{ count, latestUpdatedAt(UTC) }`. On each `/mothing` visit the page takes the same one-request signature and, if it matches, **reuses the snapshot** instead of re-pulling every observation. `fetchMothSignature` added; `fetchMothData` returns `sync`.
3. **Incremental mirror** — new `src/lib/mothingMirror.js`, shared by the CLI and cron. It (a) **no-ops** when the signature matches the marker stored on the summary; (b) otherwise reconstructs the full set from the PDS copy and overlays only observations changed since the last sync (`updated_since`), writing just those + the refreshed summary; (c) reconciles deletions via the live id list. `is.dame.mothing` gains a `lastSyncedAt` marker; the CLI swaps `--prune` for `--full` (deletion is now automatic).

## Privacy
Location stays fully excluded — the signature uses a UTC-normalized edit instant (no tz offset), and the mirror only ever handles already-normalized, location-free observations.

## Verification
Tested against real data with a mock PDS: no-op (signature match → no list/write), incremental (40 of 238 re-pulled, 41 writes vs 239, summary still exact), and deletion-reconcile (stale record removed) paths all behave. Snapshot leak-check clean; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiBF6gexaUPNuN4q7P489t)_