### PR TITLE
Chrome bars: match page side margins on mobile/tablet

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -476,12 +476,37 @@
   will-change: transform;
 }
 
+/* Below the 65rem cap the chrome bars are full-bleed, exactly like `.main`.
+   Match `.main`'s own horizontal padding so the header/dock content lines
+   up with the page's content column. (The base `6vw - 3.5rem` padding only
+   makes sense once the bar is actually capped at 65rem and sits inset from
+   the wider 72rem main column above this width.) */
+@media (max-width: 65rem) {
+  .chrome-bar-row,
+  .chrome-bottom-row {
+    padding-left: clamp(var(--space-5), 6vw, var(--space-9));
+    padding-right: clamp(var(--space-5), 6vw, var(--space-9));
+  }
+  /* Drop the top-right chevron's outdent here so the right margin stays
+     symmetric with the left and matches the page's content edge. */
+  .chrome-expand {
+    margin-right: 0;
+  }
+}
+
 @media (max-width: 700px) {
   .chrome-bar-row {
     gap: var(--space-2);
   }
   .chrome-bottom-row {
     gap: var(--space-2);
+  }
+  /* `.main` tightens to `var(--space-4)` at this width — track it so the
+     chrome margins stay locked to the content column. */
+  .chrome-bar-row,
+  .chrome-bottom-row {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
   }
   .chrome-signals-secondary {
     flex-direction: column;


### PR DESCRIPTION
On mobile the top header and bottom action dock sat closer to the screen edge than the page content.

The chrome bars used a padding formula (`6vw − 3.5rem`) that's only correct on wide screens, where the 65rem-wide bar sits inset within the 72rem main column. Below that cap both bars are full-bleed, so this matches them to `.main`'s actual horizontal padding at each breakpoint (`1rem` on phones, `clamp(1.5rem, 6vw, 6rem)` on tablet), and drops the top-right chevron's `-0.5rem` outdent so the left and right margins stay symmetric.

Verified by rendering the built site at a 402px mobile viewport with guide lines at the main content's padding edges — the header avatar/wordmark and the dock's left/right controls now align with the page content column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFZN8zQPLh1FjSuqzVT3Sj)_