### PR TITLE
Blog index: drop button-like hover, tighten timestamp spacing, richer date

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -97,6 +97,16 @@ export function formatDateLong(date) {
   return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
 }
 
+/**
+ * US-style long date, e.g. "March 7, 2025". Pairs with `relativeTime` in
+ * the blog index meta line.
+ */
+export function formatDateFull(date) {
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
 export function formatTime(date) {
   const d = new Date(date);
   if (Number.isNaN(d.getTime())) return '';

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -25,8 +25,15 @@
   color: var(--ink);
 }
 
-.blogging-toc-link:hover {
-  background: var(--page-edge);
+/* Only devices that truly hover get an affordance, and it's a subtle title
+   underline rather than a full-width background box — the box read as a
+   button and left a sticky highlight on touch. */
+@media (hover: hover) {
+  .blogging-toc-link:hover .blogging-toc-title {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.15em;
+  }
 }
 
 .blogging-toc-num {
@@ -152,12 +159,17 @@
 @media (max-width: 700px) {
   .blogging-toc-link {
     grid-template-columns: 1fr;
+    gap: var(--space-2);
   }
   .blogging-toc-num {
     display: none;
   }
   .blogging-toc-meta {
     text-align: left;
+    /* In the stacked single-column layout the meta is its own row, so the
+       baseline nudge (meant for the desktop 3-column row) just piles space
+       above the timestamp. */
+    padding-top: 0;
   }
 }
 

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -7,7 +7,7 @@ import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
-import { relativeTime, compareIsoDesc } from '../lib/time.js';
+import { relativeTime, formatDateFull, compareIsoDesc } from '../lib/time.js';
 import { isPortfolioDoc } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
@@ -76,7 +76,9 @@ export default function Blogging() {
                   {e.summary && <p className="blogging-toc-summary">{e.summary}</p>}
                 </span>
                 <span className="blogging-toc-meta gutter">
-                  {e.createdAt ? relativeTime(e.createdAt) : ''}
+                  {e.createdAt
+                    ? `${relativeTime(e.createdAt)} • ${formatDateFull(e.createdAt)}`
+                    : ''}
                 </span>
               </Link>
             </li>


### PR DESCRIPTION
Fixes three issues on the blog index (`/blogging`):

- **Button-like hover/touch state** — entries had a full-width background hover that read as a button and left a sticky highlight on touch. Replaced with a subtle title underline gated behind `@media (hover: hover)`, so touch devices show no state at all.
- **Spacing above the timestamp** — removed the desktop baseline nudge and tightened the row gap in the stacked mobile layout.
- **Timestamp format** — now shows relative time plus a full date, e.g. `1y ago • March 7, 2025`, via a new `formatDateFull` helper in `time.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFZN8zQPLh1FjSuqzVT3Sj)_