### PR TITLE
Put timestamp on the verb line for text-less feed posts

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -48,6 +48,35 @@
   max-width: 100%;
 }
 
+/* Head row for text-less posts (images / embed only): the verb gerund
+   sits at the start and the hoisted timestamp at the end, sharing one
+   line instead of leaving the time on a lonely row above the embed. */
+.feed-item-head {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.feed-item-head .feed-item-verb {
+  align-self: baseline;
+}
+
+.feed-item-head-time {
+  flex: 0 0 auto;
+  margin-left: auto;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+/* The hoisted time is a copy of the card's own standalone-time row; show
+   exactly one. In normal density the hoisted copy wins, so hide the
+   in-card row. */
+[data-density='normal'] .feed-item:has(.feed-item-head-time) .post-card-row-meta {
+  display: none;
+}
+
 .feed-item-verb-icon {
   color: var(--ink-muted);
   transition: color 120ms ease;
@@ -1305,6 +1334,21 @@ a.reference-card-profile:focus-visible {
    that verb's icon without needing !important. */
 [data-density='compact'] .feed-item-verb:where(:not(.feed-item-verb-reply):not(.feed-item-verb-thread)),
 [data-density='tight'] .feed-item-verb:where(:not(.feed-item-verb-reply):not(.feed-item-verb-thread)) {
+  display: none;
+}
+
+/* Compact / tight strip the verb column entirely, so the "gerund + time
+   on one line" treatment doesn't apply. Dissolve the head wrapper so the
+   verb badge is a direct child of .feed-item again (the verb-grid rules
+   below rely on that), drop the hoisted time out of flow, and let the
+   card's own standalone-time row carry the timestamp as before. */
+[data-density='compact'] .feed-item-head,
+[data-density='tight'] .feed-item-head {
+  display: contents;
+}
+
+[data-density='compact'] .feed-item-head-time,
+[data-density='tight'] .feed-item-head-time {
   display: none;
 }
 

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -1,7 +1,8 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { CornerDownRight } from 'lucide-react';
 import StatusEntry from './StatusEntry.jsx';
-import PostCard from './PostCard.jsx';
+import PostCard, { postCardShowsStandaloneTime } from './PostCard.jsx';
+import RelativeTimeText from './RelativeTimeText.jsx';
 import BlogCard from './BlogCard.jsx';
 import ListenRow from './ListenRow.jsx';
 import CreatingCard from './CreatingCard.jsx';
@@ -142,6 +143,15 @@ export default function FeedItem({ item }) {
       <span className="feed-item-verb-label">{VERB_LABEL_OVERRIDES[item.verb] || item.verb}</span>
     </>
   );
+  // Text-less posts (images / embed only) would otherwise render their
+  // timestamp on a lonely row above the embed. Hoist a copy up here so it
+  // sits on the same line as the verb gerund ("posting", "reposting",
+  // "replying to @handle", …) instead. In `normal` density this hoisted
+  // time is shown and the card's own row is hidden; in compact/tight —
+  // where the verb column is stripped — this hoisted copy is hidden and
+  // the card's in-place timestamp is what remains (see Feed.css).
+  const hoistTime = cfg.renderer === 'PostCard' && postCardShowsStandaloneTime(item);
+  const hoistTs = hoistTime ? item.createdAt || item.payload?.indexedAt : null;
   const liClassName = [
     'feed-item',
     `feed-item-${item.verb}`,
@@ -160,15 +170,33 @@ export default function FeedItem({ item }) {
       data-thread-length={item._thread?.length}
       onClick={href ? handleRowClick : undefined}
     >
-      {href ? (
-        <Link className={verbClassName} to={href}>
-          {verbInner}
-        </Link>
-      ) : (
-        <span className={verbClassName}>
-          {verbInner}
-        </span>
-      )}
+      {(() => {
+        const verbEl = href ? (
+          <Link className={verbClassName} to={href}>
+            {verbInner}
+          </Link>
+        ) : (
+          <span className={verbClassName}>
+            {verbInner}
+          </span>
+        );
+        if (!hoistTime) return verbEl;
+        const timeEl = href ? (
+          <Link className="gutter post-card-time feed-item-head-time" to={href}>
+            <RelativeTimeText value={hoistTs} />
+          </Link>
+        ) : (
+          <span className="gutter post-card-time feed-item-head-time">
+            <RelativeTimeText value={hoistTs} />
+          </span>
+        );
+        return (
+          <div className="feed-item-head">
+            {verbEl}
+            {timeEl}
+          </div>
+        );
+      })()}
       <Component
         {...item}
         verb={item.verb}

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -8,6 +8,20 @@ import { getReplyHint } from '../lib/postReplyHint.js';
 import PostEmbed from './PostEmbed.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
 
+/**
+ * True when a post has no text body and no foreign-author header, so its
+ * timestamp would otherwise render as a lonely right-aligned row above the
+ * embed (see `showStandaloneTime` below). FeedItem uses this to hoist that
+ * timestamp up onto the verb line instead, keeping the two on one row.
+ */
+export function postCardShowsStandaloneTime({ payload, createdAt, variant = 'timeline' } = {}) {
+  const text = payload?.text || '';
+  const ts = createdAt || payload?.indexedAt;
+  const isOriginalAuthorMe = payload?.author?.did === ME_DID;
+  const showOriginalAuthor = !isOriginalAuthorMe && payload?.author?.handle;
+  return Boolean(!text && !showOriginalAuthor && ts && variant !== 'record');
+}
+
 export default function PostCard({
   verb,
   payload,
@@ -43,6 +57,10 @@ export default function PostCard({
   // OriginalAuthorHeader; otherwise drop it onto its own minimal
   // meta row so the time is still discoverable.
   const showTimeInHeader = showOriginalAuthor && !text && ts && variant !== 'record';
+  // For text-less posts the feed hoists this timestamp up onto the verb
+  // line (see FeedItem + Feed.css); in `normal` density the in-card row
+  // below is hidden by CSS, and in compact/tight — where the verb column
+  // is stripped — this row is what stays visible.
   const showStandaloneTime = !text && !showOriginalAuthor && ts && variant !== 'record';
 
   return (


### PR DESCRIPTION
When a home-feed post has no top-level text (images or an embed only), its timestamp used to sit on a lonely right-aligned row above the embed. This hoists the timestamp up onto the verb-gerund line ("posting", "reposting", "replying to @handle", …) so the two share one row.

## Changes
- **`FeedItem.jsx`** — for text-less `PostCard` items, render the verb badge and a hoisted copy of the timestamp together in a `.feed-item-head` flex row (gerund left, time right).
- **`PostCard.jsx`** — export a `postCardShowsStandaloneTime()` predicate so FeedItem and the card agree on exactly when this applies (no text, no foreign-author header, has a timestamp).
- **`Feed.css`** — the hoisted time is a copy of the card's own standalone-time row; CSS shows exactly one:
  - **normal** density: show the hoisted copy on the verb line, hide the card's in-place row;
  - **compact/tight** (which already strip the verb column): dissolve the head wrapper back to direct children so the existing verb-grid rules keep working, hide the hoisted copy, and let the card's own timestamp carry it as before.

## Verification
Built successfully and checked against the live feed in a browser: 3 meta-only posts picked up the head layout, normal density shows one timestamp on the verb line, and compact density falls back cleanly to the in-card timestamp with no duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmYXQ6PQf7VhdzT1mKDPa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmYXQ6PQf7VhdzT1mKDPa8)_