### PR TITLE
UI pass: two themes, upward nav sheet, lightbox control bar, finer icons

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -1,22 +1,61 @@
-/* The dock panel content lives inside <Modal variant="centered">, so
-   positioning, scrim, surface, and enter/exit animation are all owned
-   by the Modal. Rules here only style the panel's interior layout. */
-.dock-panel {
-  width: var(--dock-w);
-  max-width: min(var(--dock-w), 100%);
-  padding: var(--space-4);
-  /* Smoothly interpolate the panel's width when crossing between
-     views that demand different room (the debug pane is much wider
-     than menu/account). */
-  transition: width 220ms ease, max-width 220ms ease;
+/* The dock is a sheet that expands upward out of the bottom chrome
+   bar — the mirror of the top bar's expand-down rows.
+
+   .dock-backdrop: a transparent, non-dimming click-catcher below the
+   chrome bars (z 29 < bars' 30) so tapping the page closes the sheet
+   while the toolbar buttons stay live. No visual tint — the sheet
+   reads as part of the chrome, like the top-bar expansions do. */
+.dock-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+  background: transparent;
 }
 
-/* The atmosphere debug pane carries dense readouts and a JSON dump,
-   so it needs the same wider envelope the old standalone overlay
-   used. Menu and account stay at the default --dock-w. */
-.dock-panel-view-debug {
-  width: min(560px, 100%);
-  max-width: min(560px, 100%);
+/* .dock-sheet-wrap: the animated clip box, pinned directly on top of
+   the bottom bar and centered on the same 65rem card. Framer animates
+   its height 0 ↔ auto; overflow:hidden means the panel inside unfurls
+   upward out of the bar. Sits above the bars (z 31) so its top edge
+   and shadow overlap the page cleanly. */
+.dock-sheet-wrap {
+  position: fixed;
+  bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px));
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  z-index: 31;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/* .dock-panel: the visible surface. Matches the chrome bar's raised
+   surface and hairlines so the sheet + bar read as one continuous
+   card. Capped in height with its own scroll so long views (the
+   route list, the debug dump) never push past the top bar. */
+.dock-panel {
+  pointer-events: auto;
+  background: var(--surface-raised);
+  border-top: 1px solid var(--rule);
+  /* Crisp divider between the expanded sheet and the button row below.
+     Lives on the sheet's bottom edge (the sheet paints above the bar,
+     z 31 > 30, so it wins over the bar's own hidden top border). */
+  border-bottom: 1px solid var(--rule);
+  padding: var(--space-4);
+  max-height: min(72dvh, calc(100dvh - var(--chrome-h) - 4rem));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 -8px 24px var(--shadow);
+}
+
+/* On wide screens the chrome bars float as a 65rem card with side
+   hairlines; the sheet closes its box to match. */
+@media (min-width: 65rem) {
+  .dock-panel {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
 }
 
 .dock-section {
@@ -160,12 +199,9 @@
 }
 
 @media (max-width: 540px) {
-  /* On phones the 280px default leaves too much background visible;
-     let the panel fill the available column so the menu feels like
-     a real sheet. */
+  /* Tighten the sheet's padding on phones and give routes a slightly
+     taller tap target. */
   .dock-panel {
-    width: 100%;
-    max-width: 100%;
     padding: var(--space-3) var(--space-4) var(--space-4);
   }
 

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { NavLink } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { Bug, ChevronLeft, User } from 'lucide-react';
 import { useActionDock } from '../hooks/useActionDock.jsx';
-import Modal from './Modal.jsx';
 import DensityToggle from './DensityToggle.jsx';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
@@ -75,17 +75,49 @@ export default function ActionDock() {
     return () => window.removeEventListener('keydown', onKey);
   }, [open, view, openDock, closeDock]);
 
-  return (
-    <Modal
-      open={open}
-      onClose={closeDock}
-      label="Site menu"
-      id="action-dock-panel"
-      className={`dock-panel dock-panel-view-${view}`}
-      scrimLabel="Close menu"
-      closeOnEscape={false}
-    >
-      <div className="dock-stage">
+  if (typeof document === 'undefined') return null;
+
+  // The dock is a sheet that expands UPWARD out of the bottom chrome
+  // bar — the mirror of the top bar's expand-down rows. A motion.div
+  // pinned above the bar animates height 0 ↔ auto with overflow
+  // hidden, so the panel unfurls upward instead of overlaying as a
+  // centered modal. A transparent (non-dimming) backdrop below the
+  // bars catches outside clicks to close, keeping the toolbar itself
+  // tappable. Portalled to <body> so no transformed feed ancestor can
+  // trap its fixed positioning.
+  return createPortal(
+    <>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="dock-backdrop"
+            className="dock-backdrop"
+            onClick={closeDock}
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.2 }}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="dock-sheet"
+            className="dock-sheet-wrap"
+            initial={{ height: 0 }}
+            animate={{ height: 'auto' }}
+            exit={{ height: 0 }}
+            transition={{ duration: reduce ? 0 : 0.34, ease: [0.32, 0.72, 0, 1] }}
+          >
+            <div
+              id="action-dock-panel"
+              className={`dock-panel dock-panel-view-${view}`}
+              role="dialog"
+              aria-label="Site menu"
+            >
+              <div className="dock-stage">
         <AnimatePresence initial={false} mode="wait">
           {view === 'menu' && (
             <motion.div
@@ -194,7 +226,12 @@ export default function ActionDock() {
             </motion.div>
           )}
         </AnimatePresence>
-      </div>
-    </Modal>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>,
+    document.body,
   );
 }

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, Moon, MoonStar, Search, Sun, SunDim } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, MoonStar, Search, SunDim } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
@@ -14,13 +14,9 @@ import SearchModal from './SearchModal.jsx';
 import InfoModal from './InfoModal.jsx';
 import './ChromeBar.css';
 
-// Per-theme glyph for the cycle button — each of the 4 stops gets a
-// distinct sun/moon variant so the current theme is readable at a
-// glance instead of being collapsed into a binary sun/moon swap.
+// Per-theme glyph for the toggle button: sun for light, moon for dark.
 const THEME_ICON = {
-  'light-mono': Sun,
   light: SunDim,
-  'dark-mono': Moon,
   dark: MoonStar,
 };
 
@@ -216,7 +212,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const scrolledPast = useScrolledPastFeedItems();
   const { available: filterAvailable, open: filterOpen, toggleModal: toggleFilter } = useFeedFilter();
   const { theme, cycle: cycleTheme } = useTheme();
-  const ThemeIcon = THEME_ICON[theme] || Sun;
+  const ThemeIcon = THEME_ICON[theme] || SunDim;
   // Trigger buttons highlight when the corresponding URL state is
   // populated — search has a `?q=`, filter has a custom verb set.
   const searchActive = !!params.get('q');
@@ -255,8 +251,8 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           type="button"
           className="chrome-nav chrome-theme-toggle"
           onClick={cycleTheme}
-          aria-label={`Cycle theme (current: ${theme})`}
-          title={`Theme: ${theme} — tap to cycle`}
+          aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme (current: ${theme})`}
+          title={`Theme: ${theme} — tap to switch`}
         >
           <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
         </button>

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -13,7 +13,10 @@
   gap: var(--space-1);
   align-items: stretch;
   padding-bottom: var(--space-4);
-  border-bottom: 1px solid var(--rule-soft);
+  /* Hairline separator: half the strength of --rule-soft (blended
+     toward the page) so consecutive items read as a gentle rhythm
+     rather than hard-ruled rows. */
+  border-bottom: 1px solid color-mix(in srgb, var(--rule-soft) 50%, transparent);
   min-width: 0;
 }
 

--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -20,13 +20,18 @@
   overflow: visible;
 }
 
+/* Reserve the control-bar band at the bottom so the flex-centered image
+   centers in the space ABOVE the bar rather than the full viewport —
+   keeps the photo clear of the fixed controls. */
 .modal-variant-centered:has(.lightbox-panel) {
   padding: var(--space-2);
+  padding-bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px) + var(--space-3));
 }
 
 @media (max-width: 540px) {
   .modal-variant-centered:has(.lightbox-panel) {
     padding: var(--space-1, 4px);
+    padding-bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px) + var(--space-2));
   }
 }
 
@@ -39,11 +44,12 @@
   width: 100%;
   max-height: 100%;
   min-height: 0;
-  /* Height budget for the image: leave headroom for the footer (close
-     button) underneath so it doesn't get pushed off-screen on short
-     viewports. A variable because entries with known dimensions also use
-     it to reserve the frame width inline before the image loads. */
-  --lightbox-maxh: calc(100dvh - 8rem);
+  /* Height budget for the image: leave headroom for the fixed control
+     bar (the height of the chrome nav) plus breathing room top and
+     bottom, so the photo never sits under the controls. A variable
+     because entries with known dimensions also use it to reserve the
+     frame width inline before the image loads. */
+  --lightbox-maxh: calc(100dvh - var(--chrome-h) - 4rem);
 }
 
 /* Wrapper around the image and its optional attached caption bar, so the
@@ -54,14 +60,6 @@
   align-items: center;
   max-width: 100%;
   min-height: 0;
-}
-
-.lightbox-frame.has-caption {
-  align-items: stretch;
-  border-radius: var(--radius-2);
-  box-shadow: 0 16px 40px var(--shadow);
-  /* Reserved by the frame-width calc so image + caption stay in budget. */
-  --lightbox-caption-h: 2.5rem;
 }
 
 .lightbox-image {
@@ -77,130 +75,128 @@
   box-shadow: 0 16px 40px var(--shadow);
 }
 
-.lightbox-frame.has-caption .lightbox-image {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  box-shadow: none;
+/* Control bar — sits exactly where the bottom chrome nav is (fixed to
+   the viewport bottom, same 65rem card, same raised surface + height)
+   so the nav appears to morph into the photo controls. Above the Modal
+   scrim (z 60). Holds the source / reverse-search links (left), and the
+   prev/counter/next + close cluster (right). */
+.lightbox-controls {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 70;
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  background: var(--surface-raised);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-/* Caption bar attached beneath the image — source / reverse-image search
-   links for the current photo. Continues the image's border and rounds
-   off its bottom corners. */
-.lightbox-caption {
+@media (min-width: 65rem) {
+  .lightbox-controls {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
+}
+
+.lightbox-controls-row {
   display: flex;
   align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: var(--space-4);
-  min-height: 2.5rem;
-  padding: var(--space-1) var(--space-3);
-  background: var(--page-edge);
-  border: 1px solid var(--rule);
-  border-top: 1px solid var(--rule-soft);
-  border-radius: 0 0 var(--radius-2) var(--radius-2);
+  gap: var(--space-3);
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  padding: 0 clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
+  min-height: var(--chrome-h);
 }
 
-.lightbox-caption-link {
+.lightbox-controls-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.lightbox-controls-spacer {
+  flex: 1 1 auto;
+}
+
+.lightbox-controls-links {
+  gap: var(--space-4);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.lightbox-controls-link {
   font-family: var(--sans);
   font-size: var(--text-xs);
   letter-spacing: 0.06em;
   text-transform: lowercase;
-  color: var(--ink);
-  opacity: 0.75;
+  color: var(--ink-muted);
   text-decoration: underline;
   text-underline-offset: 0.2em;
+  transition: color 120ms ease;
 }
 
-.lightbox-caption-link:hover,
-.lightbox-caption-link:focus-visible {
-  opacity: 1;
+.lightbox-controls-link:hover,
+.lightbox-controls-link:focus-visible {
+  color: var(--accent);
 }
 
-/* Footer beneath the image — holds the close button and (for
-   multi-image embeds) the prev/next nav with N/M counter. Everything
-   sits below the image so the photo is never obscured. */
-.lightbox-footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: var(--space-3);
-  width: 100%;
-  max-width: 100%;
-  padding: 0 var(--space-2);
-}
-
-.lightbox-footer-nav {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.lightbox-footer-count {
+.lightbox-controls-count {
   font-family: var(--sans);
   font-size: var(--text-sm);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
-  color: var(--scrim-ink, #fff);
-  opacity: 0.85;
+  color: var(--ink-muted);
   min-width: 3.25rem;
   text-align: center;
 }
 
-.lightbox-close {
+/* Control buttons mirror the chrome-nav vocabulary: square, hairline
+   border, ink glyph, accent on hover. Close is the accent-filled
+   primary, matching the compass's promoted styling in the real nav. */
+.lightbox-ctl {
+  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5em;
-  height: 2.25rem;
-  padding: 0 var(--space-3);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: var(--radius-2);
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
-  font-family: var(--sans);
-  font-size: var(--text-xs);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease;
-}
-
-.lightbox-close:hover,
-.lightbox-close:focus-visible {
-  background: rgba(0, 0, 0, 0.75);
-  border-color: rgba(255, 255, 255, 0.35);
-}
-
-.lightbox-close-label {
-  display: inline-block;
-}
-
-/* Footer nav chevrons (multi-image only). Same chrome as the close
-   button so the footer reads as a single control cluster. */
-.lightbox-nav {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 1.75rem;
+  height: 1.75rem;
   padding: 0;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: var(--radius-2);
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-soft);
   cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
-.lightbox-nav:hover,
-.lightbox-nav:focus-visible {
-  background: rgba(0, 0, 0, 0.75);
-  border-color: rgba(255, 255, 255, 0.35);
+.lightbox-ctl:hover,
+.lightbox-ctl:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
 }
 
-@media (max-width: 540px) {
-  .lightbox-figure {
-    --lightbox-maxh: calc(100dvh - 7rem);
-  }
+.lightbox-ctl-close {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--page);
+}
+
+.lightbox-ctl-close:hover,
+.lightbox-ctl-close:focus-visible {
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+  color: var(--page);
+}
+
+.lightbox-ctl-glyph {
+  width: 1rem;
+  height: 1rem;
 }

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import Modal from './Modal.jsx';
 import './Lightbox.css';
@@ -27,6 +29,7 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
   const count = list.length;
   const [active, setActive] = useState(index);
   const [loadedSrcs, setLoadedSrcs] = useState(() => new Set());
+  const reduce = useReducedMotion();
   const markLoaded = useCallback((src) => {
     setLoadedSrcs((prev) => (prev.has(src) ? prev : new Set(prev).add(src)));
   }, []);
@@ -65,16 +68,14 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
   if (count === 0) return null;
   const current = list[active] || list[0];
   const alt = current.alt || '';
-  const hasCaption = Boolean(current.sourceUrl || current.searchUrl);
   // With intrinsic dimensions we can size the frame before the file
   // arrives: natural width, clamped by the panel width and by the
-  // viewport-height budget (transferred through the aspect ratio, minus
-  // the caption bar when there is one). Without them the image sizes
-  // itself on load, as before.
+  // viewport-height budget (transferred through the aspect ratio).
+  // Without them the image sizes itself on load, as before.
   const ratio = current.width > 0 && current.height > 0 ? current.width / current.height : null;
   const frameStyle = ratio
     ? {
-        width: `min(${current.width}px, 100%, calc((var(--lightbox-maxh) - var(--lightbox-caption-h, 0rem)) * ${ratio.toFixed(5)}))`,
+        width: `min(${current.width}px, 100%, calc(var(--lightbox-maxh) * ${ratio.toFixed(5)}))`,
       }
     : undefined;
   const placeholderStyle =
@@ -99,6 +100,7 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
       : 'Image';
 
   return (
+    <>
     <Modal
       open={open}
       onClose={onClose}
@@ -110,7 +112,7 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
     >
       <figure className="lightbox-figure">
         <div
-          className={`lightbox-frame${hasCaption ? ' has-caption' : ''}`}
+          className="lightbox-frame"
           style={frameStyle}
         >
           <img
@@ -129,66 +131,94 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
             }}
             style={imageStyle}
           />
-          {hasCaption && (
-            <div className="lightbox-caption">
-              {current.sourceUrl && (
-                <a
-                  href={current.sourceUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="lightbox-caption-link"
-                >
-                  source
-                </a>
-              )}
-              {current.searchUrl && (
-                <a
-                  href={current.searchUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="lightbox-caption-link"
-                >
-                  reverse image search
-                </a>
-              )}
-            </div>
-          )}
         </div>
       </figure>
-      <footer className="lightbox-footer">
-        {count > 1 && (
-          <div className="lightbox-footer-nav">
-            <button
-              type="button"
-              className="lightbox-nav lightbox-nav-prev"
-              onClick={prev}
-              aria-label="Previous image"
-            >
-              <ChevronLeft size={18} aria-hidden="true" />
-            </button>
-            <span className="lightbox-footer-count" aria-hidden="true">
-              {active + 1} / {count}
-            </span>
-            <button
-              type="button"
-              className="lightbox-nav lightbox-nav-next"
-              onClick={next}
-              aria-label="Next image"
-            >
-              <ChevronRight size={18} aria-hidden="true" />
-            </button>
-          </div>
-        )}
-        <button
-          type="button"
-          className="lightbox-close"
-          onClick={onClose}
-          aria-label="Close image"
-        >
-          <X size={18} aria-hidden="true" />
-          <span className="lightbox-close-label">Close</span>
-        </button>
-      </footer>
     </Modal>
+      {/* Control bar — pinned to the viewport bottom at the exact
+          position + height of the bottom chrome nav, on the same raised
+          surface, so the nav appears to morph into the photo controls
+          when the lightbox opens (and back on close). Portalled to
+          <body> because the Modal panel carries a scale transform, which
+          would otherwise trap this fixed bar inside the panel's box. It
+          sits above the Modal scrim (z 60) so it reads as the persistent
+          chrome the rest of the page dims behind. */}
+      {createPortal(
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              key="lightbox-controls"
+              className="lightbox-controls"
+              role="group"
+              aria-label="Image controls"
+              initial={reduce ? { opacity: 0 } : { opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={reduce ? { opacity: 0 } : { opacity: 0, y: 10 }}
+              transition={{ duration: reduce ? 0 : 0.26, ease: [0.32, 0.72, 0, 1] }}
+            >
+              <div className="lightbox-controls-row">
+                <div className="lightbox-controls-cluster lightbox-controls-links">
+                  {current.sourceUrl && (
+                    <a
+                      href={current.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="lightbox-controls-link"
+                    >
+                      source
+                    </a>
+                  )}
+                  {current.searchUrl && (
+                    <a
+                      href={current.searchUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="lightbox-controls-link"
+                    >
+                      reverse image search
+                    </a>
+                  )}
+                </div>
+
+                <div className="lightbox-controls-spacer" aria-hidden="true" />
+
+                {count > 1 && (
+                  <div className="lightbox-controls-cluster lightbox-controls-nav">
+                    <button
+                      type="button"
+                      className="lightbox-ctl"
+                      onClick={prev}
+                      aria-label="Previous image"
+                    >
+                      <ChevronLeft className="lightbox-ctl-glyph" aria-hidden="true" />
+                    </button>
+                    <span className="lightbox-controls-count" aria-hidden="true">
+                      {active + 1} / {count}
+                    </span>
+                    <button
+                      type="button"
+                      className="lightbox-ctl"
+                      onClick={next}
+                      aria-label="Next image"
+                    >
+                      <ChevronRight className="lightbox-ctl-glyph" aria-hidden="true" />
+                    </button>
+                  </div>
+                )}
+
+                <button
+                  type="button"
+                  className="lightbox-ctl lightbox-ctl-close"
+                  onClick={onClose}
+                  aria-label="Close image"
+                >
+                  <X className="lightbox-ctl-glyph" aria-hidden="true" />
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
+    </>
   );
 }

--- a/src/components/ProfileStats.jsx
+++ b/src/components/ProfileStats.jsx
@@ -49,13 +49,13 @@ export default function ProfileStats() {
       </span>
     );
   }
-  const userLabel = followers === 1 ? 'user' : 'users';
+  const peopleLabel = followers === 1 ? 'person' : 'people';
   return (
     <span className="chrome-signal chrome-signal-stats">
       <span className="chrome-signal-label">followed by</span>
-      <TickerText className="chrome-signal-value" title={`followed by ${followers.toLocaleString()} ${userLabel} on bluesky`}>
+      <TickerText className="chrome-signal-value" title={`followed by ${followers.toLocaleString()} ${peopleLabel} on Bluesky`}>
         <strong>{followers.toLocaleString()}</strong>
-        {` ${userLabel} on bluesky`}
+        {` ${peopleLabel} on Bluesky`}
       </TickerText>
     </span>
   );

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -3,28 +3,33 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 const ThemeContext = createContext(null);
 const STORAGE_KEY = 'dame.theme';
 
-// Cycle order is intentional: each row of the toggle button advances
-// by one stop, walking the user through light-mono → light-color →
-// dark-mono → dark-color → back to light-mono.
-const VALID = ['light-mono', 'light', 'dark-mono', 'dark'];
+// Two themes: warm light and dark green. The toggle flips between them.
+const VALID = ['light', 'dark'];
+
+// Retired monochrome variants map to their color equivalent so a
+// returning visitor who last used a mono theme keeps its light/dark
+// polarity instead of being reset to the default.
+const THEME_ALIAS = {
+  'light-mono': 'light',
+  'dark-mono': 'dark',
+};
 
 // Matches --surface-raised in theme.css. Used for the iOS Safari URL
 // bar surround / Android browser chrome so the OS UI blends with the
 // dame.is chrome bar instead of falling back to a system default.
 const THEME_COLOR = {
-  'light-mono': '#dedede',
   light: '#e3d8ba',
-  'dark-mono': '#0a0a0a',
   dark: '#13180f',
 };
 
 const DEFAULT_THEME = 'light';
 
 function migrateStoredTheme(stored) {
-  if (VALID.includes(stored)) return stored;
-  // Legacy / missing values land on the colored light theme so new
-  // visitors get a predictable first paint — they can cycle to dark
-  // (or either mono variant) from the chrome bar.
+  const resolved = THEME_ALIAS[stored] || stored;
+  if (VALID.includes(resolved)) return resolved;
+  // Legacy / missing values land on the light theme so new visitors
+  // get a predictable first paint — they can flip to dark from the
+  // chrome bar.
   return DEFAULT_THEME;
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,20 +8,21 @@ import './styles/typography.css';
 import './styles/app.css';
 
 // Theme selection happens here (before React mounts) so the first
-// paint is in the correct palette. Four cycle stops, with legacy
-// values (`system`, missing) resolving to the OS preference's color
-// variant. Keep VALID_THEMES + THEME_COLORS in sync with useTheme.jsx.
-const VALID_THEMES = ['light-mono', 'light', 'dark-mono', 'dark'];
+// paint is in the correct palette. Two themes; retired monochrome
+// variants alias to their color equivalent, and legacy/missing values
+// fall to light. Keep VALID_THEMES + THEME_COLORS + THEME_ALIASES in
+// sync with useTheme.jsx.
+const VALID_THEMES = ['light', 'dark'];
+const THEME_ALIASES = { 'light-mono': 'light', 'dark-mono': 'dark' };
 const THEME_COLORS = {
-  'light-mono': '#dedede',
   light: '#e3d8ba',
-  'dark-mono': '#0a0a0a',
   dark: '#13180f',
 };
 const storedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.theme') : null;
-// Default to colored-light for new visitors (and legacy `system` /
-// other invalid values). Keep in sync with DEFAULT_THEME in useTheme.
-const initialTheme = VALID_THEMES.includes(storedTheme) ? storedTheme : 'light';
+const resolvedStoredTheme = THEME_ALIASES[storedTheme] || storedTheme;
+// Default to light for new visitors (and legacy `system` / other
+// invalid values). Keep in sync with DEFAULT_THEME in useTheme.
+const initialTheme = VALID_THEMES.includes(resolvedStoredTheme) ? resolvedStoredTheme : 'light';
 document.documentElement.setAttribute('data-theme', initialTheme);
 
 document.querySelectorAll('meta[name="theme-color"]').forEach((m) => m.remove());

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8,6 +8,15 @@
   padding-bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px));
 }
 
+/* Finer icon strokes site-wide. Lucide renders its stroke-width as a
+   presentation attribute (default 2, most call sites pass 1.75); an
+   author CSS rule on the shared .lucide class overrides them all with
+   a single lighter value, so every icon — current and future — reads
+   as a finer line without touching each call site. */
+.lucide {
+  stroke-width: 1.5;
+}
+
 .layout {
   flex: 1;
   display: flex;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -65,7 +65,6 @@
   --radius-3: 0;
 
   --chrome-h: 56px;
-  --dock-w: 280px;
 
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
@@ -102,60 +101,6 @@
   color-scheme: dark;
 }
 
-/* Monochrome variants — same brand-accent green, but every other
-   color drops its tan/olive warmth for a neutral grayscale palette.
-   Cycled to via the theme toggle alongside the regular colored
-   themes. */
-[data-theme='light-mono'] {
-  --page:        #f5f5f5;
-  --page-edge:   #ebebeb;
-  --surface-raised: #dedede;
-  --ink:         #1a1a1a;
-  --ink-soft:    #404040;
-  --ink-muted:   #707070;
-  --ink-faint:   #a0a0a0;
-  --rule:        #bcbcbc;
-  /* Slightly darker than --surface-raised so soft hairlines (e.g.
-     between the chrome bar's primary and secondary rows) actually
-     read against the bar's bg — the colored themes get hue contrast
-     for free; mono needs explicit luminance separation. */
-  --rule-soft:   #c8c8c8;
-  --accent:      #5e7a47;
-  --accent-soft: #8a9f6e;
-  --tan:         #888888;
-  --highlight:   rgba(94, 122, 71, 0.16);
-  --shadow:      rgba(0, 0, 0, 0.14);
-
-  --scrim:       rgba(235, 235, 235, 0.86);
-  --scrim-clear: rgba(235, 235, 235, 0);
-  --scrim-ink:   rgba(26, 26, 26, 0.9);
-
-  color-scheme: light;
-}
-
-[data-theme='dark-mono'] {
-  --page:        #181818;
-  --page-edge:   #101010;
-  --surface-raised: #0a0a0a;
-  --ink:         #f0f0f0;
-  --ink-soft:    #cccccc;
-  --ink-muted:   #888888;
-  --ink-faint:   #5a5a5a;
-  --rule:        #2e2e2e;
-  --rule-soft:   #232323;
-  --accent:      #a3b486;
-  --accent-soft: #8a9f6e;
-  --tan:         #888888;
-  --highlight:   rgba(163, 180, 134, 0.16);
-  --shadow:      rgba(0, 0, 0, 0.45);
-
-  --scrim:       rgba(0, 0, 0, 0.82);
-  --scrim-clear: rgba(0, 0, 0, 0);
-  --scrim-ink:   rgba(240, 240, 240, 0.9);
-
-  color-scheme: dark;
-}
-
 /* Raised-surface ink re-tuning.
 
    The --ink-muted / --ink-faint steps are calibrated for text on
@@ -177,22 +122,11 @@
   --ink-faint: #74705c;
 }
 
-[data-theme='light-mono'] .chrome-bar,
-[data-theme='light-mono'] .modal-panel {
-  --ink-muted: #5e5e5e;
-  --ink-faint: #767676;
-}
-
-/* Dark themes keep their muted step (already high-contrast on the very
-   dark raised surface); only the faint step needs a lift. */
+/* The dark theme keeps its muted step (already high-contrast on the
+   very dark raised surface); only the faint step needs a lift. */
 [data-theme='dark'] .chrome-bar,
 [data-theme='dark'] .modal-panel {
   --ink-faint: #857f68;
-}
-
-[data-theme='dark-mono'] .chrome-bar,
-[data-theme='dark-mono'] .modal-panel {
-  --ink-faint: #6c6c6c;
 }
 
 html, body {


### PR DESCRIPTION
A batch of UI refinements:

- **Two themes only** — drops the two monochrome variants, leaving warm light and dark green. Retired mono values alias to their color equivalent (light-mono→light, dark-mono→dark) in both the pre-mount init and the hook, so returning visitors keep their light/dark polarity. The bottom-bar toggle becomes a two-state sun/moon switch.
- **Compass opens an upward sheet** — no longer a centered modal. It expands upward out of the bottom chrome bar (the mirror of the top bar's expand-down rows) via a `height 0↔auto` motion.div pinned above the bar, on the same 65rem card and raised surface, with a transparent click-catcher for outside-tap close. A border on the sheet's bottom edge separates it crisply from the button row.
- **Lightbox controls become the nav** — controls + source/search links move out from under the image into a fixed bar at the exact position, height, and surface of the bottom nav, so the nav appears to morph into the photo controls. Buttons restyled to the chrome-nav vocabulary; close is the accent-filled primary like the compass.
- **Subtler feed separators** — item borders drop to a hairline (half-strength `--rule-soft` blended toward the page).
- **Finer icons site-wide** — a single `.lucide { stroke-width: 1.5 }` rule (author CSS overrides the per-icon presentation attribute).
- **Copy** — the profile stat now reads "N people on Bluesky" (was "users on bluesky").

Verified in light and dark themes against the production build: sheet expands from the bar, lightbox control bar sits at the nav's exact box, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu)_