### PR TITLE
Revive film grain: restore dock toggle, default on under versioned key

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -6,6 +6,7 @@ import { useActionDock } from '../hooks/useActionDock.jsx';
 import Modal from './Modal.jsx';
 import DensityToggle from './DensityToggle.jsx';
 import TypefaceToggle from './TypefaceToggle.jsx';
+import FilmGrainToggle from './FilmGrainToggle.jsx';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
@@ -121,6 +122,7 @@ export default function ActionDock() {
                 <div className="dock-display-row">
                   <DensityToggle />
                   <TypefaceToggle />
+                  <FilmGrainToggle />
                   <button
                     type="button"
                     className="dock-tool-icon"

--- a/src/hooks/useFilmGrain.jsx
+++ b/src/hooks/useFilmGrain.jsx
@@ -1,12 +1,13 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 const FilmGrainContext = createContext(null);
-const STORAGE_KEY = 'dame.grain';
+// Versioned key: while the feature was dormant the provider persisted
+// 'off' under the old `dame.grain` key on every visit, so that key
+// can't distinguish "user chose off" from "dormant default". Starting
+// fresh under .v2 gives everyone the on-by-default grain again.
+const STORAGE_KEY = 'dame.grain.v2';
 const VALID = ['on', 'off'];
-// Feature dormant — the toggle UI is hidden in ActionDock and the
-// default is off. The hook, component, and styles are kept around
-// so the grain can be revived later by re-rendering FilmGrainToggle.
-const DEFAULT = 'off';
+const DEFAULT = 'on';
 
 function applyGrain(grain) {
   document.documentElement.setAttribute('data-grain', grain);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -51,12 +51,14 @@ document.documentElement.setAttribute('data-density', storedDensity);
 
 // Film grain: apply the saved preference before React mounts so the
 // overlay paints (or doesn't) on the first frame instead of flashing
-// in once <FilmGrainProvider> hydrates. Feature is currently dormant —
-// the toggle UI is hidden and the default is off; keep this read so a
-// future revival picks up any preference users had previously set.
+// in once <FilmGrainProvider> hydrates. The key is versioned (.v2)
+// because during the feature's dormant phase every visit persisted
+// 'off' under the old `dame.grain` key — reading that key would pin
+// grain off for everyone who visited in that window. Keep the key +
+// default in sync with useFilmGrain.jsx.
 const VALID_GRAIN = ['on', 'off'];
-let storedGrain = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.grain') : null;
-if (!VALID_GRAIN.includes(storedGrain)) storedGrain = 'off';
+let storedGrain = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.grain.v2') : null;
+if (!VALID_GRAIN.includes(storedGrain)) storedGrain = 'on';
 document.documentElement.setAttribute('data-grain', storedGrain);
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
Brings the dormant FilmGrain feature back (dormant since 7c7df57):

- Re-renders `FilmGrainToggle` in the ActionDock tools row (aperture = on, dashed circle = off)
- Flips the default back to **on** in both `useFilmGrain.jsx` and the pre-mount initializer in `main.jsx`, so the grain paints on the first frame with no flash
- Moves the localStorage key from `dame.grain` to `dame.grain.v2`: during the dormant phase the provider persisted `off` under the old key on every visit, so that key can't distinguish "user chose off" from "dormant default" — reading it would pin grain off for everyone who visited in that window. Fresh key, fresh default; new toggle choices persist as before.

Verified against the production build with a real browser: grain on at first paint, menu toggle flips `data-grain` and persists, light and dark themes both render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu)_