### PR TITLE
Overlay breadcrumb chrome to avoid scroll jerk; raise reveal threshold

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -20,7 +20,11 @@
   background: var(--surface-raised);
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
-  overflow: hidden;
+  /* `visible` (not `hidden`) so the tertiary breadcrumb — absolutely
+     positioned at the header's bottom edge — can spill below the bar
+     instead of being clipped. The secondary/atmosphere wrap still clips
+     its own height animation via its inline `overflow: hidden`. */
+  overflow: visible;
   width: 100%;
   /* Chrome bar caps at 65rem — narrower than the page's 72rem main
      column, so on wide screens the bar sits as a tighter strip
@@ -78,9 +82,31 @@
   padding: var(--space-3) 0;
 }
 
-/* Tertiary chrome: the scroll-driven breadcrumb strip. Sits below the
-   secondary (atmosphere) row when both are visible, separated by the same
-   soft hairline. Kept short so it reads as quiet orientation metadata. */
+/* Tertiary chrome: the scroll-driven breadcrumb strip. It's absolutely
+   positioned at the header's bottom edge (top: 100%) rather than sitting in
+   the header's normal flow — so revealing it grows nothing in the document
+   and the page content beneath never shifts/jerks mid-scroll. It overlays
+   the top sliver of content while shown, reading as an extension of the
+   chrome. Anchored below the whole header, it naturally lands beneath the
+   secondary row when that's expanded too. */
+.chrome-bar-tertiary-wrap {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--rule);
+  /* inline `overflow: hidden` on the element animates the height reveal so
+     the strip unrolls downward from under the bar. */
+}
+
+@media (min-width: 65rem) {
+  .chrome-bar-tertiary-wrap {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
+}
+
 .chrome-bar-tertiary {
   border-top: 1px solid var(--rule-soft);
   overflow: hidden;

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -367,9 +367,10 @@ function buildCrumbs(pathname) {
 
 /** True once the window is scrolled past `threshold` px from the top.
  *  Drives the tertiary breadcrumb: it slides down as you leave the top of
- *  the page and folds back up on return. Threshold roughly tracks the
- *  chrome bar's own height so the crumb doesn't flicker on tiny nudges. */
-function useScrolledDown(threshold = 64) {
+ *  the page and folds back up on return. The threshold is a few hundred px
+ *  so the crumb only appears once you've deliberately scrolled into the
+ *  page, not on the first small nudge away from the top. */
+function useScrolledDown(threshold = 220) {
   const [down, setDown] = useState(false);
   useEffect(() => {
     function onScroll() {


### PR DESCRIPTION
Follow-up to the scroll-driven breadcrumb chrome.

**No more scroll jerk.** The tertiary breadcrumb strip used to live in the sticky header's normal flow, so expanding it grew the header and pushed page content down ~36px mid-scroll — a visible jump. It's now absolutely positioned at the header's bottom edge (`top: 100%`), overlaying the top sliver of content, so revealing/collapsing it changes nothing in the document layout. The header's `overflow` becomes `visible` to let the strip spill below the bar; the secondary/atmosphere row still self-clips via its own inline overflow. The same height/opacity unroll animation is preserved.

**Appears further down.** Raised the scroll threshold from 64px to 220px so the crumb only shows once you've deliberately scrolled into the page.

## Verification
Headless Chromium at a 500px viewport:
- crumb hidden at 0px and 150px, shown by 400px (new threshold)
- content's document position measured 58px whether the breadcrumb is hidden or shown — shift of 0, confirming no layout jerk

Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM)_