### PR TITLE
Vertically center the verb and hoisted time on text-less feed posts

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -54,13 +54,17 @@
 .feed-item-head {
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  /* Center rather than baseline-align: the verb is an icon + small-caps
+     cluster and the time is lowercase mono with a descender, so their
+     text baselines don't optically center. Centering lines up the two
+     clusters' vertical midpoints instead. */
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
 }
 
 .feed-item-head .feed-item-verb {
-  align-self: baseline;
+  align-self: center;
 }
 
 .feed-item-head-time {


### PR DESCRIPTION
Follow-up to #79. On text-less feed posts, the head row aligned the verb gerund and the hoisted timestamp by text baseline, which left the timestamp's box ~2.6px below the verb's icon + small-caps label — their baselines line up but their optical centers don't.

Switch the row to `align-items: center` so the verb cluster and the timestamp share a vertical midpoint. Verified against the live render: the measured center offset goes from ~2.6px to 0px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmYXQ6PQf7VhdzT1mKDPa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmYXQ6PQf7VhdzT1mKDPa8)_