### PR TITLE
Fix blog post text overflow and scroll-to-top on navigation

### DIFF
--- a/src/components/LeafletDocument.css
+++ b/src/components/LeafletDocument.css
@@ -3,6 +3,9 @@
   font-size: 1.05rem;
   line-height: 1.6;
   color: var(--ink);
+  /* Long unbreakable tokens (bare URLs, AT URIs, NSIDs) must wrap instead of
+     pushing the column wide and forcing a horizontal scroll. */
+  overflow-wrap: break-word;
 }
 
 .leaflet-paragraph {

--- a/src/components/RouteTransition.jsx
+++ b/src/components/RouteTransition.jsx
@@ -1,4 +1,5 @@
-import { useLocation, Routes } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigationType, Routes } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 
 /**
@@ -18,7 +19,15 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
  */
 export default function RouteTransition({ children }) {
   const location = useLocation();
+  const navType = useNavigationType();
   const reduce = useReducedMotion();
+
+  // Reset scroll to the top on forward navigation so a new page starts at its
+  // top rather than inheriting the previous page's scroll offset. POP (back /
+  // forward) is left alone so the browser can restore the prior position.
+  useEffect(() => {
+    if (navType !== 'POP') window.scrollTo(0, 0);
+  }, [location.pathname, navType]);
 
   if (reduce) {
     return <Routes location={location}>{children}</Routes>;

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -67,6 +67,12 @@
 }
 
 .blog-article {
+  /* `width: 100%` is load-bearing: `.page` is a flex column, and the auto
+     margins below otherwise defeat flex stretch, letting the article size to
+     its max-content (clamped to --measure) and overflow narrow viewports.
+     Pinning width to the column keeps --measure a cap, not a floor. Mirrors
+     the same fix already applied to the sibling `.page-title` below. */
+  width: 100%;
   max-width: var(--measure);
   margin: 0 auto;
 }


### PR DESCRIPTION
Two layout bugs, both visible on the migrated posts.

## 1. Text overflowing the right edge
`.blog-article` lives in a flex-column `.page` and has `margin: 0 auto`. Auto margins defeat flex `stretch`, so the article sized itself to its **max-content** (clamped to `--measure` = `65ch` ≈ 520px) instead of the parent's width. On a phone the article became 520px inside a ~358px column, so every paragraph ran past the right edge and forced a horizontal scroll.

**Fix:** pin `width: 100%` so `--measure` acts as a cap, not a floor (the sibling `.page-title` already had this exact fix). Also added `overflow-wrap: break-word` on `.leaflet-doc` so long unbreakable tokens (bare URLs, AT URIs, NSIDs) wrap rather than widening the column.

Diagnosed and verified with an offline harness rendering the real post through the actual CSS:

| viewport | article width | horizontal overflow |
| --- | --- | --- |
| 360px | 328px | none |
| 390px | 358px | none |
| 768px | 520px (measure) | none |
| 1200px | 520px, centered | none |

(Before: article was 520px at every width, overflowing anything narrower.)

## 2. New page starts part-way scrolled
Route changes kept the previous page's scroll offset, so opening a post from a scrolled-down index landed you mid-post. `RouteTransition` now resets scroll to top on **forward** navigation; POP (back/forward) is left alone so the browser restores the prior position. Fixes it site-wide, not just the blog.

Offline build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH8boYeS6h2Qgo56J1yCfL)_