### PR TITLE
Animate breadcrumb reveal with transform/opacity, not height, to keep scroll smooth

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -94,27 +94,31 @@
   top: 100%;
   left: 0;
   right: 0;
-  background: var(--surface-raised);
-  /* Keep this strip out of the browser's scroll-anchoring calculation so its
-     collapse never nudges the scroll position. */
+  /* A fixed-height clip (height auto = the strip's natural height, since the
+     strip slides via transform without affecting layout). The strip slides
+     within this box; the box itself is transparent so when the strip is
+     translated up out of view, the page content shows through. */
+  overflow: hidden;
+  /* Keep this strip out of the browser's scroll-anchoring calculation so it
+     never nudges the scroll position. */
   overflow-anchor: none;
-  /* inline `overflow: hidden` on the element animates the height reveal so
-     the strip unrolls downward from under the bar. The bottom rule lives on
-     the inner row (not here) so nothing paints when collapsed to height 0. */
-}
-
-@media (min-width: 65rem) {
-  .chrome-bar-tertiary-wrap {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 .chrome-bar-tertiary {
+  background: var(--surface-raised);
   border-top: 1px solid var(--rule-soft);
   border-bottom: 1px solid var(--rule);
-  overflow: hidden;
   min-height: 0;
+  /* Promote to its own compositor layer so the slide is a pure transform —
+     no layout, no repaint of the page, nothing that can stall scrolling. */
+  will-change: transform;
+}
+
+@media (min-width: 65rem) {
+  .chrome-bar-tertiary {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
 }
 
 .chrome-breadcrumb {

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -143,66 +143,60 @@ export default function ChromeBar() {
           )}
         </AnimatePresence>
 
-        {/* Breadcrumb stays mounted the whole time we're off the home page and
-            only its height/opacity animate on scroll. Mounting/unmounting a DOM
-            node synchronously inside the scroll handler (as AnimatePresence did)
-            interrupted the browser's momentum scroll on the way up — the node
-            removal stalled the scroll. Persisting the node avoids that entirely
-            while keeping the same unroll look. */}
+        {/* Breadcrumb stays mounted the whole time we're off the home page,
+            and the reveal animates ONLY transform + opacity — never height.
+            A height:auto animation forces a layout measurement/reflow on the
+            frame it starts, and a reflow mid-scroll hands scrolling back to
+            the main thread and stalls the momentum. transform/opacity run on
+            the compositor and can't interrupt the scroll. The strip slides
+            down from behind the bar inside a fixed clip (`overflow: hidden`
+            on the wrap) instead of growing the box. */}
         {crumbs.length > 0 && (
-          <motion.div
+          <div
             id="chrome-bar-tertiary"
             className="chrome-bar-tertiary-wrap"
-            initial={false}
-            animate={{ height: showBreadcrumb ? 'auto' : 0 }}
-            transition={{ duration: reduce ? 0 : 0.32, ease: [0.32, 0.72, 0, 1] }}
-            style={{ overflow: 'hidden' }}
             inert={showBreadcrumb ? undefined : ''}
             aria-hidden={showBreadcrumb ? undefined : true}
+            style={{ pointerEvents: showBreadcrumb ? 'auto' : 'none' }}
           >
-            <div className="chrome-bar-row chrome-bar-tertiary">
-              <motion.nav
-                className="chrome-breadcrumb"
-                aria-label="Breadcrumb"
-                initial={false}
-                animate={{ opacity: showBreadcrumb ? 1 : 0, y: showBreadcrumb ? 0 : -6 }}
-                transition={{
-                  duration: reduce ? 0 : 0.24,
-                  ease: [0.22, 0.61, 0.36, 1],
-                  delay: reduce ? 0 : (showBreadcrumb ? 0.04 : 0),
-                }}
-              >
+            <motion.div
+              className="chrome-bar-row chrome-bar-tertiary"
+              initial={false}
+              animate={{ y: showBreadcrumb ? '0%' : '-100%', opacity: showBreadcrumb ? 1 : 0 }}
+              transition={{ duration: reduce ? 0 : 0.32, ease: [0.32, 0.72, 0, 1] }}
+            >
+              <nav className="chrome-breadcrumb" aria-label="Breadcrumb">
                 <ol className="chrome-crumbs">
-                    <li className="chrome-crumb">
-                      <Link to="/" className="chrome-crumb-link chrome-crumb-root" aria-label="Home">
-                        /
-                      </Link>
-                    </li>
-                    {crumbs.map((c, i) => {
-                      const last = i === crumbs.length - 1;
-                      return (
-                        <li key={c.to} className="chrome-crumb">
-                          {i > 0 && (
-                            <span className="chrome-crumb-sep" aria-hidden="true">
-                              /
-                            </span>
-                          )}
-                          {last ? (
-                            <span className="chrome-crumb-current" aria-current="page">
-                              {c.label}
-                            </span>
-                          ) : (
-                            <Link to={c.to} className="chrome-crumb-link">
-                              {c.label}
-                            </Link>
-                          )}
-                        </li>
-                      );
-                    })}
+                  <li className="chrome-crumb">
+                    <Link to="/" className="chrome-crumb-link chrome-crumb-root" aria-label="Home">
+                      /
+                    </Link>
+                  </li>
+                  {crumbs.map((c, i) => {
+                    const last = i === crumbs.length - 1;
+                    return (
+                      <li key={c.to} className="chrome-crumb">
+                        {i > 0 && (
+                          <span className="chrome-crumb-sep" aria-hidden="true">
+                            /
+                          </span>
+                        )}
+                        {last ? (
+                          <span className="chrome-crumb-current" aria-current="page">
+                            {c.label}
+                          </span>
+                        ) : (
+                          <Link to={c.to} className="chrome-crumb-link">
+                            {c.label}
+                          </Link>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ol>
-              </motion.nav>
-            </div>
-          </motion.div>
+              </nav>
+            </motion.div>
+          </div>
         )}
       </header>
 


### PR DESCRIPTION
Follow-up to the breadcrumb chrome. Revealing the breadcrumb still stalled inertial scrolling.

## Root cause
The strip stayed mounted (from the prior fix), but the reveal still animated `height: 0 → auto`. Animating *to* `auto` forces Framer to synchronously measure the natural height — a layout reflow — on the frame the animation begins. A reflow mid-scroll hands scrolling from the compositor back to the main thread, which abruptly stops the momentum.

## Fix
The strip now slides in with `transform` (`translateY -100% → 0`) and `opacity` only — both compositor-thread properties that never touch layout. The wrapper is a fixed-height clip (`overflow: hidden`) the strip slides within, and the strip is promoted with `will-change: transform`. No height animation, no reflow, nothing that can interrupt the scroll.

## Verification
Headless Chromium at a 500px viewport:
- hidden: `opacity 0` + `translateY(-37px)` (slid up out of the clip), `inert`
- shown: `opacity 1` + `transform: none`
- content's document position holds at 58px throughout (still zero layout shift)
- not rendered on the home page

Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZd4aL9CAmnRa5BeLHZ5bM)_