### PR TITLE
Render images on live-fetched blog posts

### DIFF
--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -9,6 +9,7 @@ import { resolvePds, listRecords } from '../lib/atproto.js';
 import { formatDateLong, relativeTime } from '../lib/time.js';
 import { dayOfLife } from '../lib/dayOfLife.js';
 import { getPostThread } from '../lib/atproto.js';
+import { transformRecords } from '../lib/feedBuilder.js';
 import { isPortfolioDoc } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Blogging.css';
@@ -32,7 +33,16 @@ export default function BlogPost() {
     strategy: 'snapshot-first',
     fetchLive: async () => {
       const pds = await resolvePds(ME_DID);
-      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.blogging, max: 200 });
+      const records = await listRecords(pds, {
+        repo: ME_DID,
+        collection: COLLECTIONS.blogging,
+        max: 200,
+      });
+      // Bake `_url` onto image/cover blob refs (and a summary) so live-fetched
+      // posts — ones not yet in the prefetched snapshot — render their images.
+      // The snapshot path already does this at build time via transformRecords.
+      transformRecords(records, COLLECTIONS.blogging, pds, ME_DID);
+      return records;
     },
     mapItems: (data) => resolveById(data, id),
     deps: [id],

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -6,6 +6,7 @@ import { BloggingTocSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
+import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
 import { isPortfolioDoc } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -28,7 +29,15 @@ export default function Blogging() {
     strategy: 'snapshot-first',
     fetchLive: async () => {
       const pds = await resolvePds(ME_DID);
-      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.blogging, max: 200 });
+      const records = await listRecords(pds, {
+        repo: ME_DID,
+        collection: COLLECTIONS.blogging,
+        max: 200,
+      });
+      // Match the snapshot path: bake blob `_url`s (and a summary fallback) so
+      // live-fetched posts render consistently with prefetched ones.
+      transformRecords(records, COLLECTIONS.blogging, pds, ME_DID);
+      return records;
     },
     mapItems: mergeBlogEntries,
   });


### PR DESCRIPTION
Fixes migrated posts rendering their text but not their images until the next prefetch.

## Cause
`LeafletDocument`'s image renderer draws `block.image._url`. That `_url` (the `com.atproto.sync.getBlob` URL) is stamped by `transformRecords` / `annotateLeafletBlobs`. `/creating` runs `transformRecords` on its live fetch, but `BlogPost` and `Blogging` returned a bare `listRecords` result — so blob URLs were only ever baked in the **prefetched snapshot**. A freshly migrated post that isn't in the snapshot yet had valid blob refs with no resolvable URL, so its images rendered blank while the text (which needs no annotation) showed fine.

## Fix
Run `transformRecords(records, COLLECTIONS.blogging, pds, ME_DID)` on the live fetch in `BlogPost.jsx` and `Blogging.jsx`, matching the snapshot path and the `/creating` pages. This bakes `_url` onto image and cover blob refs (plus a summary fallback) so live-fetched posts render images immediately, without waiting for a rebuild.

## Verification
- Confirmed the constructed `getBlob` URL serves the real image (content-type `image/png`, `content-length` matching the record's blob `size`).
- `transformRecords` routes `site.standard.document` to cover + content blob annotation.
- Offline build passes. (Full in-browser render couldn't be exercised in the sandbox — the headless browser has no outbound network to reach the PDS — but the mechanism is verified above and mirrors the working `/creating` path.)

No re-migration needed; this is a read/render fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL)_