### PR TITLE
Move theme toggle to left of bottom chrome bar

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -251,6 +251,15 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   return (
     <div className="chrome-bar chrome-bar-bottom" role="toolbar" aria-label="Global actions">
       <div className="chrome-bottom-row">
+        <button
+          type="button"
+          className="chrome-nav chrome-theme-toggle"
+          onClick={cycleTheme}
+          aria-label={`Cycle theme (current: ${theme})`}
+          title={`Theme: ${theme} — tap to cycle`}
+        >
+          <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+        </button>
         {filterAvailable && (
           <button
             type="button"
@@ -330,15 +339,6 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
             <Home className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
           </Link>
         )}
-        <button
-          type="button"
-          className="chrome-nav chrome-theme-toggle"
-          onClick={cycleTheme}
-          aria-label={`Cycle theme (current: ${theme})`}
-          title={`Theme: ${theme} — tap to cycle`}
-        >
-          <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-        </button>
         <button
           type="button"
           className={`chrome-nav chrome-nav-bottom ${dockOpen ? 'is-open' : ''}`}


### PR DESCRIPTION
Relocates the theme cycle button to the far-left edge of the bottom chrome bar.

- **Left:** theme · filter · search · info
- **Right:** back · top/bottom · home · compass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vm18PD3gV9uPTxHNeNdw3

---
_Generated by [Claude Code](https://claude.ai/code/session_012vm18PD3gV9uPTxHNeNdw3)_