### PR TITLE
Add Aturi Waypoints "Open in…" picker for outbound Atmosphere links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@atproto/api": "^0.19.17",
         "@atproto/oauth-client-browser": "^0.3.42",
+        "@aturi.to/waypoints": "^0.1.1",
         "@vercel/analytics": "^2.0.1",
         "highlight.js": "^11.11.1",
         "lucide-react": "^1.14.0",
@@ -266,6 +267,15 @@
       "dependencies": {
         "@atproto/lexicon": "^0.6.0",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@aturi.to/waypoints": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@aturi.to/waypoints/-/waypoints-0.1.1.tgz",
+      "integrity": "sha512-cVLylDn5OJNc7z8fNlLWCTv6EznXuzQOsiG0aXl1vBk9doxtvsjb0E34kU+8FLXQ6Yrb5wOftHc81JEtkab/aQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@atproto/api": "^0.19.17",
     "@atproto/oauth-client-browser": "^0.3.42",
+    "@aturi.to/waypoints": "^0.1.1",
     "@vercel/analytics": "^2.0.1",
     "highlight.js": "^11.11.1",
     "lucide-react": "^1.14.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
 import { FeedFilterProvider } from './hooks/useFeedFilter.jsx';
 import { AtprotoSessionProvider } from './hooks/useAtprotoSession.jsx';
 import { FilmGrainProvider } from './hooks/useFilmGrain.jsx';
+import { WaypointsModalProvider } from './hooks/useWaypointsModal.jsx';
 
 /**
  * Verbs whose record page is handled by a bespoke page component (not the
@@ -86,6 +87,7 @@ export default function App() {
       <AtprotoSessionProvider>
       <FeedFilterProvider>
       <ActionDockProvider>
+      <WaypointsModalProvider>
           <div className="app-shell">
             <ChromeBar />
             <main className="layout">
@@ -145,6 +147,7 @@ export default function App() {
             <FilmGrain />
             <Analytics />
           </div>
+      </WaypointsModalProvider>
       </ActionDockProvider>
       </FeedFilterProvider>
       </AtprotoSessionProvider>

--- a/src/components/AturiActions.jsx
+++ b/src/components/AturiActions.jsx
@@ -1,25 +1,28 @@
-import { aturiUniversalUrl, aturiExplorerUrl } from '../lib/atproto.js';
+import { aturiExplorerUrl } from '../lib/atproto.js';
+import { useWaypointsModal } from '../hooks/useWaypointsModal.jsx';
 
 /**
- * Small row of links under a record that hand off to aturi.to:
- *   - "Open in…"     → the universal-link landing page (pick any client)
- *   - "Inspect Data" → the Atmosphere Explorer raw-record view
+ * Small row of actions under a record:
+ *   - "Open in…"     → opens the in-site waypoints picker (choose any client),
+ *                       powered by @aturi.to/waypoints.
+ *   - "Inspect Data" → the Atmosphere Explorer raw-record view on aturi.to.
  *
- * Renders nothing when the URI can't be parsed.
+ * Renders nothing when the URI can't be turned into either action.
  */
 export default function AturiActions({ atUri }) {
-  const openUrl = aturiUniversalUrl(atUri);
+  const { openWaypoints } = useWaypointsModal();
   const inspectUrl = aturiExplorerUrl(atUri);
-  if (!openUrl && !inspectUrl) return null;
+  const canOpen = typeof atUri === 'string' && atUri.startsWith('at://');
+  if (!canOpen && !inspectUrl) return null;
   return (
     <div className="record-aturi-actions">
-      {openUrl && (
-        <a href={openUrl} target="_blank" rel="noreferrer noopener">
+      {canOpen && (
+        <button type="button" onClick={() => openWaypoints(atUri)}>
           Open in…
-        </a>
+        </button>
       )}
       {inspectUrl && (
-        <a href={inspectUrl} target="_blank" rel="noreferrer noopener">
+        <a href={inspectUrl} target="_blank" rel="noreferrer noopener" data-no-waypoints>
           Inspect Data
         </a>
       )}

--- a/src/components/WaypointsModal.css
+++ b/src/components/WaypointsModal.css
@@ -1,0 +1,208 @@
+/* Interior of the "Open in…" picker. The <Modal> shell owns positioning,
+   surface, scrim, and motion — only the layout of the picker lives here.
+   Styling follows the same language as InfoModal: small-caps header, hairline
+   rules, accent-on-hover. */
+
+.waypoints-modal-panel {
+  width: min(440px, 100%);
+  display: flex;
+  flex-direction: column;
+}
+
+.waypoints-modal {
+  display: flex;
+  flex-direction: column;
+}
+
+.waypoints-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-5) var(--space-4);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.waypoints-modal-heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.waypoints-modal-heading .small-caps {
+  font-size: var(--text-xs);
+  letter-spacing: 0.16em;
+}
+
+.waypoints-modal-subtitle {
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.waypoints-modal-close {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.waypoints-modal-close:hover,
+.waypoints-modal-close:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
+}
+
+.waypoints-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+}
+
+.waypoints-modal-note {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+}
+
+/* --- groups --------------------------------------------------------------- */
+
+.waypoints-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.waypoints-group-title {
+  margin: 0;
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+}
+
+.waypoints-group.is-recommended .waypoints-group-title {
+  color: var(--accent);
+}
+
+.waypoints-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.waypoints-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-1);
+}
+
+.waypoints-row-open {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--rule);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.waypoints-group.is-recommended .waypoints-row-open {
+  border-color: var(--accent-soft);
+}
+
+.waypoints-row-open:hover,
+.waypoints-row-open:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
+}
+
+.waypoints-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.waypoints-row-arrow {
+  flex: none;
+  color: var(--ink-faint);
+  transition: color 120ms ease;
+}
+
+.waypoints-row-open:hover .waypoints-row-arrow,
+.waypoints-row-open:focus-visible .waypoints-row-arrow {
+  color: var(--accent);
+}
+
+.waypoints-row-copy {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.waypoints-row-copy:hover,
+.waypoints-row-copy:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
+}
+
+/* --- original-link fallback ---------------------------------------------- */
+
+.waypoints-modal-original {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-5) var(--space-5);
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.waypoints-modal-original:hover,
+.waypoints-modal-original:focus-visible {
+  color: var(--accent);
+  outline: none;
+}

--- a/src/components/WaypointsModal.jsx
+++ b/src/components/WaypointsModal.jsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, Copy, Check, ArrowUpRight } from 'lucide-react';
+import Modal from './Modal.jsx';
+import { resolveWaypoints, groupWaypoints, describeResolved } from '../lib/waypoints.js';
+import './WaypointsModal.css';
+
+/**
+ * The "Open in…" picker. Given an outbound Atmosphere link (or `at://` URI),
+ * it resolves the record to the set of clients that can open it and lets the
+ * visitor choose one — powered by @aturi.to/waypoints.
+ *
+ * Rendered once at the app root by <WaypointsModalProvider>; `href` is set by
+ * the global link interceptor (or an imperative `openWaypoints()` call). The
+ * whole subtree carries `data-no-waypoints` so its own links don't re-trigger
+ * the interceptor.
+ */
+export default function WaypointsModal({ open, href, onClose }) {
+  const [status, setStatus] = useState('idle'); // idle | loading | ready | empty | error
+  const [sections, setSections] = useState({ recommended: [], groups: [] });
+  const [subtitle, setSubtitle] = useState('');
+  const [copiedUrl, setCopiedUrl] = useState(null);
+  const copyTimer = useRef(null);
+
+  const isHttp = typeof href === 'string' && /^https?:\/\//.test(href);
+
+  useEffect(() => {
+    if (!open || !href) {
+      setStatus('idle');
+      setSections({ recommended: [], groups: [] });
+      setSubtitle('');
+      return;
+    }
+    let cancelled = false;
+    setStatus('loading');
+    setSubtitle('');
+    resolveWaypoints(href)
+      .then((result) => {
+        if (cancelled) return;
+        if (result && Array.isArray(result.waypoints) && result.waypoints.length > 0) {
+          setSections(groupWaypoints(result));
+          setSubtitle(describeResolved(result));
+          setStatus('ready');
+        } else {
+          setStatus('empty');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, href]);
+
+  // Reset the transient "copied" checkmark whenever the modal closes.
+  useEffect(() => {
+    if (!open) {
+      setCopiedUrl(null);
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+    }
+  }, [open]);
+
+  useEffect(() => () => copyTimer.current && clearTimeout(copyTimer.current), []);
+
+  async function copy(url) {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedUrl(url);
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => setCopiedUrl(null), 1600);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} label="Open in…" className="waypoints-modal-panel">
+      <div className="waypoints-modal" data-no-waypoints>
+        <div className="waypoints-modal-header">
+          <div className="waypoints-modal-heading">
+            <span className="small-caps">open in…</span>
+            {subtitle && <span className="waypoints-modal-subtitle">{subtitle}</span>}
+          </div>
+          <button
+            type="button"
+            className="waypoints-modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="waypoints-modal-body">
+          {status === 'loading' && (
+            <p className="waypoints-modal-note">Resolving destinations…</p>
+          )}
+
+          {status === 'error' && (
+            <p className="waypoints-modal-note">
+              Couldn't resolve this link into Atmosphere clients.
+            </p>
+          )}
+
+          {status === 'empty' && (
+            <p className="waypoints-modal-note">
+              No other clients can open this link.
+            </p>
+          )}
+
+          {status === 'ready' && (
+            <>
+              {sections.recommended.length > 0 && (
+                <WaypointGroup
+                  name={sections.recommendedLabel}
+                  waypoints={sections.recommended}
+                  copiedUrl={copiedUrl}
+                  onCopy={copy}
+                  onOpen={onClose}
+                  recommended
+                />
+              )}
+              {sections.groups.map((group) => (
+                <WaypointGroup
+                  key={group.id}
+                  name={group.name}
+                  waypoints={group.waypoints}
+                  copiedUrl={copiedUrl}
+                  onCopy={copy}
+                  onOpen={onClose}
+                />
+              ))}
+            </>
+          )}
+        </div>
+
+        {isHttp && status !== 'loading' && (
+          <a
+            className="waypoints-modal-original"
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+            onClick={onClose}
+          >
+            Open the original link
+            <ArrowUpRight size={13} aria-hidden="true" />
+          </a>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function WaypointGroup({ name, waypoints, copiedUrl, onCopy, onOpen, recommended }) {
+  return (
+    <section className={`waypoints-group${recommended ? ' is-recommended' : ''}`}>
+      <h3 className="waypoints-group-title small-caps">{name}</h3>
+      <ul className="waypoints-list">
+        {waypoints.map((w) => (
+          <li key={w.id} className="waypoints-row">
+            <a
+              className="waypoints-row-open"
+              href={w.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              onClick={onOpen}
+            >
+              <span className="waypoints-row-name">{w.name}</span>
+              <ArrowUpRight size={14} aria-hidden="true" className="waypoints-row-arrow" />
+            </a>
+            <button
+              type="button"
+              className="waypoints-row-copy"
+              onClick={() => onCopy(w.url)}
+              aria-label={`Copy ${w.name} link`}
+            >
+              {copiedUrl === w.url ? (
+                <Check size={14} aria-hidden="true" />
+              ) : (
+                <Copy size={14} aria-hidden="true" />
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/hooks/useWaypointsModal.jsx
+++ b/src/hooks/useWaypointsModal.jsx
@@ -1,0 +1,78 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import WaypointsModal from '../components/WaypointsModal.jsx';
+import { isWaypointHref } from '../lib/waypoints.js';
+
+const WaypointsModalContext = createContext(null);
+
+/**
+ * Global "Open in…" picker for outbound Atmosphere links.
+ *
+ * Rather than wrap every one of the dozens of `bsky.app` / `at://` links
+ * scattered across the site, the provider installs a single capture-phase
+ * click listener on the document. When a plain left-click lands on an anchor
+ * pointing at a record on a supported Atmosphere host, it cancels the
+ * navigation and opens a modal where the visitor can choose which client to
+ * open it in (Bluesky, Anisota, Grain, Leaflet, a dev tool, …).
+ *
+ * Escape hatches:
+ *   - Modified clicks (⌘/Ctrl/Shift/Alt, middle-click) are left alone so
+ *     "open in new tab" still works.
+ *   - Any anchor (or ancestor) carrying `data-no-waypoints` is ignored — the
+ *     modal marks its own links this way so its rows don't re-trigger it.
+ *   - `download` links are left alone.
+ *
+ * Consumers can also open the picker imperatively via `useWaypointsModal()`
+ * — used by <AturiActions> to turn its "Open in…" affordance into this modal
+ * instead of a round-trip to aturi.to.
+ */
+export function WaypointsModalProvider({ children }) {
+  const [href, setHref] = useState(null);
+
+  const openWaypoints = useCallback((target) => {
+    if (target) setHref(String(target));
+  }, []);
+  const close = useCallback(() => setHref(null), []);
+
+  useEffect(() => {
+    function onClick(e) {
+      // Respect new-tab / new-window intents and non-primary buttons.
+      if (e.defaultPrevented) return;
+      if (e.button != null && e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+      const anchor = e.target?.closest?.('a[href]');
+      if (!anchor) return;
+      if (anchor.hasAttribute('download')) return;
+      // Opt-out for the modal's own links (and any consumer that wants the
+      // native navigation).
+      if (anchor.closest('[data-no-waypoints]')) return;
+
+      // Use the resolved absolute href from the DOM; unknown schemes like
+      // `at://` are preserved verbatim by the browser.
+      if (!isWaypointHref(anchor.href)) return;
+
+      e.preventDefault();
+      setHref(anchor.href);
+    }
+
+    // Capture phase so we win before React Router / other handlers, and so a
+    // stopPropagation() upstream can't hide the click from us.
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+
+  const value = useMemo(() => ({ openWaypoints, close }), [openWaypoints, close]);
+
+  return (
+    <WaypointsModalContext.Provider value={value}>
+      {children}
+      <WaypointsModal open={href != null} href={href} onClose={close} />
+    </WaypointsModalContext.Provider>
+  );
+}
+
+export function useWaypointsModal() {
+  const ctx = useContext(WaypointsModalContext);
+  if (!ctx) throw new Error('useWaypointsModal must be used inside <WaypointsModalProvider>');
+  return ctx;
+}

--- a/src/lib/waypoints.js
+++ b/src/lib/waypoints.js
@@ -1,0 +1,108 @@
+// Thin wrapper around @aturi.to/waypoints — the MIT-licensed core catalog and
+// resolver that powers aturi.to. We use it to turn an outbound Bluesky /
+// Atmosphere link (or a bare `at://` URI) into the list of clients that can
+// open the same record, so a visitor can pick their own client rather than
+// being forced onto whatever host the link happened to point at.
+//
+// The React picker (@aturi.to/waypoints-react) ships its own components + CSS;
+// we intentionally use the zero-dependency core instead and render the picker
+// with the site's own <Modal> so it matches the design system exactly.
+
+import {
+  matchSupportedUrl,
+  resolveAtUri,
+  resolveUrl,
+  SUPPORTED_HOSTS,
+  WAYPOINT_CATEGORIES_DATA,
+  CATEGORY_ORDER,
+} from '@aturi.to/waypoints';
+import { resolveHandle } from './atproto.js';
+
+const SUPPORTED_HOST_SET = new Set(SUPPORTED_HOSTS);
+
+/**
+ * Cheap, synchronous test for "is this a link the waypoints modal should
+ * intercept?" — a bare `at://` URI, or a URL on one of the Atmosphere hosts
+ * the catalog knows how to reverse-parse into a record. Everything else
+ * (internal SPA links, unrelated external links) returns false so the click
+ * falls through to the browser untouched.
+ */
+export function isWaypointHref(href) {
+  if (!href) return false;
+  const s = String(href);
+  if (s.startsWith('at://')) return true;
+  let url;
+  try {
+    url = new URL(s);
+  } catch {
+    return false;
+  }
+  // Fast host gate before the (slightly heavier) pattern match.
+  if (!SUPPORTED_HOST_SET.has(url.hostname)) return false;
+  try {
+    return matchSupportedUrl(url) != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve an outbound link (or `at://` URI) into its waypoints. `at://` URIs
+ * resolve offline; page URLs use the offline pattern matcher plus the site's
+ * own `resolveHandle` so DID-only destinations (Grain, PDSls, Margin, …) are
+ * included when the handle resolves. Returns `null` when the input can't be
+ * mapped to a record.
+ */
+export async function resolveWaypoints(href) {
+  const s = String(href || '');
+  if (s.startsWith('at://')) return resolveAtUri(s);
+  try {
+    return await resolveUrl(s, { resolveHandle });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shape a raw `ResolveResult` into the sections the modal renders:
+ *   - `recommended`  — the recommended waypoints, in the catalog's order.
+ *   - `groups`       — the remaining waypoints bucketed by display category,
+ *                      in `CATEGORY_ORDER`, with recommended ones removed so
+ *                      nothing appears twice.
+ * Empty groups are dropped.
+ */
+export function groupWaypoints(result) {
+  if (!result) return { recommended: [], recommendedLabel: '', groups: [] };
+  const byId = new Map(result.waypoints.map((w) => [w.id, w]));
+  const recommendedIds = (result.recommended?.ids || []).filter((id) => byId.has(id));
+  const recommended = recommendedIds.map((id) => byId.get(id));
+  const recommendedSet = new Set(recommendedIds);
+
+  const groups = CATEGORY_ORDER.map((catId) => ({
+    id: catId,
+    name: WAYPOINT_CATEGORIES_DATA[catId]?.name || catId,
+    waypoints: result.waypoints.filter(
+      (w) => w.category === catId && !recommendedSet.has(w.id),
+    ),
+  })).filter((g) => g.waypoints.length > 0);
+
+  return {
+    recommended,
+    recommendedLabel: result.recommended?.label || 'Recommended',
+    groups,
+  };
+}
+
+/**
+ * A short, human label for the resolved record — e.g. "Post by alice.bsky.social".
+ * Used as the modal's subtitle. Falls back gracefully when parts are missing.
+ */
+export function describeResolved(result) {
+  const parsed = result?.parsed;
+  if (!parsed) return '';
+  const typeLabel =
+    { post: 'Post', profile: 'Profile', list: 'List', record: 'Record' }[parsed.type] ||
+    'Record';
+  const who = parsed.handle && !parsed.handle.startsWith('did:') ? parsed.handle : parsed.did;
+  return who ? `${typeLabel} · ${who}` : typeLabel;
+}

--- a/src/pages/Record.css
+++ b/src/pages/Record.css
@@ -46,21 +46,27 @@
   margin-top: var(--space-4);
 }
 
-.record-aturi-actions a {
+.record-aturi-actions a,
+.record-aturi-actions button {
   font-family: var(--sans);
   font-size: var(--text-xs);
   letter-spacing: 0.06em;
   padding: 0.4em 0.85em;
   border: 1px solid var(--rule);
+  border-radius: 0;
   background: var(--page);
   color: var(--ink-soft);
   text-decoration: none;
+  cursor: pointer;
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
-.record-aturi-actions a:hover {
+.record-aturi-actions a:hover,
+.record-aturi-actions button:hover,
+.record-aturi-actions button:focus-visible {
   color: var(--accent);
   border-color: var(--accent-soft);
+  outline: none;
 }
 
 .record-fallback-json {


### PR DESCRIPTION
Integrate the MIT-licensed `@aturi.to/waypoints` core so tapping an outbound Bluesky / Atmosphere link (or a bare `at://` URI) opens an in-site modal where the visitor picks which client to open the record in.

## Approach

Rather than wrapping each of the ~28 places that render `bsky.app` / `at://` links, a single capture-phase click interceptor at the app root covers every outbound Atmosphere link automatically — post links, profile mentions, hashtags, list/feed links, rich-text links, comments — with no call-site changes.

## Changes

- **`src/lib/waypoints.js`** — thin wrapper over the zero-dependency core resolver: `isWaypointHref` (cheap synchronous match test), `resolveWaypoints` (uses the site's own `resolveHandle` so DID-only clients resolve), `groupWaypoints`, `describeResolved`.
- **`src/hooks/useWaypointsModal.jsx`** — provider with one capture-phase `click` listener. Respects ⌘/Ctrl/Shift/Alt and middle-clicks, `download` links, and a `data-no-waypoints` opt-out. Also exposes `openWaypoints()` for imperative use.
- **`src/components/WaypointsModal.jsx` / `.css`** — the picker, built on the existing `Modal` shell and design tokens. Shows recommended destinations first, then category groups, each row with an open link + copy button, plus an "Open the original link" fallback and loading/empty/error states.
- **`src/components/AturiActions.jsx`** — "Open in…" now opens this modal directly instead of a round-trip to aturi.to; "Inspect Data" stays as an external link. `Record.css` updated so the new `<button>` matches the existing action styling.
- **`src/App.jsx`** — mounts `WaypointsModalProvider`.
- Adds `@aturi.to/waypoints` to dependencies.

## Verification

Offline vite build compiles cleanly. End-to-end check in headless Chromium: clicking a `bsky.app` post link cancels navigation, opens the modal, resolves to `Post · dame.is`, renders Recommended + all category groups, keeps its own rows out of the interceptor, and closes on Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7fk5GpxBacarUSiEnoRfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7fk5GpxBacarUSiEnoRfR)_