### PR TITLE
Keep breadcrumb mounted so collapsing it doesn't stall the scroll

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -95,9 +95,12 @@
   left: 0;
   right: 0;
   background: var(--surface-raised);
-  border-bottom: 1px solid var(--rule);
+  /* Keep this strip out of the browser's scroll-anchoring calculation so its
+     collapse never nudges the scroll position. */
+  overflow-anchor: none;
   /* inline `overflow: hidden` on the element animates the height reveal so
-     the strip unrolls downward from under the bar. */
+     the strip unrolls downward from under the bar. The bottom rule lives on
+     the inner row (not here) so nothing paints when collapsed to height 0. */
 }
 
 @media (min-width: 65rem) {
@@ -109,6 +112,7 @@
 
 .chrome-bar-tertiary {
   border-top: 1px solid var(--rule-soft);
+  border-bottom: 1px solid var(--rule);
   overflow: hidden;
   min-height: 0;
 }

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -130,32 +130,36 @@ export default function ChromeBar() {
           )}
         </AnimatePresence>
 
-        <AnimatePresence initial={false}>
-          {showBreadcrumb && (
-            <motion.div
-              key="tertiary"
-              id="chrome-bar-tertiary"
-              className="chrome-bar-tertiary-wrap"
-              initial={{ height: 0 }}
-              animate={{ height: 'auto' }}
-              exit={{ height: 0 }}
-              transition={{ duration: reduce ? 0 : 0.32, ease: [0.32, 0.72, 0, 1] }}
-              style={{ overflow: 'hidden' }}
-            >
-              <div className="chrome-bar-row chrome-bar-tertiary">
-                <motion.nav
-                  className="chrome-breadcrumb"
-                  aria-label="Breadcrumb"
-                  initial={{ opacity: 0, y: -6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -6 }}
-                  transition={{
-                    duration: reduce ? 0 : 0.24,
-                    ease: [0.22, 0.61, 0.36, 1],
-                    delay: reduce ? 0 : 0.04,
-                  }}
-                >
-                  <ol className="chrome-crumbs">
+        {/* Breadcrumb stays mounted the whole time we're off the home page and
+            only its height/opacity animate on scroll. Mounting/unmounting a DOM
+            node synchronously inside the scroll handler (as AnimatePresence did)
+            interrupted the browser's momentum scroll on the way up — the node
+            removal stalled the scroll. Persisting the node avoids that entirely
+            while keeping the same unroll look. */}
+        {crumbs.length > 0 && (
+          <motion.div
+            id="chrome-bar-tertiary"
+            className="chrome-bar-tertiary-wrap"
+            initial={false}
+            animate={{ height: showBreadcrumb ? 'auto' : 0 }}
+            transition={{ duration: reduce ? 0 : 0.32, ease: [0.32, 0.72, 0, 1] }}
+            style={{ overflow: 'hidden' }}
+            inert={showBreadcrumb ? undefined : ''}
+            aria-hidden={showBreadcrumb ? undefined : true}
+          >
+            <div className="chrome-bar-row chrome-bar-tertiary">
+              <motion.nav
+                className="chrome-breadcrumb"
+                aria-label="Breadcrumb"
+                initial={false}
+                animate={{ opacity: showBreadcrumb ? 1 : 0, y: showBreadcrumb ? 0 : -6 }}
+                transition={{
+                  duration: reduce ? 0 : 0.24,
+                  ease: [0.22, 0.61, 0.36, 1],
+                  delay: reduce ? 0 : (showBreadcrumb ? 0.04 : 0),
+                }}
+              >
+                <ol className="chrome-crumbs">
                     <li className="chrome-crumb">
                       <Link to="/" className="chrome-crumb-link chrome-crumb-root" aria-label="Home">
                         /
@@ -182,12 +186,11 @@ export default function ChromeBar() {
                         </li>
                       );
                     })}
-                  </ol>
-                </motion.nav>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+                </ol>
+              </motion.nav>
+            </div>
+          </motion.div>
+        )}
       </header>
 
       <ChromeBarBottom dockOpen={dockOpen} toggleDock={toggleDock} />
@@ -373,12 +376,20 @@ function buildCrumbs(pathname) {
 function useScrolledDown(threshold = 220) {
   const [down, setDown] = useState(false);
   useEffect(() => {
+    let frame = 0;
     function onScroll() {
-      setDown((window.scrollY || 0) > threshold);
+      // Coalesce through rAF so the state flip (and the height animation it
+      // drives) never runs synchronously inside the scroll event, keeping
+      // momentum scrolling smooth as the breadcrumb expands/collapses.
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => setDown((window.scrollY || 0) > threshold));
     }
     onScroll();
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', onScroll);
+    };
   }, [threshold]);
   return down;
 }


### PR DESCRIPTION
Follow-up to the breadcrumb chrome. Scrolling back **up** stalled momentum scrolling.

## Cause
A second mechanism, separate from the earlier layout-shift fix: the breadcrumb was unmounted via `AnimatePresence`, and removing that DOM node synchronously inside the scroll handler interrupts the browser's inertial/smooth scroll. Mounting on the way down has no such effect — which is why only the up direction stalled.

## Fix
- The strip now stays mounted the whole time you're off the home page and only animates its height/opacity between shown and hidden — no structural DOM mutation during scroll. Verified the same DOM node is reused across a full down-then-up scroll cycle rather than remounted.
- Marked `inert` + `aria-hidden` when collapsed so the hidden crumb links stay out of tab order and the a11y tree.
- Moved the bottom hairline onto the inner row so nothing paints at height 0 (collapsed height is exactly 0).
- Belt-and-suspenders: coalesce the scroll-position hook through `requestAnimationFrame`, and set `overflow-anchor: none` on the strip.

## Verification
Headless Chromium at a 500px viewport:
- collapsed at top (height 0, inert), expanded when scrolled (height 37, not inert)
- same marked DOM node persists across scroll down → up (not remounted)
- content's document position holds at 58px throughout (still zero layout shift)
- not rendered at all on the home page

Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM)_