### PR TITLE
Fix lightbox open flash and make backdrop theme-aware

### DIFF
--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -141,8 +141,7 @@
   font-size: var(--text-sm);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
-  color: var(--ink-on-scrim, #fff);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  color: var(--scrim-ink, #fff);
   opacity: 0.85;
   min-width: 3.25rem;
   text-align: center;

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -15,9 +15,9 @@ const PRESETS = {
     exit: { opacity: 0, y: -6, scale: 0.99 },
   },
   scale: {
-    initial: { opacity: 0, scale: 0.96 },
+    initial: { opacity: 0, scale: 0.92 },
     animate: { opacity: 1, scale: 1 },
-    exit: { opacity: 0, scale: 0.98 },
+    exit: { opacity: 0, scale: 0.96 },
   },
   fade: {
     initial: { opacity: 0 },
@@ -79,7 +79,12 @@ export default function Modal({
   // drop-shadow alone, while still dismissing on outside click because
   // that's owned by modal-root (see handleRootClick), not the scrim.
   const paintsScrim = scrim === 'dark';
-  const dimColor = 'rgba(0, 0, 0, 0.78)';
+  // Theme-aware backdrop: --scrim is a near-black tint in dark themes and a
+  // bright frosted tint in light themes, so the photo reads against a
+  // surround that matches the mode. --scrim-clear is the same color at zero
+  // alpha, so the enter/exit fade only ramps opacity (no gray midtones).
+  const dimColor = 'var(--scrim)';
+  const dimColorClear = 'var(--scrim-clear)';
   const dimBlur = 'blur(8px)';
 
   function handleRootClick(e) {
@@ -108,7 +113,7 @@ export default function Modal({
             key="scrim-dim"
             className={`modal-scrim modal-scrim-${scrim}`}
             initial={{
-              backgroundColor: 'rgba(0, 0, 0, 0)',
+              backgroundColor: dimColorClear,
               backdropFilter: 'blur(0px)',
               WebkitBackdropFilter: 'blur(0px)',
             }}
@@ -118,7 +123,7 @@ export default function Modal({
               WebkitBackdropFilter: dimBlur,
             }}
             exit={{
-              backgroundColor: 'rgba(0, 0, 0, 0)',
+              backgroundColor: dimColorClear,
               backdropFilter: 'blur(0px)',
               WebkitBackdropFilter: 'blur(0px)',
             }}

--- a/src/components/PostEmbed.jsx
+++ b/src/components/PostEmbed.jsx
@@ -237,9 +237,16 @@ function ImageGrid({ images }) {
   const list = (images || []).filter((im) => im?.thumb || im?.fullsize);
   const [lightbox, setLightbox] = useState({ open: false, index: 0 });
   if (list.length === 0) return null;
+  // Pass the already-cached grid thumbnail plus intrinsic dimensions so the
+  // lightbox paints the exact pixels the reader tapped immediately — the
+  // frame is pre-sized and the full-res file swaps in on load, instead of a
+  // blank box that pops to size (the "flash" on open).
   const lightboxImages = list.map((im) => ({
     src: im.fullsize || im.thumb,
     alt: im.alt || '',
+    thumb: im.thumb || undefined,
+    width: im.aspectRatio?.width || undefined,
+    height: im.aspectRatio?.height || undefined,
   }));
   return (
     <>

--- a/src/components/cards/MediaCard.jsx
+++ b/src/components/cards/MediaCard.jsx
@@ -19,9 +19,12 @@ export default function MediaCard({ payload, atUri, source }) {
   const visible = items.slice(0, 4);
   const overflow = Math.max(0, items.length - visible.length);
   const [lightbox, setLightbox] = useState({ open: false, index: 0 });
+  // thumb === src here (same CDN URL as the grid), so the lightbox paints
+  // the cached pixels instantly on open rather than flashing while it
+  // re-fetches.
   const lightboxImages = items
     .filter((it) => it.url)
-    .map((it) => ({ src: it.url, alt: it.alt || '' }));
+    .map((it) => ({ src: it.url, alt: it.alt || '', thumb: it.url }));
 
   return (
     <article className="media-card feed-card" data-at-uri={atUri}>

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -365,7 +365,7 @@ function AlbumArt({ payload }) {
       <Lightbox
         open={lightboxOpen}
         onClose={() => setLightboxOpen(false)}
-        images={[{ src: art.url, alt }]}
+        images={[{ src: art.url, alt, thumb: art.url, width: 600, height: 600 }]}
       />
     </figure>
   );

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -18,6 +18,16 @@
   --highlight:   rgba(94, 122, 71, 0.16);
   --shadow:      rgba(29, 36, 25, 0.14);
 
+  /* Lightbox backdrop — theme-aware. Light themes get a bright frosted
+     scrim so the photo reads against a light surround; dark themes get a
+     near-black one. --scrim-clear shares the same RGB as --scrim so the
+     open/close fade only ramps alpha (no muddy gray midtones). --scrim-ink
+     is the bare-text tone (e.g. the N/M counter) that stays legible on
+     that backdrop. */
+  --scrim:       rgba(230, 222, 195, 0.86);
+  --scrim-clear: rgba(230, 222, 195, 0);
+  --scrim-ink:   rgba(29, 36, 25, 0.9);
+
   --bg:    var(--page);
   --fg:    var(--ink);
   --muted: var(--ink-muted);
@@ -82,6 +92,10 @@
   --highlight:   rgba(163, 180, 134, 0.16);
   --shadow:      rgba(0, 0, 0, 0.45);
 
+  --scrim:       rgba(0, 0, 0, 0.78);
+  --scrim-clear: rgba(0, 0, 0, 0);
+  --scrim-ink:   rgba(236, 228, 203, 0.9);
+
   color-scheme: dark;
 }
 
@@ -109,6 +123,10 @@
   --highlight:   rgba(94, 122, 71, 0.16);
   --shadow:      rgba(0, 0, 0, 0.14);
 
+  --scrim:       rgba(235, 235, 235, 0.86);
+  --scrim-clear: rgba(235, 235, 235, 0);
+  --scrim-ink:   rgba(26, 26, 26, 0.9);
+
   color-scheme: light;
 }
 
@@ -127,6 +145,10 @@
   --tan:         #888888;
   --highlight:   rgba(163, 180, 134, 0.16);
   --shadow:      rgba(0, 0, 0, 0.45);
+
+  --scrim:       rgba(0, 0, 0, 0.82);
+  --scrim-clear: rgba(0, 0, 0, 0);
+  --scrim-ink:   rgba(240, 240, 240, 0.9);
 
   color-scheme: dark;
 }


### PR DESCRIPTION
Two lightbox polish fixes.

## Kill the "flash" on open
`PostEmbed` opened the lightbox loading the uncached full-res image with no placeholder and no reserved dimensions, so a blank box popped to size — reading as a re-render flash. Now the already-cached grid thumbnail and intrinsic dimensions are passed through (as `CuratingChannel` already did), so the tapped pixels paint instantly, the frame is pre-sized, and the full-res file swaps in on load. Same treatment for `MediaCard` and the album-art viewer. The panel's open animation is bumped to a slightly more pronounced scale so it reads as an expand.

## Theme-aware backdrop
The scrim color was hardcoded near-black, so light themes got a dark backdrop. It's now driven by new `--scrim` / `--scrim-clear` / `--scrim-ink` CSS variables per theme: a bright frosted tint in light modes, near-black in dark modes. `--scrim-clear` shares the same RGB so the fade only ramps alpha (no gray midtones), and the footer image counter uses `--scrim-ink` so it stays legible on a light backdrop.

Verified with a production `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJWP4r4ci7MTESbx9Ku7Gh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJWP4r4ci7MTESbx9Ku7Gh)_