### PR TITLE
Replace floral brand glyph with live Bluesky avatar

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -200,6 +200,23 @@
   transition: color 240ms ease;
 }
 
+/* When the mark is Dame's live avatar rather than the floral glyph, center
+   it against the wordmark's line box instead of sitting on the baseline. */
+.chrome-mark.chrome-mark-avatar {
+  align-self: center;
+  font-size: 1em;
+}
+
+.chrome-mark-img {
+  display: block;
+  width: 1.3em;
+  height: 1.3em;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--surface-2, rgba(0, 0, 0, 0.06));
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
 .chrome-mark.is-refreshing {
   animation: chrome-mark-pulse 1.6s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
 }

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -211,10 +211,10 @@
   display: block;
   width: 1.3em;
   height: 1.3em;
-  border-radius: 50%;
+  border-radius: 0;
+  border: 1px solid var(--rule);
   object-fit: cover;
-  background: var(--surface-2, rgba(0, 0, 0, 0.06));
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  background: var(--surface-soft, transparent);
 }
 
 .chrome-mark.is-refreshing {

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-do
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, Moon, MoonStar, Search, Sun, SunDim } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
+import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
@@ -31,6 +32,16 @@ export default function ChromeBar() {
   const location = useLocation();
   // Pulse the brand mark whenever any live feed is currently refreshing.
   const refreshing = useSyncExternalStore(subscribeRefresh, isRefreshing, () => false);
+  // Brand mark: Dame's live Bluesky avatar (regenerated hourly to track the
+  // sun). Falls back to the floral glyph while it loads or if it fails.
+  const avatar = useAvatar();
+  const [avatarBroken, setAvatarBroken] = useState(false);
+  const showAvatar = avatar && !avatarBroken;
+  // A new hourly avatar URL gets a fresh chance to load — clear any prior
+  // load failure whenever the URL turns over.
+  useEffect(() => {
+    setAvatarBroken(false);
+  }, [avatar]);
 
   // Tertiary chrome: a breadcrumb that slides down out of the top bar once
   // the page is scrolled away from its top, orienting you to where you are.
@@ -49,10 +60,20 @@ export default function ChromeBar() {
           <div className="chrome-cluster">
             <Link to="/" className="chrome-title">
               <span
-                className={`chrome-mark${refreshing ? ' is-refreshing' : ''}`}
+                className={`chrome-mark${refreshing ? ' is-refreshing' : ''}${showAvatar ? ' chrome-mark-avatar' : ''}`}
                 aria-hidden="true"
               >
-                &#x2767;
+                {showAvatar ? (
+                  <img
+                    key={avatar}
+                    className="chrome-mark-img"
+                    src={avatar}
+                    alt=""
+                    onError={() => setAvatarBroken(true)}
+                  />
+                ) : (
+                  '❧'
+                )}
               </span>
               <span className="chrome-name">dame.is</span>
               {refreshing && <span className="chrome-mark-sr-status">Updating live data</span>}

--- a/src/hooks/useAvatar.js
+++ b/src/hooks/useAvatar.js
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+import { getProfile } from '../lib/atproto.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
+import { subscribeRefreshTick } from '../lib/refreshTick.js';
+import { ME_DID } from '../config.js';
+
+// The Bluesky avatar is a content-addressed CDN URL — its blob CID (and so
+// the URL) changes whenever the avatar image changes. Dame's avatar is
+// regenerated every hour to track the sun's position, so a URL grabbed once
+// on mount goes stale for anyone who leaves the tab open across the hour.
+//
+// We keep it current by re-fetching the profile on the shared refresh tick,
+// throttled to a few minutes — the avatar only turns over hourly, so there's
+// no need to hammer the AppView every 30s. The tick's visibility handler also
+// fires a refresh the moment the tab regains focus, so returning after a while
+// snaps to the current avatar immediately.
+const AVATAR_REFETCH_MS = 5 * 60_000;
+
+/**
+ * Current avatar URL for the site owner, kept fresh across hourly changes.
+ * Returns `null` until the first (snapshot or live) value resolves, so callers
+ * can fall back to a placeholder glyph while it loads.
+ */
+export function useAvatar() {
+  const [avatar, setAvatar] = useState(null);
+  const cancelledRef = useRef(false);
+  const avatarRef = useRef(null);
+  const lastFetchRef = useRef(0);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    async function refresh() {
+      // Only actually hit the network every few minutes — the tick fires far
+      // more often than the avatar changes.
+      const now = Date.now();
+      if (now - lastFetchRef.current < AVATAR_REFETCH_MS) return;
+      lastFetchRef.current = now;
+      try {
+        const live = await getProfile(ME_DID, { cache: 'no-store' });
+        if (cancelledRef.current) return;
+        if (live?.avatar && live.avatar !== avatarRef.current) {
+          avatarRef.current = live.avatar;
+          setAvatar(live.avatar);
+        }
+      } catch {
+        // Network hiccup — keep showing the last-known avatar.
+      }
+    }
+
+    async function boot() {
+      const seed = await fetchSnapshot('profile');
+      if (!cancelledRef.current && seed?.avatar) {
+        avatarRef.current = seed.avatar;
+        setAvatar(seed.avatar);
+      }
+      // Force the boot fetch past the throttle so we replace the (possibly
+      // hours-old) snapshot avatar with the current one right away.
+      lastFetchRef.current = 0;
+      refresh();
+    }
+
+    boot();
+    const unsubscribe = subscribeRefreshTick(refresh);
+    return () => {
+      cancelledRef.current = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return avatar;
+}

--- a/src/lib/atproto.js
+++ b/src/lib/atproto.js
@@ -137,9 +137,11 @@ export async function listRecordsPage(
 /**
  * AppView — `app.bsky.actor.getProfile`.
  */
-export async function getProfile(actor, { appview = APPVIEW } = {}) {
+export async function getProfile(actor, { appview = APPVIEW, cache } = {}) {
   const url = `${appview}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(actor)}`;
-  return fetchJson(url);
+  // `cache: 'no-store'` lets callers that need a *current* value (e.g. the
+  // hourly-changing avatar) bypass the browser HTTP cache.
+  return fetchJson(url, cache ? { cache } : undefined);
 }
 
 /**


### PR DESCRIPTION
The top-chrome brand mark now shows Dame's Bluesky avatar instead of the static floral glyph (❧).

## Why
The avatar is regenerated every hour to track the sun's position, and its Bluesky URL is content-addressed (the blob CID is baked into the URL). A URL fetched once on mount would go stale for a tab left open across the hour, so it needs to stay current.

## Changes
- **`src/hooks/useAvatar.js`** (new) — seeds from the `profile.json` snapshot for first paint, then keeps the avatar current by re-fetching `getProfile` on the shared 30s refresh tick (throttled to ~5 min, `cache: 'no-store'`), and immediately when the tab regains focus.
- **`src/components/ChromeBar.jsx`** — renders the avatar `<img>` in the brand mark, falling back to the floral glyph while it loads or if it fails; a new hourly URL gets a fresh load attempt.
- **`src/lib/atproto.js`** — `getProfile` gained an optional `cache` param for cache-busting.
- **`src/components/ChromeBar.css`** — styles the mark as a square image with a thin `1px solid var(--rule)` border, matching the site's comment-avatar / post-embed convention.

## Verification
- Production build passes (`vite build`).
- Drove the running app with a headless browser: the mark renders as a square, bordered avatar centered next to the wordmark, with the floral glyph correctly showing as the fallback before it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1jQfe3RKCYuHCee1g8TFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1jQfe3RKCYuHCee1g8TFG)_