### PR TITLE
Refine avatar brand mark: no glyph fallback, no pulse, tuned spacing

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -63,7 +63,7 @@
 .chrome-cluster {
   display: flex;
   align-items: baseline;
-  gap: var(--space-3);
+  gap: var(--space-2);
   flex: 1;
   min-width: 0;
 }
@@ -180,7 +180,7 @@
 .chrome-title {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.4em;
+  gap: 0.55em;
   font-family: var(--serif);
   font-weight: 600;
   font-size: var(--text-lg);
@@ -195,20 +195,12 @@
   color: var(--accent);
 }
 
+/* The brand mark is Dame's live avatar — center it against the wordmark's
+   line box instead of sitting on the baseline. */
 .chrome-mark {
-  color: var(--accent);
-  font-size: 1.1em;
-  line-height: 1;
   display: inline-block;
-  transform-origin: center;
-  transition: color 240ms ease;
-}
-
-/* When the mark is Dame's live avatar rather than the floral glyph, center
-   it against the wordmark's line box instead of sitting on the baseline. */
-.chrome-mark.chrome-mark-avatar {
   align-self: center;
-  font-size: 1em;
+  line-height: 1;
 }
 
 .chrome-mark-img {
@@ -219,47 +211,6 @@
   border: 1px solid var(--rule);
   object-fit: cover;
   background: var(--surface-soft, transparent);
-}
-
-.chrome-mark.is-refreshing {
-  animation: chrome-mark-pulse 1.6s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
-}
-
-@keyframes chrome-mark-pulse {
-  0% {
-    opacity: 0.55;
-    transform: scale(0.96);
-    filter: drop-shadow(0 0 0 rgba(94, 122, 71, 0));
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.06);
-    filter: drop-shadow(0 0 0.35rem rgba(94, 122, 71, 0.45));
-  }
-  100% {
-    opacity: 0.55;
-    transform: scale(0.96);
-    filter: drop-shadow(0 0 0 rgba(94, 122, 71, 0));
-  }
-}
-
-.chrome-mark-sr-status {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .chrome-mark.is-refreshing {
-    animation: none;
-    opacity: 0.85;
-  }
 }
 
 .chrome-name {

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, Moon, MoonStar, Search, Sun, SunDim } from 'lucide-react';
@@ -7,7 +7,6 @@ import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
-import { isRefreshing, subscribeRefresh } from '../lib/feedCache.js';
 import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
@@ -30,10 +29,9 @@ export default function ChromeBar() {
   const { open: dockOpen, toggle: toggleDock } = useActionDock();
   const reduce = useReducedMotion();
   const location = useLocation();
-  // Pulse the brand mark whenever any live feed is currently refreshing.
-  const refreshing = useSyncExternalStore(subscribeRefresh, isRefreshing, () => false);
   // Brand mark: Dame's live Bluesky avatar (regenerated hourly to track the
-  // sun). Falls back to the floral glyph while it loads or if it fails.
+  // sun). While it's loading — or if it ever fails — the mark simply isn't
+  // rendered rather than falling back to a glyph.
   const avatar = useAvatar();
   const [avatarBroken, setAvatarBroken] = useState(false);
   const showAvatar = avatar && !avatarBroken;
@@ -59,11 +57,8 @@ export default function ChromeBar() {
         <div className="chrome-bar-row chrome-bar-primary">
           <div className="chrome-cluster">
             <Link to="/" className="chrome-title">
-              <span
-                className={`chrome-mark${refreshing ? ' is-refreshing' : ''}${showAvatar ? ' chrome-mark-avatar' : ''}`}
-                aria-hidden="true"
-              >
-                {showAvatar ? (
+              {showAvatar && (
+                <span className="chrome-mark chrome-mark-avatar" aria-hidden="true">
                   <img
                     key={avatar}
                     className="chrome-mark-img"
@@ -71,12 +66,9 @@ export default function ChromeBar() {
                     alt=""
                     onError={() => setAvatarBroken(true)}
                   />
-                ) : (
-                  '❧'
-                )}
-              </span>
+                </span>
+              )}
               <span className="chrome-name">dame.is</span>
-              {refreshing && <span className="chrome-mark-sr-status">Updating live data</span>}
             </Link>
             <div className="chrome-signals chrome-signals-primary">
               <NowStatus />


### PR DESCRIPTION
Follow-up refinements to the live Bluesky avatar brand mark in the top chrome.

## Changes
- **No glyph fallback** — while the avatar loads, or if it ever fails, the mark isn't rendered at all (rather than falling back to the floral glyph `❧`). No empty element or leading gap is left behind.
- **No pulse/animation** — removed the refresh-driven pulse keyframes and class wiring on the brand mark, along with the now-unused refresh subscription.
- **Tighter status spacing** — reduced the gap between "dame.is" and the live status (`.chrome-cluster` `--space-3` → `--space-2`).
- **More avatar spacing** — added a little breathing room between the avatar and "dame.is" (`.chrome-title` gap `0.4em` → `0.55em`).

## Verification
- Production build passes (`vite build`).
- Drove the running app with a headless browser: the avatar case shows the square, bordered mark with the tuned spacing; the fallback case renders only the "dame.is" wordmark with no glyph and no leading gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1jQfe3RKCYuHCee1g8TFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1jQfe3RKCYuHCee1g8TFG)_