### PR TITLE
Add legacy Eleventy blog migration to the admin panel

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,14 @@ export const MOTHING_OBSERVATION_NSID = 'is.dame.mothing.observation';
  */
 export const PORTFOLIO_PUBLICATION = 'at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/site.standard.publication/3mpjrojpfzg2d';
 
+/**
+ * The blog publication ("dame's leaflets"). Standard docs pointing here render
+ * on `/blogging`. Used as the `site` value when migrating the legacy Eleventy
+ * markdown blog posts into `site.standard.document` records (see
+ * `src/lib/legacyBlog.js` and the admin "Legacy blog migration" panel).
+ */
+export const BLOG_PUBLICATION = 'at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/site.standard.publication/3lpq72oeo3c2y';
+
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';

--- a/src/lib/legacyBlog.js
+++ b/src/lib/legacyBlog.js
@@ -1,0 +1,228 @@
+// Legacy blog migration.
+//
+// Before dame.is became this Vite + React SPA it was an Eleventy static site,
+// and its blog posts lived as hand-written markdown files with YAML-ish front
+// matter under `/blog`. Those files now sit in `writing/blogs/*.md` (recovered
+// from the pre-rewrite commit). This module reads them at build time, converts
+// each into a `site.standard.document` record — the same shape the admin blocks
+// editor produces — and offers a one-call `migratePost` that uploads the
+// referenced images as PDS blobs and writes the record to the user's repo.
+//
+// The pure markdown→content conversion lives in legacyBlogMarkdown.js; here we
+// add the bundled-file plumbing, image blob uploads, and the PDS write. The
+// admin "Legacy blog migration" panel (src/pages/Admin.jsx) drives it.
+
+import { ME_DID, BLOG_PUBLICATION } from '../config.js';
+import { uploadImageFile } from '../components/blocks/ImageBlockEditor.jsx';
+import {
+  parseFrontMatter,
+  parsePublishedAt,
+  markdownToContent,
+} from './legacyBlogMarkdown.js';
+
+const STANDARD_DOC = 'site.standard.document';
+const POST_COLLECTION = 'app.bsky.feed.post';
+
+/* ------------------------------------------------------------------ */
+/* Bundled source files                                                 */
+/* ------------------------------------------------------------------ */
+
+// The raw markdown for every legacy post, keyed by absolute path.
+const POST_SOURCES = import.meta.glob('/writing/blogs/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+// Served URLs for every image the posts reference. The old markdown points at
+// `/images/blog/...` paths that the SPA no longer serves directly, so we route
+// them through Vite's asset pipeline to get real, fetchable URLs at runtime
+// (both in dev and in the built site). This also emits the images into the
+// build so a migration run always has bytes to upload.
+const IMAGE_URLS = import.meta.glob(
+  '/images/blog/**/*.{jpg,jpeg,png,gif,webp,JPG,JPEG,PNG,GIF,WEBP}',
+  { query: '?url', import: 'default', eager: true },
+);
+
+/**
+ * Every legacy post, parsed and sorted newest-first. Each entry:
+ *   { slug, filePath, meta, title, description, content, images, coverSrc,
+ *     publishedAt, commentsUri }
+ * where `content` is a ready-to-store `pub.leaflet.content` value whose image
+ * blocks still carry a temporary `_src` (resolved to a blob at migrate time).
+ */
+export const LEGACY_POSTS = Object.entries(POST_SOURCES)
+  .map(([filePath, raw]) => buildPost(filePath, raw))
+  .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1));
+
+function buildPost(filePath, raw) {
+  const slug = filePath.replace(/^.*\//, '').replace(/\.md$/, '');
+  const { meta, body } = parseFrontMatter(raw);
+  const content = markdownToContent(body);
+  const images = collectImageSrcs(content);
+  const publishedAt = parsePublishedAt(meta) || new Date().toISOString();
+  const commentsUri = meta.blueskyUri
+    ? `at://${ME_DID}/${POST_COLLECTION}/${meta.blueskyUri}`
+    : null;
+  return {
+    slug,
+    filePath,
+    meta,
+    content,
+    images,
+    coverSrc: meta.ogImage || null,
+    publishedAt,
+    commentsUri,
+    title: meta.title || slug,
+    description: meta.excerpt || '',
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Image resolution                                                     */
+/* ------------------------------------------------------------------ */
+
+function collectImageSrcs(content) {
+  const srcs = new Set();
+  for (const wrap of content.pages[0].blocks) {
+    const b = wrap.block;
+    if (b?.$type === 'pub.leaflet.blocks.image' && b._src) srcs.add(b._src);
+  }
+  return [...srcs];
+}
+
+/** Map a legacy `/images/blog/...` path to a runtime-served URL, if bundled. */
+export function resolveImageUrl(src) {
+  if (!src) return null;
+  if (IMAGE_URLS[src]) return IMAGE_URLS[src];
+  // Tolerate case / leading-slash drift between the markdown and the filesystem.
+  const norm = src.replace(/^\/+/, '').toLowerCase();
+  for (const [key, url] of Object.entries(IMAGE_URLS)) {
+    if (key.replace(/^\/+/, '').toLowerCase() === norm) return url;
+  }
+  return null;
+}
+
+const MIME_BY_EXT = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+async function fetchAsFile(src) {
+  const url = resolveImageUrl(src);
+  if (!url) throw new Error(`Image not bundled: ${src}`);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Fetch failed (${res.status}) for ${src}`);
+  const blob = await res.blob();
+  const ext = (src.split('.').pop() || '').toLowerCase();
+  const type =
+    blob.type && blob.type.startsWith('image/') ? blob.type : MIME_BY_EXT[ext] || 'image/jpeg';
+  const name = src.split('/').pop() || 'image';
+  return new File([blob], name, { type });
+}
+
+/* ------------------------------------------------------------------ */
+/* Migration                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Which legacy posts already have a `site.standard.document`? Matches on the
+ * record key (we migrate with rkey = slug) or on `path` (`/<slug>`), so a post
+ * migrated under either scheme is detected. Returns the Set of migrated slugs
+ * given the caller's already-fetched record list.
+ */
+export function migratedSlugs(records, slugs) {
+  const present = new Set();
+  const bySlug = new Set(slugs);
+  for (const rec of records || []) {
+    const rkey = String(rec.uri || '').split('/').pop();
+    if (bySlug.has(rkey)) present.add(rkey);
+    const path = String(rec.value?.path || '').replace(/^\/+/, '');
+    if (bySlug.has(path)) present.add(path);
+  }
+  return present;
+}
+
+/**
+ * Migrate one legacy post to the signed-in user's PDS as a
+ * `site.standard.document`. Uploads every referenced image (and the cover) as
+ * blobs, then writes the record with `rkey = slug` so the classic
+ * `/blog/<slug>` → `/blogging/<slug>` URLs resolve and re-runs are idempotent
+ * (a second migration overwrites rather than duplicating).
+ *
+ * `onProgress(message)` is optional and reports upload steps.
+ */
+export async function migratePost({ agent, did, post, onProgress = () => {} }) {
+  if (!agent) throw new Error('Not signed in.');
+
+  // 1. Upload every distinct image once and build a src → blockFields map.
+  const uploads = new Map();
+  const total = post.images.length + (post.coverSrc ? 1 : 0);
+  let done = 0;
+  const step = (label) => onProgress(`${label} (${++done}/${total})`);
+
+  for (const src of post.images) {
+    step('Uploading image');
+    // eslint-disable-next-line no-await-in-loop
+    const file = await fetchAsFile(src);
+    // eslint-disable-next-line no-await-in-loop
+    const { blob, aspectRatio } = await uploadImageFile(agent, file);
+    uploads.set(src, { blob, aspectRatio });
+  }
+
+  let coverImage;
+  if (post.coverSrc) {
+    step('Uploading cover');
+    try {
+      const file = await fetchAsFile(post.coverSrc);
+      const { blob } = await uploadImageFile(agent, file);
+      coverImage = blob;
+    } catch {
+      // A missing cover image shouldn't block the migration.
+      coverImage = undefined;
+    }
+  }
+
+  // 2. Deep-clone the content and swap image `_src` placeholders for blob refs.
+  const content = structuredClone(post.content);
+  for (const wrap of content.pages[0].blocks) {
+    const b = wrap.block;
+    if (b?.$type !== 'pub.leaflet.blocks.image') continue;
+    const up = b._src ? uploads.get(b._src) : null;
+    delete b._src;
+    if (up) {
+      b.image = up.blob;
+      if (up.aspectRatio) b.aspectRatio = up.aspectRatio;
+    }
+  }
+
+  // 3. Assemble and write the record.
+  const record = {
+    $type: STANDARD_DOC,
+    title: post.title,
+    site: BLOG_PUBLICATION,
+    path: `/${post.slug}`,
+    content,
+    publishedAt: post.publishedAt,
+  };
+  if (post.description) record.description = post.description;
+  if (coverImage) record.coverImage = coverImage;
+  if (post.commentsUri) record.commentsUri = post.commentsUri;
+
+  onProgress('Writing record…');
+  await agent.com.atproto.repo.putRecord({
+    repo: did,
+    collection: STANDARD_DOC,
+    rkey: post.slug,
+    record,
+  });
+
+  return {
+    rkey: post.slug,
+    uri: `at://${did}/${STANDARD_DOC}/${post.slug}`,
+    href: `/blogging/${post.slug}`,
+  };
+}

--- a/src/lib/legacyBlogMarkdown.js
+++ b/src/lib/legacyBlogMarkdown.js
@@ -1,0 +1,296 @@
+// Pure markdown → pub.leaflet.content conversion for the legacy blog migration.
+//
+// Split out from legacyBlog.js so it can be unit-tested in plain Node without
+// Vite's `import.meta.glob` or the React upload helpers. Nothing here touches
+// the network, the DOM, or the PDS — it only turns a markdown string (plus
+// its front matter) into the block-document shape the site renders.
+
+import { marked } from 'marked';
+
+marked.use({ gfm: true, breaks: false, async: false });
+
+const CONTENT_TYPE = 'pub.leaflet.content';
+const PAGE_TYPE = 'pub.leaflet.pages.linearDocument';
+const WRAPPER_TYPE = 'pub.leaflet.pages.linearDocument#block';
+
+const FACET = {
+  link: (uri) => ({ $type: 'pub.leaflet.richtext.facet#link', uri }),
+  bold: { $type: 'pub.leaflet.richtext.facet#bold' },
+  italic: { $type: 'pub.leaflet.richtext.facet#italic' },
+  strikethrough: { $type: 'pub.leaflet.richtext.facet#strikethrough' },
+  code: { $type: 'pub.leaflet.richtext.facet#code' },
+};
+
+/* ------------------------------------------------------------------ */
+/* Front matter                                                         */
+/* ------------------------------------------------------------------ */
+
+export function parseFrontMatter(raw) {
+  const m = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(raw);
+  if (!m) return { meta: {}, body: raw };
+  const meta = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = /^(\w+):\s*(.*)$/.exec(line);
+    if (!kv) continue;
+    let v = kv[2].trim();
+    if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+    meta[kv[1]] = v;
+  }
+  return { meta, body: m[2] };
+}
+
+export function parsePublishedAt(meta) {
+  const date = (meta.date || '').trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  let h = 12;
+  let min = 0;
+  const t = /(\d{1,2}):(\d{2})\s*(am|pm)?/i.exec(meta.time || '');
+  if (t) {
+    h = parseInt(t[1], 10) % 12;
+    if (/pm/i.test(t[3] || '')) h += 12;
+    min = parseInt(t[2], 10);
+  }
+  const hh = String(h).padStart(2, '0');
+  const mm = String(min).padStart(2, '0');
+  // The old `time` strings say "EST"; use a fixed -05:00 offset. Precise DST
+  // handling isn't worth it — this only feeds the displayed date / day-of-life.
+  const d = new Date(`${date}T${hh}:${mm}:00-05:00`);
+  if (Number.isNaN(d.getTime())) {
+    const fallback = new Date(`${date}T12:00:00Z`);
+    return Number.isNaN(fallback.getTime()) ? null : fallback.toISOString();
+  }
+  return d.toISOString();
+}
+
+/* ------------------------------------------------------------------ */
+/* Markdown → pub.leaflet.content                                       */
+/* ------------------------------------------------------------------ */
+
+/** Convert a markdown body into a `pub.leaflet.content` value. */
+export function markdownToContent(body) {
+  const tokens = marked.lexer(body || '');
+  let blocks = blocksFromTokens(tokens);
+  if (blocks.length === 0) {
+    blocks = [{ $type: 'pub.leaflet.blocks.text', plaintext: '', facets: [] }];
+  }
+  return {
+    $type: CONTENT_TYPE,
+    pages: [
+      {
+        $type: PAGE_TYPE,
+        blocks: blocks.map((block) => ({ $type: WRAPPER_TYPE, block })),
+      },
+    ],
+  };
+}
+
+function blocksFromTokens(tokens) {
+  const out = [];
+  for (const t of tokens) {
+    switch (t.type) {
+      case 'heading':
+        out.push(headerBlock(t));
+        break;
+      case 'paragraph':
+        out.push(...paragraphBlocks(t.tokens || []));
+        break;
+      case 'blockquote':
+        out.push(...blockquoteBlocks(t));
+        break;
+      case 'list':
+        out.push(listBlock(t));
+        break;
+      case 'code':
+        out.push(codeBlock(t));
+        break;
+      case 'hr':
+        out.push({ $type: 'pub.leaflet.blocks.text', plaintext: '', facets: [] });
+        break;
+      case 'html':
+        out.push(...htmlBlocks(t));
+        break;
+      case 'space':
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+function headerBlock(t) {
+  const { plaintext, facets } = inlineToRichText(t.tokens || []);
+  return {
+    $type: 'pub.leaflet.blocks.header',
+    plaintext,
+    level: Math.min(Math.max(Number(t.depth) || 2, 1), 6),
+    facets,
+  };
+}
+
+function textBlock(rt) {
+  return { $type: 'pub.leaflet.blocks.text', plaintext: rt.plaintext, facets: rt.facets };
+}
+
+// A paragraph may hold standalone images (their own image blocks) interleaved
+// with text. Split it so each image becomes its own image block.
+function paragraphBlocks(tokens) {
+  const out = [];
+  let buffer = [];
+  const flush = () => {
+    if (!buffer.length) return;
+    const rt = inlineToRichText(buffer);
+    if (rt.plaintext.trim() || rt.facets.length) out.push(textBlock(rt));
+    buffer = [];
+  };
+  for (const t of tokens) {
+    if (t.type === 'image') {
+      flush();
+      out.push(imageBlock(t));
+    } else {
+      buffer.push(t);
+    }
+  }
+  flush();
+  return out;
+}
+
+function blockquoteBlocks(t) {
+  const out = [];
+  for (const inner of t.tokens || []) {
+    if (inner.type === 'paragraph') {
+      // Render quote paragraphs in italics so the quotation still reads as one
+      // (leaflet has no dedicated blockquote block).
+      out.push(textBlock(inlineToRichText(inner.tokens || [], [FACET.italic])));
+    } else {
+      out.push(...blocksFromTokens([inner]));
+    }
+  }
+  return out;
+}
+
+function imageBlock(t) {
+  const block = {
+    $type: 'pub.leaflet.blocks.image',
+    alt: t.text || '',
+    _src: t.href, // resolved to a blob ref at migrate time
+  };
+  if (t.title) block.caption = t.title;
+  return block;
+}
+
+function codeBlock(t) {
+  const block = { $type: 'pub.leaflet.blocks.code', plaintext: t.text || '' };
+  if (t.lang) block.language = t.lang;
+  return block;
+}
+
+function listBlock(t) {
+  const ordered = Boolean(t.ordered);
+  return {
+    $type: ordered ? 'pub.leaflet.blocks.orderedList' : 'pub.leaflet.blocks.unorderedList',
+    children: (t.items || []).map((item) => listItem(item, ordered)),
+  };
+}
+
+function listItem(item, ordered) {
+  let contentTokens = [];
+  let children = [];
+  for (const tk of item.tokens || []) {
+    if (tk.type === 'text' || tk.type === 'paragraph') {
+      contentTokens = tk.tokens || [{ type: 'text', text: tk.text || '' }];
+    } else if (tk.type === 'list') {
+      children = (tk.items || []).map((it) => listItem(it, Boolean(tk.ordered)));
+    }
+  }
+  const rt = inlineToRichText(contentTokens);
+  return {
+    $type: ordered
+      ? 'pub.leaflet.blocks.orderedList#listItem'
+      : 'pub.leaflet.blocks.unorderedList#listItem',
+    content: { $type: 'pub.leaflet.blocks.text', plaintext: rt.plaintext, facets: rt.facets },
+    children,
+  };
+}
+
+// The Eleventy posts embed Bluesky posts as raw <blockquote data-bluesky-uri>
+// HTML (from the official embed snippet). Recover the AT URI and turn it into a
+// first-class bskyPost block; drop any other raw HTML.
+function htmlBlocks(t) {
+  const uri = /data-bluesky-uri="(at:\/\/[^"]+)"/.exec(t.text || t.raw || '');
+  if (uri) return [{ $type: 'pub.leaflet.blocks.bskyPost', postRef: { uri: uri[1] } }];
+  return [];
+}
+
+/* ------------------------------------------------------------------ */
+/* Inline markdown → plaintext + facets                                 */
+/* ------------------------------------------------------------------ */
+
+const encoder = new TextEncoder();
+const byteLen = (s) => encoder.encode(s).length;
+
+/**
+ * Flatten inline markdown tokens into `{ plaintext, facets }`. Facets carry
+ * UTF-8 byte offsets (matching the leaflet renderer) and are only emitted on
+ * leaf text runs, so nested formatting stacks as multiple features on one
+ * range rather than producing overlapping facets (which the renderer drops).
+ */
+export function inlineToRichText(tokens, baseFeatures = []) {
+  let text = '';
+  const facets = [];
+
+  const append = (str, features) => {
+    if (!str) return;
+    const start = byteLen(text);
+    text += str;
+    const end = byteLen(text);
+    if (features.length && end > start) {
+      facets.push({ index: { byteStart: start, byteEnd: end }, features: features.map(clone) });
+    }
+  };
+
+  const walk = (toks, features) => {
+    for (const t of toks || []) {
+      switch (t.type) {
+        case 'text':
+          if (Array.isArray(t.tokens) && t.tokens.length) walk(t.tokens, features);
+          else append(t.text, features);
+          break;
+        case 'escape':
+          append(t.text, features);
+          break;
+        case 'br':
+          text += '\n';
+          break;
+        case 'codespan':
+          append(t.text, features.concat(FACET.code));
+          break;
+        case 'strong':
+          walk(t.tokens, features.concat(FACET.bold));
+          break;
+        case 'em':
+          walk(t.tokens, features.concat(FACET.italic));
+          break;
+        case 'del':
+          walk(t.tokens, features.concat(FACET.strikethrough));
+          break;
+        case 'link':
+          walk(t.tokens, features.concat(FACET.link(t.href)));
+          break;
+        case 'image':
+          // An inline image inside otherwise-textual content: keep its alt so
+          // the sentence still reads (standalone images are split out earlier).
+          append(t.text || '', features);
+          break;
+        default:
+          if (t.text) append(t.text, features);
+      }
+    }
+  };
+
+  walk(tokens, baseFeatures);
+  return { plaintext: text, facets };
+}
+
+function clone(feature) {
+  return { ...feature };
+}

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -454,3 +454,70 @@ select.admin-input {
 .admin-collection-row-legacy:focus-within {
   opacity: 1;
 }
+
+/* Legacy blog migration panel. */
+.legacy-blog-list {
+  margin-top: var(--space-4);
+}
+
+.legacy-blog-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+}
+
+.legacy-blog-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.legacy-blog-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.legacy-blog-title {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  color: var(--ink);
+}
+
+.legacy-blog-badge {
+  color: var(--accent, var(--ink-muted));
+  font-size: var(--text-xs);
+}
+
+.legacy-blog-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: var(--space-1);
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+}
+
+.legacy-blog-dot {
+  color: var(--rule);
+}
+
+.legacy-blog-excerpt {
+  margin-top: var(--space-2);
+  max-width: var(--measure);
+  color: var(--ink-muted);
+  font-size: var(--text-sm);
+}
+
+.legacy-blog-status {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+}
+
+.legacy-blog-actions {
+  flex-shrink: 0;
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -10,6 +10,8 @@ import { LEXICONS, lexiconFor, knownCollections } from '../lib/lexicons.js';
 
 const STANDARD_DOC = 'site.standard.document';
 import { knownPageSlugs, pageSlugForCollection } from '../lib/pageRegistry.js';
+import { LEGACY_POSTS, migratedSlugs, migratePost } from '../lib/legacyBlog.js';
+import { formatDateLong } from '../lib/time.js';
 import './Admin.css';
 
 /**
@@ -60,6 +62,9 @@ export default function Admin() {
 
   if (view === 'pages') {
     return <PagesOverview agent={agent} did={did} />;
+  }
+  if (view === 'legacy-blogs') {
+    return <LegacyBlogMigration agent={agent} did={did} />;
   }
   if (!collection) {
     return <CollectionPicker />;
@@ -177,6 +182,16 @@ function CollectionPicker() {
           <p className="admin-collection-summary">
             See which pages serve their title &amp; intro from the PDS vs hardcoded
             defaults, and migrate or revert them.
+          </p>
+        </li>
+        <li className="admin-collection-row">
+          <Link to="/admin?view=legacy-blogs" className="admin-collection-link">
+            <span className="admin-collection-label">Legacy blog migration</span>
+            <code className="admin-collection-nsid">{STANDARD_DOC}</code>
+          </Link>
+          <p className="admin-collection-summary">
+            The old Eleventy markdown blog posts, ready to publish to your PDS as
+            standard.site documents with one click.
           </p>
         </li>
         {primary.map(renderRow)}
@@ -467,6 +482,164 @@ function PagesOverview({ agent, did }) {
           ))}
         </div>
       )}
+    </PageShell>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Legacy blog migration                                                */
+/* ------------------------------------------------------------------ */
+
+function LegacyBlogMigration({ agent, did }) {
+  // Per-slug migration state: { status, message, href }.
+  const [state, setState] = useState({});
+  const [migrated, setMigrated] = useState(null); // Set of already-migrated slugs
+  const [loadError, setLoadError] = useState(null);
+  const [runningAll, setRunningAll] = useState(false);
+
+  const refreshMigrated = useCallback(async () => {
+    try {
+      const slugs = LEGACY_POSTS.map((p) => p.slug);
+      const res = await agent.com.atproto.repo.listRecords({
+        repo: did,
+        collection: STANDARD_DOC,
+        limit: 100,
+      });
+      const records = (res?.data || res)?.records || [];
+      setMigrated(migratedSlugs(records, slugs));
+    } catch (err) {
+      setLoadError(err?.message || String(err));
+      setMigrated(new Set());
+    }
+  }, [agent, did]);
+
+  useEffect(() => {
+    refreshMigrated();
+  }, [refreshMigrated]);
+
+  const runOne = useCallback(
+    async (post) => {
+      setState((s) => ({ ...s, [post.slug]: { status: 'running', message: 'Starting…' } }));
+      try {
+        const result = await migratePost({
+          agent,
+          did,
+          post,
+          onProgress: (message) =>
+            setState((s) => ({ ...s, [post.slug]: { status: 'running', message } })),
+        });
+        setState((s) => ({
+          ...s,
+          [post.slug]: { status: 'done', message: 'Migrated.', href: result.href },
+        }));
+        setMigrated((prev) => new Set(prev).add(post.slug));
+        return true;
+      } catch (err) {
+        setState((s) => ({
+          ...s,
+          [post.slug]: { status: 'error', message: err?.message || String(err) },
+        }));
+        return false;
+      }
+    },
+    [agent, did],
+  );
+
+  const runAll = useCallback(async () => {
+    setRunningAll(true);
+    // Sequential — image uploads are the bottleneck and this keeps the PDS
+    // write load gentle and the progress readable.
+    for (const post of LEGACY_POSTS) {
+      if (migrated?.has(post.slug)) continue;
+      // eslint-disable-next-line no-await-in-loop
+      await runOne(post);
+    }
+    setRunningAll(false);
+  }, [migrated, runOne]);
+
+  const pendingCount = LEGACY_POSTS.filter((p) => !migrated?.has(p.slug)).length;
+
+  return (
+    <PageShell
+      title="Legacy blog migration"
+      intro="Publish the pre-rewrite Eleventy markdown posts to your PDS as standard.site blog documents. Images are uploaded as blobs and each post keeps its original slug, so old /blog links keep working. Re-running a migration overwrites the existing record rather than duplicating it."
+      headTitle="Legacy blog migration — Admin — Dame is…"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <button
+          type="button"
+          className="admin-gate-button admin-gate-button-tight"
+          onClick={runAll}
+          disabled={runningAll || migrated == null || pendingCount === 0}
+        >
+          {runningAll
+            ? 'Migrating…'
+            : pendingCount === 0
+              ? 'All migrated'
+              : `Migrate all (${pendingCount})`}
+        </button>
+      </div>
+
+      {loadError && <p className="admin-error">Couldn’t check existing posts: {loadError}</p>}
+
+      <ul className="admin-record-list legacy-blog-list">
+        {LEGACY_POSTS.map((post) => {
+          const st = state[post.slug];
+          const isMigrated = migrated?.has(post.slug);
+          const busy = st?.status === 'running' || runningAll;
+          return (
+            <li key={post.slug} className="admin-record-row legacy-blog-row">
+              <div className="legacy-blog-main">
+                <div className="legacy-blog-head">
+                  <span className="legacy-blog-title">{post.title}</span>
+                  {isMigrated && <span className="small-caps legacy-blog-badge">migrated</span>}
+                </div>
+                <div className="legacy-blog-meta small-caps">
+                  {formatDateLong(post.publishedAt)}
+                  <span className="legacy-blog-dot">·</span>
+                  <code className="admin-record-rkey">/blogging/{post.slug}</code>
+                  {post.images.length > 0 && (
+                    <>
+                      <span className="legacy-blog-dot">·</span>
+                      {post.images.length} image{post.images.length === 1 ? '' : 's'}
+                    </>
+                  )}
+                </div>
+                {post.description && (
+                  <p className="legacy-blog-excerpt">{post.description}</p>
+                )}
+                {st?.message && (
+                  <p
+                    className={`legacy-blog-status${st.status === 'error' ? ' admin-error-inline' : ''}${
+                      st.status === 'done' ? ' admin-success' : ''
+                    }`}
+                  >
+                    {st.message}{' '}
+                    {st.status === 'done' && st.href && (
+                      <Link to={st.href} className="admin-link-subtle">View →</Link>
+                    )}
+                  </p>
+                )}
+              </div>
+              <div className="legacy-blog-actions">
+                <button
+                  type="button"
+                  className="admin-gate-button admin-gate-button-tight"
+                  onClick={() => runOne(post)}
+                  disabled={busy}
+                >
+                  {st?.status === 'running'
+                    ? 'Migrating…'
+                    : isMigrated
+                      ? 'Re-migrate'
+                      : 'Migrate'}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </PageShell>
   );
 }

--- a/writing/blogs/creating-a-decentralized-bathroom-at-protocol.md
+++ b/writing/blogs/creating-a-decentralized-bathroom-at-protocol.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: "Creating a decentralized bathroom (powered by the AT Protocol)"
+date: "2025-03-08"
+time: "10:00am EST"
+author: "Dame"
+excerpt: "As many of you know by now, I am a Lexicon enjoyer. So much so that this week I created the world's first bathroom that is connected to the AT Protocol. Yes, you read that correctly..."
+blueskyUri: "3ljvamka4422e"
+ogImage: "/images/blog/creating-a-decentralized-bathroom-at-protocol.jpg"
+---
+
+As many of you know by now, I am a [Lexicon](https://atproto.com/guides/lexicon) enjoyer. So much so that this week I created the world's first bathroom that is connected to the AT Protocol. Yes, you read that correctly...
+
+But before we get to that, let's cover some basics for the new folks in the room.
+
+## "Explain the AT Protocol like I'm 5"
+
+Bluesky is a semi-decentralized social networking platform built on top of a new internet protocol known as the AT Protocol that uses arbitrary JSON schemas and personal data servers (PDSs) to empower user agency and autonomy. Kinda technical and difficult to understand underneath all that jargon, right? Here's a simpler way of thinking about it...
+
+**You can now own your social networking data, take it with you wherever you want, and never be locked into an app ever again.**
+
+The most exciting part of the AT Protocol to me is the concept of the [Personal Data Server (PDS)](https://docs.bsky.app/docs/advanced-guides/atproto) and the way data is stored on it. Every single post, like, reply, or follow you make on Bluesky is stored in your own PDS in the form of a lexicon record. 
+
+### Lexicons are just File Formats
+
+For the non-technical in the audience, **a Lexicon is basically just a file format** for the AT Protocol... think of it like a file on your computer that might come in many different forms: .jpg, .pdf, .doc, .txt
+
+These "file formats" are called [NSIDs](https://atproto.com/specs/nsid) and look like domain names that are backwards. Here's what Bluesky's "file formats" look like under the hood:
+
+```
+app.bsky.actor.profile
+app.bsky.feed.like
+app.bsky.feed.post
+app.bsky.feed.repost
+app.bsky.graph.follow
+```
+
+Each of these files contains some of your data that is created from an app like Bluesky. By using tools like [pdsls.dev](https://pdsls.dev/at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj), you can see all of the data that lives within a Bluesky account's personal data server. Pretty neat, right? What's even better is that anyone can create their own "file format" for whatever suits their needs, and any app can easily support any other file format at the app developer's discretion.
+
+This is how the new "decentralized" versions of TikTok, Instagram, Goodreads, etc are able to work so easily. You sign into them with your Bluesky (AT Protocol) account, and they support many of Bluesky's native "file formats" out of the box. No need to write a new bio, upload a new avatar, or create a new username for every account... you simply sign in to an app and it all gets imported "magically".
+
+So, what does any of this have to do with my bathroom, right? 
+
+Up until this point, most developers have been hard at work create new and exciting "file formats" for the AT Protocol that can do interesting things like help you [manage events](), [chat with friends](), or [write long form blog posts](). I've been experimenting with Lexicons myself for a hot minute behind-the-scenes, and I'd like to formally introduce the concept of the **Personal Lexicon**.
+
+## Introducing, the Personal Lexicon
+
+Many people such as myself are big believers in everyone having their own personal website... a plot of digital land that you control and call home. I've had a personal website since I was a teenager, so at least a decade or two by now. I've also been tracking weird and eclectic data about my personal life since I was a child (my first spreadsheet was a list of all the vanity license plates I had seen). I know, I'm a bit of an odd nerd.
+
+All this got me thinking... what if more people had their own personal "file formats"? With the AT Protocol, this is now super easy thanks to Lexicons.
+
+As a proof of concept to show what this could look like, I've begun writing records to my own PDS that utilize my domain name:
+
+```
+is.dame.counting.turtles
+is.dame.tasting.wine
+is.dame.on.the.toilet
+```
+
+Yes, I have a silly file format for going to the bathroom, cause why not?
+
+<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/app.bsky.feed.post/3ljppqso5t22w" data-bluesky-cid="bafyreif6zppvorddm2y5xt6yomohc3ejr4hudd7zv6bltutwvpiml54hma"><p lang="en">i like that my domain name (dame.is) reads like a sentence either forwards or backwards
+
+forwards: it's a statement ➡️
+
+backwards: it's a question ⬅️
+
+something very beautiful and sublime about that<br><br><a href="https://bsky.app/profile/did:plc:gq4fo3u6tqzzdkjlwzpb23tj/post/3ljppqso5t22w?ref_src=embed">[image or embed]</a></p>&mdash; dame (<a href="https://bsky.app/profile/did:plc:gq4fo3u6tqzzdkjlwzpb23tj?ref_src=embed">@dame.is</a>) <a href="https://bsky.app/profile/did:plc:gq4fo3u6tqzzdkjlwzpb23tj/post/3ljppqso5t22w?ref_src=embed">Mar 6, 2025 at 9:36 AM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>
+
+Now I know what some of you fellow nerds are thinking... "WHAT ABOUT MY INTEROPERABILITY?!"
+
+I'm not suggesting everyone throw out collectively used lexicons that we all know and love. That would be dumb. What I am saying though is that not all data needs to be interoperable or socially connected out of the box. Yes, I could create a proprietary "am I on the toilet?" app that is a bespoke social network for those of us who post from the toilet... but that would be silly, right? RIGHT!?
+
+## My decentralized bathroom
+
+Here's the stupid, unhinged, out-of-pocket, bat-shit crazy thing that I made this week... 
+
+![A roll of toilet paper in the bathroom with a white stickerk above it](/images/blog/creating-a-decentralized-bathroom-at-protocol.jpg "nfc sticker")
+
+See that white little circular thing above my toilet paper? That's a cheap NFC sticker I bought online in a roll of 50. When I tap my iPhone against it, it instantly creates a record on my AT Protocol PDS under the Lexicon `is.dame.on.the.toilet`, with the `answer` property being `yes`.
+
+Now, anyone can see when the last time I was on the toilet, and the data is hosted on a decentralized network. Lemme guess, your jealous right? Fine, if you say so...
+
+## Introducing im.flushing
+
+That bespoke social network I mentioned earlier? Well... I decided to actually make it. You can create your first post (called a "flush") here: [https://flushing.im/](https://flushing.im/)
+
+It's like [statusphere.xyz](https://statusphere.xyz), but for seeing who's going to the bathroom right now. You login with your Bluesky/ATProto account, choose an emoji, and let the network know you're on the throne. All records are stored in a custom lexicon:
+
+```
+im.flushing.right.now
+```
+
+It's technically my first official AppView for the AT Protocol and my first public lexicon. What a professional way to kick things off! I hope you enjoy it.
+
+Try it here: [https://flushing.im/](https://flushing.im/)
+
+![A promotional screenshot of the app im.flushing](/images/blog/og-image.png "im.flushing promo image")
+

--- a/writing/blogs/how-i-made-an-automated-dynamic-avatar-for-my-bluesky-profile.md
+++ b/writing/blogs/how-i-made-an-automated-dynamic-avatar-for-my-bluesky-profile.md
@@ -1,0 +1,67 @@
+---
+layout: post
+title: "How I made an automated dynamic avatar for my Bluesky profile"
+date: "2025-02-05"
+time: "10:00am EST"
+author: "Dame"
+excerpt: "Several years ago, back when Twitter was a thing and it had a decent API, my friend @goose.art did a weird little experiment where he made his avatar dynamic... it automatically changed appearances on a regular basis and became increasingly deep-fried (increased in distortion and lossy compression). I've seen several other people mess around with this concept since then, and I've always had it in the back of my head as something I wanted to eventually try for myself."
+blueskyUri: "3lhh4e7j4xk2b"
+ogImage: "/images/blog/automated-avatar-graphics/avatar-grid.jpg"
+---
+
+Several years ago, back when Twitter was a thing and it had a decent API, my friend [@goose.art](https://bsky.app/profile/goose.art) did a weird little experiment where he made his avatar dynamic... it automatically changed appearances on a regular basis and became increasingly deep-fried (increased in distortion and lossy compression). I've seen several other people mess around with this concept since then, and I've always had it in the back of my head as something I wanted to eventually try for myself.
+
+Flash forward to today, and I've finally done exactly that thanks to Bluesky and its wonderful API.
+
+Today I activated an automation that changes my Bluesky avatar every hour of each day to roughly correspond with the daylight (or lack thereof) that I'm experiencing in my time zone (EST). As the sun is rising and setting each day, you'll see it reflected on my profile in the form of ever-changing sky gradients. I felt that this expression was especially appropriate given the theme of the Bluesky brand.
+
+![A screenshot of my bluesky profile showing one of the avatar designs](/images/blog/automated-avatar-graphics/avatar-profile.png "avatar profile example")
+
+In case anyone is wondering how this automation works under the surface, I thought it might be worthwhile to write up a blog post explaining my process. I'm sure all of the devs/engineers can deduce what's going on, but I think I implemented it in a pretty fun way that should be entertaining regardless of your skill level.
+
+## The Visuals and Concept
+
+Ever since coming back to social media after a long break last year, my profile picture had just been my name in Arial font loosely in the style of Charli xcx's Brat album cover. I evolved the design of it overtime to be more my own style, and  then I realized that it would work perfectly for this project. So, I began creating a bunch of interesting variants of the design in Adobe Illustrator.
+
+![A grid showing all 24 versions of my avatar with various sky gradient backgrounds, one for each hour of the day](/images/blog/automated-avatar-graphics/avatar-grid.jpg "bluesky sky avatar gradients grid")
+
+The backgrounds are simple two-color gradients with noise filters applied and then styled with a gaussian blur. The variations of the word "dame" were made using numerous blending layers, strokes, and effects all smashed together in funky and disturbing ways.
+
+![A closeup of one of the dynamic avatars](/images/blog/automated-avatar-graphics/5pmbig.jpg "bluesky sky avatar close up")
+
+After the fact, I realized that the visuals I produced had a taste of Ed Ruscha's style to them, an artist whose work I have long appreciated. 
+
+![A collection of Ed Ruscha paintings hanging on a gallery wall](/images/blog/automated-avatar-graphics/ed-ruscha-example.jpg "ed ruscha example")
+*[Artwork © Ed Ruscha. Photo: Rob McKeever](https://gagosian.com/exhibitions/2017/ed-ruscha-custom-built-intrigue-drawings-1974-1984/)*
+
+## The "Code"
+
+While I could have used a traditional [cron job](https://en.wikipedia.org/wiki/Cron) to schedule the changes each hour, that seemed pretty boring, and I have an affinity towards making Apple Shortcuts... so I challenged myself to go that route instead, which had the added benefit of letting me control things from wherever I happen to be thanks to the fact that I have my phone with me at all times.
+
+There were several possible ways to implement the necessary API calls, and I tried several of them, but ultimately I landed on using a single dictionary full of the necessary CIDs for each image. Every hour the shortcut performs these steps:
+
+1. Queries the dictionary for the image CID corresponding to the current time.
+2. Authenticates my Bluesky account using an app password.
+3. Uses the API to fetch my profile's current data.
+4. Builds a POST request using the fetched profile data + the new avatar CID, before then sending it back via the putRecord endpoint.
+5. Checks that the data was updated correctly and notifies me if there was an error.
+
+![A screenshot of the apple shortcut code that automates the bluesky avatar](/images/blog/automated-avatar-graphics/apple-shortcut.png "bluesky apple shortcut avatar automation")
+
+There's quite a bit of regex that was needed to properly match/filter JSON data, and I don't know regex, but luckily claude/chatgpt is very good at writing it for me.
+
+The one surprise I had along the way was realizing that I couldn't just push one element of profile data through the API... I originally sent a test request through that just contained the avatar update, and quickly discovered that it "removed" my display name, banner, pinned post, and description because I didn't include those elements in the data I was pushing. That's why the Apple Shortcut includes the step of fetching the existing profile data, so that even though nothing else changes it can be fed back into the POST request along with the avatar update.
+
+Here's a copy of [the Apple Shortcut file](https://www.icloud.com/shortcuts/dd304c7087b84a90bd7286c887e94caa) if you're interested in looking at the "code" yourself or modifying it.
+
+## Future Updates and Ideas
+
+I'd like to create a Version 2 of this project in a few weeks that adds some additional elements like logic paths and layers that display based on weather data (fog, rain, cloud cover, rare random events like shooting stars, etc). It would also be nice to automate my banner image to match the backgrounds of the avatar.
+
+In addition to this automation, I also added a dynamic bio to my status update account ([@now.dame.is](https://bsky.app/profile/did:plc:jucg4ddb2budmcy2pjo5fo2g)) that includes regularly updated data about my current psychological state + environment (focus level, mood, current song, indoor temp, etc).
+
+![A screenshot of my status update profile showing dynamic data](/images/blog/automated-avatar-graphics/bio-profile.png "bio profile example")
+
+Using Apple Shortcuts to automate Bluesky data has a lot of interesting experimental potential thanks to the large number of automation triggers that Apple provides. Everything from sound recognition to whether or you're stationary or not... and don't even get me started with NFC tags. I hope we see more people trying weird things in the future.
+
+Special shout out to [@cagrimmett.com](https://bsky.app/profile/did:plc:xs7gyx2tysuh5dy33bvgkntb) for sharing [this template](https://www.icloud.com/shortcuts/aea8c8f6cb074e179be0a28ff2145c48) that saved me a bunch of time  I would've spent trying to figure out how to setup the session/auth functions.

--- a/writing/blogs/my-personal-goals-for-2025.md
+++ b/writing/blogs/my-personal-goals-for-2025.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: "My personal goals for 2025"
+date: "2024-12-26"
+time: "10:00am EST"
+author: "Dame"
+excerpt: "Yes, I'm a new year goals person... have been most of my life."
+blueskyUri: "3leact5gkl22t"
+ogImage: "/images/blog/social-images/my-personal-goals-blog.jpg"
+---
+
+Yes, I'm a new year goals person... have been most of my life.
+
+While the Gregorian calendar is probably not the best or most interesting framework for time, it is the most widely used across the planet, and it's deeply embedded in my psyche, so I continue to find it helpful to make plans around. If it's cringe to do so, then I'm cringe.
+
+I don't subscribe to any particular goal-setting methodology, but I do attempt to keep things organized, simple, and natural with a mix of both qualitative and quantitative measurements as is appropriate. I should note that I'm deeply suspicious of tech people who use OKRs or similar corporate paradigms for their personal or relational development.
+
+Also, I don't ever expect or hold myself to achieving all my goals to 100%. I'm usually satisfied as long as I make forward progress on things, especially if it ends up being like 50-70% of the way there. That's not to say my goals are aspirational, it's more just to say that I'm not a stickler.
+
+Anywho, I wanted to provide that bit of context for all the new people I've met this year who aren't familiar with my feelings on the topic yet.
+
+## Health
+- Continue aiming for a somewhat mediterranean diet
+- Continue playing tennis 2-3 times a week
+- Continue to consume a lower amount of added sugar, alcohol, and fried food
+- Start exercising outside of tennis on a regular basis
+- Start going back to the dentist after ~1 year off
+- Consider trying to reduce the dosages of my mental health related medications (anxiety/depression) now that I've been stable for awhile
+- Get to bed earlier and achieve 7-8 hours of sleep
+
+## Career
+- End my (unpaid) sabbatical
+- Land my next job (ideally thru relationships and discovery rather than applications) OR begin to generate income from a project
+
+## Art
+- Use are.na on a daily/weekly basis
+- Create one major art project
+- Create one minor art project
+- Create a new series of photographs
+
+## Development
+- Build another web app
+- Make a custom website for myself for the first time
+- Launch [redacted]
+- Finally get Bluesky oAuth working
+
+## Content
+- Begin publishing longer form content on my blog at least once a month
+- Create some sort of helpful + free "evergreen" content series
+- Continue microblogging daily
+
+## Tennis
+- Take some private tennis lessons to improve fundamentals
+- Play in a tennis league now that I'm not a total noob
+- Setup some singles matches rather than just playing doubles
+
+## Dating
+- Find someone I want to enter into a formal relationship with (doesn't necessarily need to be extremely serious, but I want to go beyond the 4-8 dates stage that I've experienced several times in 2024)
+- If need be, continue going on first dates regularly (2-4 a month ideally)
+
+## Friendship
+- Make some new friends within a 50 mile radius of where I live
+- Cultivate existing relationships
+- Find and join a book club
+
+## Personal & Spiritual Development
+- Meditate more than I did in 2023
+- Research sigils and magick finally
+- Read at least one book a month
+- Start journaling again
+- Take a solo trip
+- Travel someplace new
+- Clean the garage
+- Volunteer for something
+
+If you have goals for 2025, I'd love to hear what they are!

--- a/writing/blogs/my-top-10-moments-of-2024.md
+++ b/writing/blogs/my-top-10-moments-of-2024.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: "My top 10 moments from 2024"
+date: "2024-12-31"
+time: "10:00am EST"
+author: "Dame"
+excerpt: "Rhett & Link have a tradition of using their final podcast episode of the year to rank their top 10 moments of the year. These are always some of my favorite episodes of Ear Biscuits, so I thought I should try to do the same thing for myself."
+blueskyUri: "3len3e4oemc2j"
+ogImage: "/images/blog/social-images/my-top-10-moments-blog-image.jpg"
+---
+
+Rhett & Link have a tradition of using [their final podcast episode of the year to rank their top 10 moments of the year](https://www.youtube.com/watch?v=LXG_plpS69M). These are always some of my favorite episodes of Ear Biscuits, so I thought I should try to do the same thing for myself.
+
+For me, "top moments" refers to experiences I had that made a lasting impact on my life even if they were difficult. I was fortunate to have a fairly good year though, as opposed to 2023 which was probably the hardest year of my life. Ranking my moments was difficult, so don't read too much into the order I've listed them in. I'll start at number 10 and work up to number one.
+
+## 10. Becoming obsessed with music again.
+
+I give full credit to Charli xcx for making this happening; the release of BRAT was so monumental for my musical journey that I can't possibly measure its impact. She was my most listened artist of the year and her songs made up half of my top 10 songs. It was because of BRAT that I discovered Magdalena Bay, SOPHIE, Alice Longyu Gao, and Caroline Polachek... each of whom also dominated my year's discography. For most of my adult life I've probably averaged less than 5,000 minutes a year of music listening, and I'd go long stretches of not listening to anything.
+
+## 9. Celebrating one year of playing tennis.
+
+In an effort to stay active and be more social, I started taking tennis lessons and joined a tennis club in late 2023. For the entire year of 2024, I played tennis 2-3 times a week religiously and it's probably been one of the greatest decisions of my entire life. Much like BRAT, I can't begin to fathom the innumerable ways in which it has impacted my life for the better. To celebrate my 1 year anniversary I finally bought new tennis shoes and a better racket.
+
+## 8. Moving into a new house.
+
+My first house was purchased during the first year of the COVID-19 pandemic with my ex when interest rates were at historic lows. When our relationship ended in 2023, I knew that I needed to get into a new place in order to be able to fully move on. I cried a lot on the day that I moved into the new home, but after about a month I was settled and at peace.
+
+## 7. Seeing my niece grow and playing with her.
+
+She turned 1 year old in 2024 and it's been so much fun seeing her grow and getting to spend time with her. I hadn't really spent time around kids or babies as an adult, so it was inspiring to watch her curiosity. The concept of Shoshin (Beginner's Mind) has been very important to me ever since I started studying Buddhism 7 years ago, so watching her has been a helpful reminder to work on staying young at heart.
+
+## 6. Dating for the first time.
+
+I'm writing a much longer retrospective about my year in dating, so I'll save most of my reflections for it... but overall I really enjoyed actively dating for the first time at the age of 31. I learned about myself, developed some new skills, made new memories, met a lot of cool people, and even ended up with some new friendships as a result.
+
+## 5. Making my first web app.
+
+This is probably the freshest experience from the year because it happened in December, but it's been very consequential. I've been a software enthusiast as a user and a non-technical employee at software companies for over a decade, but I always dreamed of one day making my own things. I took the plunge by making [a relatively simple tool for Bluesky/Atproto](https://reviewer.skeet.tools) that let's you sort through all of your posts and selectively delete stuff that you no longer want using the KonMari method. I'm even already hard at work developing my second web app which should launch in January!
+
+## 4. Spending extended time together as a family.
+
+My immediate family hadn't gone on a family vacation together since us kids became adults, that is until last year when we traveled abroad together for the first time. It seems like we're now going to try to make some sort of trip a yearly tradition, so we rented a beach house together for a week during the summer. It was very relaxing and fun just to hang out with everyone.
+
+Secondarily, when Hurricane Helene slammed through the southeastern United States we were without power for 3-5 days and I was able to use my electric vehicle to power a large portion of my house, so my immediate family camped out at my place for a lot of the outage. It was a nice excuse to see everyone.
+
+## 3. Making new friends who are geographically close.
+
+I've lived in the same general region for most of my life, and I started to realize that a lot of my geographically close friendships had naturally fizzled out for one reason or another over the years. People move away, life stages change, etc. I started to make a concerted effort to make new connections even though I knew it was going to be an uphill battle. While I didn't suddenly find myself with a massive new friend group, I did end the year with a handful of special connections that went beyond a few hangouts, and for that I'm very grateful. I may write a longer post about this in the future because I know a lot of people find themselves in a similar predicament and aren't even sure where to even start.
+
+## 2. Leaving my job to go on an unpaid sabbatical.
+
+I graduated college in the mid 2010s and worked part-time in school, so I've been a "professional" for a decade now without taking enough time off. I'm not a workaholic by any means and have taken a handful of small vacations here and there, but the sustained period of work did take a toll on my overall wellbeing. I'm incredibly privileged to have worked in some relatively high paying jobs (not for my industry necessarily, but for the region and social sphere in which I live), so I've been lucky to have enough savings that it makes taking a sabbatical a financially responsible thing to do.
+
+I'd like to give a special shoutout/thanks to [Mosh (Michelle Lee)](https://bsky.app/profile/mosh.bsky.social) and [Robin Berjon](https://bsky.app/profile/robin.berjon.com) for being such nice managers/coworkers in my most recent position at IPFS (and for being so understanding of my need to step away). Mosh and I met on Twitter several years ago and she must have seen something in me that led her to think I would be a good fit for some projects that she was overseeing/advising. That was the second time that being a chronically online poster somehow led to formal employment.
+
+My sabbatical is now coming to a close, so I'll be beginning to explore what's next for my career in 2025. I'm refreshed now and excited to enter into the next decade of my career with renewed passion and clarity. If you'd like to work together in 2025 or think I might be a good fit for something in your orbit, feel free to [DM me on Bluesky](https://bsky.app/profile/dame.bsky.social), [use my contact page](http://dame.contact), or send me a text if you the number. My skillset is very diverse.
+
+I'm most interested in technology that enables humans to live healthier and more rewarding lives... stuff like thoughtfully designed software (are.na, iA writer, Bluesky, iOS apps), impactful consumer hardware (Withings home health, Apple Watch, novel computing), and emerging protocols/communities (atproto).
+
+## 1. Being happy again.
+
+As I said in the introduction, 2023 was probably the hardest year of my life so far. I experienced more difficult emotions than easy ones, and I felt like I was drowning a lot of the time. Thankfully, I was able to persevere with the help of family, friends, better healthcare, and lifestyle changes. All of the hard work I put in meant that a good portion of 2024 turned out to be extremely happy and fulfilling... I came out the other side feeling healthier than ever. 
+
+I have a renewed gratitude for life and the good things in it.
+
+## Honorable mentions
+- Investing time in are.na
+- Getting back on social media (Bluesky) after a long break
+- Going to the Mythical Tour
+- Trip to see snow with my sister
+- Picnics with my dog in the park
+
+Here's to whatever comes my way in 2025! Happy new year!

--- a/writing/blogs/why-i-started-posting-like-its-the-2000s-again.md
+++ b/writing/blogs/why-i-started-posting-like-its-the-2000s-again.md
@@ -1,0 +1,58 @@
+---
+layout: post
+title: "Why I started posting like it's the 2000s again"
+date: "2025-01-29"
+time: "10:00am EST"
+author: "Dame"
+excerpt: "In November of 2007, Facebook made a tiny change to its user interface that would massively influence what we know of today as a 'post' on social media. What was that change?"
+blueskyUri: "3lgvhp7rq622b"
+ogImage: "/images/blog/social-images/why-i-started-blog-image.jpg"
+---
+
+In November of 2007, Facebook made a **tiny** change to its user interface that would massively influence what we know of today as a "post" on social media. What was that change?
+
+They removed the mandatory word "is" from the beginning of what were once called "status updates".
+
+> Initially, the status format forced you to write about yourself in the third person; you couldn't get rid of the verb "is" after your name, so getting your feelings across often required some grammatical maneuvering. ([source](https://www.the-independent.com/life-style/facebook-status-post-evolution-anniversary-b2489534.html))
+
+In those days, all of our posts looked like this:
+
+> Dame is watching a movie
+
+> Dame is hanging out with friends
+
+> Dame is sad
+
+![An old screenshot of Facebook mobile from 2007 that shows how status updates use to look](/images/blog/2007-facebook-status-updates.jpg "2007 facebook status updates")
+*image source: [tech crunch](https://techcrunch.com/2007/08/15/facebook-iphone-ultrahype/)*
+
+Back then, social media was a place you went to keep up with what your friends were actually **doing**. You didn't go there to consume the news, follow influencers, or debate culture war issues with strangers.
+
+Social media was a digital location for the expression of your state of being. After all, the word "is" is the 3rd-person singular present indicative of the word "be", which means "to exist or live" as in Shakespeare's existential question: "To be or not to be..."
+
+But overtime, most social media websites shifted towards prompting you with questions like "What's on your mind?" (Facebook) or "What's happening?" (Twitter) instead of asking for a simple update about the state of your current existence. These subtle UI changes turned out to be massively consequential for how we experience reality in the 2020s, a time period in which social media has finally worked its way inside almost every facet of our lives.
+
+![An old screenshot of Facebook showing the newer "what's on your mind?" status prompt](/images/blog/facebook-new-status-prompt.png "new facebook status prompt")
+*image source: [chscommunicator](https://chscommunicator.com/23672/features/2012/01/facebook-status-whats-the-point/)*
+
+While I'm glad that the concept of "posting" on social media evolved over time, I am sad that we seemed to essentially abandoned the traditional "status update" of Facebook's yesteryears in the process. I wish people still made simple reports of what they were doing, eating, reading, or listening to. 
+
+**I think this loss is part of a larger phenomenon of everyone becoming much more disembodied and less grounded while we're inhabiting digital spaces.** To help combat this shift in my own life, I decided to create a new personal website this year that felt more "alive" and reflective of my lived experience. The frameworks that social media unconsciously put us within do not lend well to mindfulness or embodiment, and I wanted to take a swing at giving myself a healthier digital playground.
+
+For the past 4-5 years, I've kept a fairly consistent [logbook](https://en.wikipedia.org/wiki/Logbook) of what I was doing at almost every hour of the day. Doing this is a form of journaling for me, and it's neat to be able to look back at a given time in my life and see what the day-to-day experience was like. We tend to easily remember major events or certain qualia about our past lifestyles, but the seemingly mundane or simpler parts tend to be easily forgotten if we don't keep a record of them.
+
+![A screenshot of dame's logbook that shows various logs such as "eating a bowl of freshed mixed berries" and "visiting with parents"](/images/blog/dame-logbook-example.jpg "dame logbook example")
+
+As I was thinking about how to make my new website feel "alive", I realized it would be interesting if I began publishing all of my daily logs publicly and in a format similar to Facebook's old "status updates". So, I acquired the domain **dame.is**, and hacked together a solution that would make sharing all of my logs really simple. 
+
+When you go to my website, the most prominent thing featured are now these status updates. This means that if you visit my site 8 different times in a given day, you'll likely see 8 different reports of what it is that I'm currently doing... much like you'd have seen from me back during the early days of Facebook.
+
+![A screenshot of the dame.is website navigation bar that says "dame is taking a shower as of 16 minutes ago](/images/blog/dame-is-website-example.jpg "dame.is website example")
+
+How might you incorporate this into your social media practice? Well, you could start sharing these kinds of updates on your main account periodically... or you might create a separate account for them so that people could selectively see them only if they want to. My dame.is status updates are actually hosted on a dedicated Bluesky/Atproto PDS using Bluesky's post lexicon, and then my website merely fetches that data anytime it loads. So, you can also follow my status updates on Bluesky from that account: [@dame.is](https://bsky.app/profile/did:plc:jucg4ddb2budmcy2pjo5fo2g)
+
+For speed and efficiency's sake, I created an Apple Shortcut that is triggered via my iPhone's Action Button that allows me to quickly type in the update and have it sent to the Bluesky account via the API. This allows me to post an update in less than 15 seconds from either my phone or my watch.
+
+Here's a template of the shortcut I use if you're interested in seeing it in action: [shortcut link](https://www.icloud.com/shortcuts/b21adf7035d14992941ef72855d9003a)
+
+**What other helpful frameworks from the web's past have we accidentally discarded? What new methods might we create to foster more groundedness in our digital lives?**


### PR DESCRIPTION
Recovers the blog posts from the pre-rewrite Eleventy site and adds an admin panel to publish them to the PDS as `site.standard.document` blog records.

## What it does
A new **"Legacy blog migration"** view in the admin (`/admin?view=legacy-blogs`) lists all six recovered posts with date, slug, image count, and excerpt, and gives you a per-post **Migrate** button plus **Migrate all**. Posts already on the PDS are detected and badged.

Each migration:
- Converts the markdown into `pub.leaflet.content` blocks — the same shape the blocks editor produces (headings; text with link/bold/italic/code facets at UTF-8 byte offsets; ordered + nested lists; code fences; standalone images; blockquotes as italics; and the raw Bluesky embed recovered into a `bskyPost` block).
- Uploads every referenced image and the cover image to the PDS as blobs.
- Writes the record with `rkey = slug` so the classic `/blog/<slug>` → `/blogging/<slug>` links keep resolving and re-runs overwrite rather than duplicate.
- Wires each post's `blueskyUri` into `commentsUri` so the Bluesky comment thread shows up.

## Where the posts came from
The five original posts weren't in this repo's history — they lived on the pre-rewrite Eleventy commit (`11bfea9`) and are now checked into `writing/blogs/`, alongside the sixth (`how-to-use-bluesky-to-grow-your-brand.md`) that was already present.

## Changes
- `writing/blogs/*.md` — the recovered Eleventy posts, bundled via Vite so their `/images/blog` assets get real served URLs (the root `images/` dir isn't served in production).
- `src/lib/legacyBlogMarkdown.js` — pure, unit-tested markdown → `pub.leaflet.content` conversion.
- `src/lib/legacyBlog.js` — front-matter parsing, image blob uploads, and the idempotent PDS write.
- `src/pages/Admin.jsx` / `Admin.css` — the migration view and its picker card.
- `src/config.js` — `BLOG_PUBLICATION` (the "dame's leaflets" publication) as the `site` value for migrated docs.

## Verification
- Offline build passes; the Admin route loads in a headless browser with no code errors.
- A Node test ran the converter over all six real posts: 0 structural problems — every facet in-range and non-overlapping, lists/images/embeds well-formed.
- Confirmed `/images/blog/...` returns the SPA HTML in production, so images are routed through Vite's asset pipeline; verified the built `/assets/*.jpg` serve real image bytes (what the migration fetches).
- The PDS write itself uses the same `putRecord`/`uploadBlob` agent calls as the rest of the admin and produces records matching existing blog docs; it couldn't be exercised headlessly since it needs an OAuth login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL)_