### PR TITLE
Fix blank Scriptable widget and restyle to match the site

### DIFF
--- a/scripts/scriptable/README.md
+++ b/scripts/scriptable/README.md
@@ -7,8 +7,13 @@ file here is a self-contained script you paste into the app.
 
 Shows the most recent `is.dame.now` status update(s) — the same records behind
 [dame.is/logging](https://dame.is/logging) — pulled live from the AT Protocol
-PDS. `now` records are public, so there's no login: the widget reads them with
-`com.atproto.repo.listRecords`.
+PDS. `now` records are public, so there's no login and no Bluesky AppView: the
+widget resolves the PDS host from the PLC directory and reads records straight
+from it with `com.atproto.repo.listRecords`, exactly like the site does.
+
+The look mirrors the site — flat earthy palette, a serif voice (Charter, the
+closest iOS system serif to the site's Crimson Pro), mono timestamps, square
+corners, hairline rules — and follows the phone's light/dark appearance.
 
 ### Install
 
@@ -31,8 +36,7 @@ In **Edit Widget → Parameter**, pass `key=value` pairs separated by `;`:
 
 | Key | Default | Meaning |
 |---|---|---|
-| `handle` | `dame.is` | Handle to resolve for the repo. |
-| `did` | `did:plc:gq4fo3u6tqzzdkjlwzpb23tj` | Fallback DID if handle resolution fails. |
+| `did` | `did:plc:gq4fo3u6tqzzdkjlwzpb23tj` | The repo (DID) whose `now` records to read. |
 | `count` | `4` | How many updates to show (medium/large). |
 | `site` | `https://dame.is` | Where a tap opens (deep-links to the record when possible). |
 

--- a/scripts/scriptable/dame-now-widget.js
+++ b/scripts/scriptable/dame-now-widget.js
@@ -1,28 +1,31 @@
 // Variables used by Scriptable.
 // These must be at the very top of the file. Do not edit.
-// icon-color: deep-blue; icon-glyph: satellite-dish;
+// icon-color: deep-green; icon-glyph: satellite-dish;
 //
 // dame.is — "now" status widget for the Scriptable app (https://scriptable.app)
 // ---------------------------------------------------------------------------
 // Shows the latest `is.dame.now` status update(s) straight from the AT Protocol
-// PDS — the same records that power dame.is/logging. No login required: `now`
-// records are public, read via `com.atproto.repo.listRecords`.
+// PDS — the same records that power dame.is/logging. No login, and no Bluesky
+// AppView: the PDS is queried directly with `com.atproto.repo.listRecords`,
+// exactly like the website does.
+//
+// The look mirrors the site: flat earthy palette, a serif voice (Charter, the
+// closest iOS system serif to the site's Crimson Pro), mono timestamps, square
+// corners, hairline rules. It follows the phone's light/dark appearance.
 //
 // SETUP
 //   1. Install Scriptable from the App Store.
 //   2. Scriptable → + (new script) → paste this whole file. Name it "dame.is now".
 //   3. Home screen → long-press → + → Scriptable → pick a size → add.
 //   4. Long-press the widget → Edit Widget → Script: "dame.is now".
-//      (Optional) "When Interacting: Run Script" if you'd rather it refresh on tap.
 //
 //   Sizes: small shows the latest status; medium/large show a short history.
 //
-//   Widget Parameter (optional, in Edit Widget) lets you point it at any repo
-//   and tune it, as `key=value` pairs separated by `;`. Examples:
-//     handle=dame.is
+//   Widget Parameter (optional, in Edit Widget) — `key=value` pairs separated
+//   by `;`. All optional; empty just works:
 //     did=did:plc:gq4fo3u6tqzzdkjlwzpb23tj
 //     count=5
-//   Everything has sensible defaults, so an empty parameter just works.
+//     site=https://dame.is
 //
 // Runs standalone too: press ▶ in the Scriptable editor to preview.
 
@@ -31,31 +34,49 @@
 // ---------------------------------------------------------------------------
 
 const DEFAULTS = {
-  handle: 'dame.is',
-  // Pinned DID so the widget works even if handle resolution is down. The PDS
-  // itself is always resolved live from the PLC directory, so a PDS migration
-  // needs no change here.
+  // The repo (DID) whose `now` records we read. Pinned so the widget works
+  // without any handle lookup against a third-party AppView.
   did: 'did:plc:gq4fo3u6tqzzdkjlwzpb23tj',
   collection: 'is.dame.now',
   count: 4, // how many recent updates to show in medium/large widgets
-  site: 'https://dame.is', // tapping the widget opens here (record page when possible)
+  site: 'https://dame.is', // tapping opens here (record page when possible)
 };
 
 const PLC_DIRECTORY = 'https://plc.directory';
-const APPVIEW = 'https://public.api.bsky.app';
 const PDS_FALLBACK = 'https://pds.atpota.to'; // last-known PDS if PLC is unreachable
 const CACHE_FILE = 'dame-now-widget-cache.json';
 
-// Palette — muted, atmospheric, tuned for both light and dark home screens.
-const COLORS = {
-  bgTop: new Color('#0b1020'),
-  bgBottom: new Color('#161c2e'),
-  prefix: new Color('#7c88a8'),
-  status: new Color('#f2f4f8'),
-  meta: new Color('#5f6b86'),
-  accent: new Color('#6ea8fe'),
-  divider: new Color('#2a3350'),
+// Palette lifted straight from the site's theme.css (earthy: warm off-white
+// page, greenish-black ink, mossy-green accent). One set per appearance.
+const THEMES = {
+  light: {
+    page: new Color('#f1ead4'),
+    ink: new Color('#1d2419'),
+    inkMuted: new Color('#6f6e58'),
+    inkFaint: new Color('#9d9784'),
+    accent: new Color('#5e7a47'),
+    rule: new Color('#cabf9f'),
+  },
+  dark: {
+    page: new Color('#1d2419'),
+    ink: new Color('#ece4cb'),
+    inkMuted: new Color('#9a9377'),
+    inkFaint: new Color('#6a6450'),
+    accent: new Color('#a3b486'),
+    rule: new Color('#3a4232'),
+  },
 };
+
+// Serif that matches the site's Crimson Pro voice. Charter ships with iOS and
+// is in the site's own fallback stack; if unavailable Scriptable falls back to
+// the system font on its own.
+function serif(size) {
+  return new Font('Charter-Roman', size);
+}
+// Mono for timestamps, matching the site's `.gutter` (IBM Plex Mono → Menlo).
+function mono(size) {
+  return new Font('Menlo', size);
+}
 
 // ---------------------------------------------------------------------------
 // Parse the optional widget parameter (`key=value;key=value`)
@@ -81,9 +102,11 @@ function parseParams(raw) {
 }
 
 const cfg = parseParams(args.widgetParameter);
+const theme = Device.isUsingDarkAppearance() ? THEMES.dark : THEMES.light;
 
 // ---------------------------------------------------------------------------
-// AT Protocol helpers — plain fetch + JSON, no SDK.
+// AT Protocol helpers — plain fetch + JSON. No SDK, no URLSearchParams (not
+// available in Scriptable's JS engine); query strings are built by hand.
 // ---------------------------------------------------------------------------
 
 async function getJson(url) {
@@ -93,24 +116,11 @@ async function getJson(url) {
   return req.loadJSON();
 }
 
-async function resolveHandle(handle) {
-  try {
-    const res = await getJson(
-      `${APPVIEW}/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`,
-    );
-    if (res && res.did) return res.did;
-  } catch (_) {
-    // fall through to the pinned DID
-  }
-  return null;
-}
-
 async function resolvePds(did) {
   try {
     const doc = await getJson(`${PLC_DIRECTORY}/${encodeURIComponent(did)}`);
     const services = (doc && doc.service) || [];
-    const svc =
-      services.find((s) => s.id === '#atproto_pds') || services[0];
+    const svc = services.find((s) => s.id === '#atproto_pds') || services[0];
     if (svc && svc.serviceEndpoint) return svc.serviceEndpoint.replace(/\/$/, '');
   } catch (_) {
     // fall through to the last-known PDS
@@ -119,14 +129,13 @@ async function resolvePds(did) {
 }
 
 async function listNow(pds, did, limit) {
-  const params = new URLSearchParams({
-    repo: did,
-    collection: cfg.collection,
-    limit: String(limit),
-  });
+  const qs =
+    `repo=${encodeURIComponent(did)}` +
+    `&collection=${encodeURIComponent(cfg.collection)}` +
+    `&limit=${encodeURIComponent(String(limit))}`;
   // listRecords returns records in descending rkey order by default, and rkeys
   // are chronological TIDs — so this is already newest-first.
-  const res = await getJson(`${pds}/xrpc/com.atproto.repo.listRecords?${params}`);
+  const res = await getJson(`${pds}/xrpc/com.atproto.repo.listRecords?${qs}`);
   const records = (res && res.records) || [];
   return records.map((r) => {
     const v = r.value || {};
@@ -168,14 +177,10 @@ function readCache() {
 function writeCache(items) {
   try {
     const fm = FileManager.local();
-    fm.writeString(cachePath(), JSON.stringify({ items, savedAt: nowIso() }));
+    fm.writeString(cachePath(), JSON.stringify({ items, savedAt: new Date().toISOString() }));
   } catch (_) {
     // best effort
   }
-}
-
-function nowIso() {
-  return new Date().toISOString();
 }
 
 // ---------------------------------------------------------------------------
@@ -209,143 +214,133 @@ async function loadItems() {
   const family = config.widgetFamily || 'medium';
   const want = family === 'small' ? 1 : cfg.count;
   try {
-    const did = (await resolveHandle(cfg.handle)) || cfg.did;
-    const pds = await resolvePds(did);
-    const items = await listNow(pds, did, Math.max(want, 1));
+    const pds = await resolvePds(cfg.did);
+    const items = await listNow(pds, cfg.did, Math.max(want, 1));
     if (items.length) {
       writeCache(items);
-      return { items, stale: false, did };
+      return { items, stale: false };
     }
   } catch (_) {
     // fall through to cache
   }
   const cached = readCache();
   if (cached && cached.items && cached.items.length) {
-    return { items: cached.items, stale: true, did: cfg.did };
+    return { items: cached.items, stale: true };
   }
-  return { items: [], stale: false, did: cfg.did };
+  return { items: [], stale: false };
 }
 
 // ---------------------------------------------------------------------------
-// Widget rendering
+// Widget rendering — flat page color, serif voice, mono timestamps, hairlines.
 // ---------------------------------------------------------------------------
 
-function backgroundGradient() {
-  const g = new LinearGradient();
-  g.colors = [COLORS.bgTop, COLORS.bgBottom];
-  g.locations = [0, 1];
-  return g;
-}
-
-function tapUrl(items, did) {
-  // Deep-link to the newest status's record page when we can; otherwise the feed.
+function tapUrl(items) {
   const base = cfg.site.replace(/\/$/, '');
   const rkey = items[0] && items[0].rkey;
   return rkey ? `${base}/logging/${rkey}` : `${base}/logging`;
 }
 
-function addStatusLine(stack, item, { big }) {
-  const row = stack.addStack();
+// Uppercase, letter-spaced metadata label like the site's `.metadata` class.
+function addHeader(widget, stale) {
+  const row = widget.addStack();
   row.layoutHorizontally();
-  row.spacing = 5;
+  row.centerAlignContent();
+
+  const label = row.addText('N O W');
+  label.font = mono(9);
+  label.textColor = theme.inkMuted;
+
+  row.addSpacer();
+
+  const site = row.addText(stale ? 'offline' : 'dame.is');
+  site.font = mono(9);
+  site.textColor = theme.inkFaint;
+}
+
+// A 1px hairline in the site's --rule color.
+function addHairline(widget) {
+  const line = widget.addStack();
+  line.size = new Size(0, 1);
+  line.backgroundColor = theme.rule;
+  line.addSpacer();
+}
+
+// One status row: "dame.is" (faint) + body (ink) on the left, mono time right.
+function addStatusRow(widget, item, { size }) {
+  const row = widget.addStack();
+  row.layoutHorizontally();
+  row.topAlignContent();
+  row.spacing = 6;
 
   const prefix = row.addText('dame.is');
-  prefix.font = big ? Font.mediumSystemFont(15) : Font.mediumSystemFont(12);
-  prefix.textColor = COLORS.prefix;
+  prefix.font = serif(size);
+  prefix.textColor = theme.inkFaint;
   prefix.lineLimit = 1;
 
-  const status = row.addText(item.status || '…');
-  status.font = big ? Font.semiboldSystemFont(15) : Font.semiboldSystemFont(12);
-  status.textColor = COLORS.status;
-  status.lineLimit = big ? 2 : 1;
-  status.minimumScaleFactor = 0.7;
+  const body = row.addText(item.status || '—');
+  body.font = serif(size);
+  body.textColor = theme.ink;
+  body.lineLimit = size >= 17 ? 3 : 2;
+  body.minimumScaleFactor = 0.7;
+
+  row.addSpacer();
+
+  const t = relativeTime(item.createdAt);
+  if (t) {
+    const time = row.addText(t);
+    time.font = mono(Math.max(9, size - 7));
+    time.textColor = theme.inkFaint;
+    time.lineLimit = 1;
+  }
 }
 
 function renderSmall(widget, data) {
-  const { items, stale } = data;
-  const item = items[0] || { status: 'no updates yet', createdAt: null };
+  const item = (data.items && data.items[0]) || { status: 'no updates yet', createdAt: null };
 
-  const header = widget.addStack();
-  header.layoutHorizontally();
-  const dot = header.addText('●');
-  dot.font = Font.systemFont(9);
-  dot.textColor = COLORS.accent;
-  header.addSpacer(5);
-  const label = header.addText('now');
-  label.font = Font.mediumSystemFont(11);
-  label.textColor = COLORS.meta;
-  header.addSpacer();
-
-  widget.addSpacer(8);
+  addHeader(widget, data.stale);
+  widget.addSpacer(10);
 
   const prefix = widget.addText('dame.is');
-  prefix.font = Font.mediumSystemFont(13);
-  prefix.textColor = COLORS.prefix;
+  prefix.font = serif(15);
+  prefix.textColor = theme.inkFaint;
 
-  widget.addSpacer(2);
+  widget.addSpacer(3);
 
-  const status = widget.addText(item.status || '…');
-  status.font = Font.semiboldSystemFont(17);
-  status.textColor = COLORS.status;
-  status.lineLimit = 4;
-  status.minimumScaleFactor = 0.6;
+  const body = widget.addText(item.status || '—');
+  body.font = serif(19);
+  body.textColor = theme.ink;
+  body.lineLimit = 4;
+  body.minimumScaleFactor = 0.6;
 
   widget.addSpacer();
 
-  const meta = widget.addText(
-    (stale ? '⚠ ' : '') + (relativeTime(item.createdAt) || ''),
-  );
-  meta.font = Font.systemFont(11);
-  meta.textColor = COLORS.meta;
+  const t = relativeTime(item.createdAt);
+  const meta = widget.addText(t || '');
+  meta.font = mono(10);
+  meta.textColor = theme.inkFaint;
 }
 
 function renderList(widget, data, { big }) {
-  const { items, stale } = data;
+  addHeader(widget, data.stale);
+  widget.addSpacer(big ? 12 : 9);
 
-  const header = widget.addStack();
-  header.layoutHorizontally();
-  header.centerAlignContent();
-  const dot = header.addText('●');
-  dot.font = Font.systemFont(9);
-  dot.textColor = COLORS.accent;
-  header.addSpacer(6);
-  const title = header.addText('dame.is · now');
-  title.font = Font.semiboldSystemFont(13);
-  title.textColor = COLORS.prefix;
-  header.addSpacer();
-  if (stale) {
-    const warn = header.addText('offline');
-    warn.font = Font.systemFont(10);
-    warn.textColor = COLORS.meta;
-  }
-
-  widget.addSpacer(big ? 12 : 8);
-
-  if (!items.length) {
+  if (!data.items.length) {
     const empty = widget.addText('No status updates yet.');
-    empty.font = Font.systemFont(13);
-    empty.textColor = COLORS.meta;
+    empty.font = serif(15);
+    empty.textColor = theme.inkMuted;
+    widget.addSpacer();
     return;
   }
 
-  const shown = items.slice(0, cfg.count);
+  const size = big ? 17 : 14;
+  const shown = data.items.slice(0, cfg.count);
   shown.forEach((item, i) => {
     if (i > 0) {
-      widget.addSpacer(big ? 9 : 6);
-      const line = widget.addStack();
-      line.backgroundColor = COLORS.divider;
-      line.size = new Size(0, 1);
-      line.addSpacer();
-      widget.addSpacer(big ? 9 : 6);
+      widget.addSpacer(big ? 9 : 7);
+      addHairline(widget);
+      widget.addSpacer(big ? 9 : 7);
     }
-    addStatusLine(widget, item, { big });
-    const t = relativeTime(item.createdAt);
-    if (t) {
-      widget.addSpacer(2);
-      const meta = widget.addText(t);
-      meta.font = Font.systemFont(big ? 11 : 10);
-      meta.textColor = COLORS.meta;
-    }
+    addStatusRow(widget, item, { size });
   });
 
   widget.addSpacer();
@@ -356,10 +351,9 @@ async function buildWidget() {
   const family = config.widgetFamily || 'medium';
 
   const widget = new ListWidget();
-  widget.backgroundGradient = backgroundGradient();
-  widget.setPadding(14, 15, 14, 15);
-  widget.url = tapUrl(data.items, data.did);
-  // Refresh at most a few times an hour; the home screen batches these.
+  widget.backgroundColor = theme.page; // flat, square — matches the site
+  widget.setPadding(15, 16, 15, 16);
+  widget.url = tapUrl(data.items);
   widget.refreshAfterDate = new Date(Date.now() + 15 * 60 * 1000);
 
   if (family === 'small') {
@@ -380,7 +374,6 @@ const widget = await buildWidget();
 if (config.runsInWidget) {
   Script.setWidget(widget);
 } else {
-  // Previewing in the app — show the medium layout.
   await widget.presentMedium();
 }
 


### PR DESCRIPTION
Follow-up to #92. Two fixes for `scripts/scriptable/dame-now-widget.js`.

## Blank widget — root cause

Scriptable's JS engine (JavaScriptCore) has no `URLSearchParams`, so the `listRecords` call threw on every run and fell through to an empty cache — nothing rendered. Query strings are now built by hand.

Also dropped the Bluesky AppView handle-resolution step entirely: the widget resolves the PDS host from the PLC directory and reads `com.atproto.repo.listRecords` directly from the PDS, the way the site does. Verified against the live PDS.

## Style — mirror the site

Replaced the generic dark-blue gradient with the site's own design language, lifted from `theme.css` / `StatusEntry`:

- Flat earthy palette (warm off-white page / greenish-black ink in light; inverse in dark) with the mossy-green accent.
- Serif voice — Charter, the closest iOS system serif to the site's Crimson Pro (already in the site's CSS fallback stack).
- Mono timestamps in the muted `.gutter` tone, `dame.is` prefix in faint ink, square corners, hairline rules.
- Follows the phone's light/dark appearance.

## Verification

Data path (PLC PDS resolution, hand-built query string, record parsing, `text`→`status` fallback, newest-first ordering, rkey deep-linking) exercised against the live PDS. File parses (`node --check`). Rendering itself is iOS-only — preview with ▶ in the Scriptable editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim)_