### PR TITLE
Refine now widget header and row alignment

### DIFF
--- a/scripts/scriptable/dame-now-widget.js
+++ b/scripts/scriptable/dame-now-widget.js
@@ -218,16 +218,21 @@ async function loadItems() {
     const items = await listNow(pds, cfg.did, Math.max(want, 1));
     if (items.length) {
       writeCache(items);
-      return { items, stale: false };
+      return { items, stale: false, updatedAt: new Date() };
     }
   } catch (_) {
     // fall through to cache
   }
   const cached = readCache();
   if (cached && cached.items && cached.items.length) {
-    return { items: cached.items, stale: true };
+    const savedAt = cached.savedAt ? new Date(cached.savedAt) : null;
+    return {
+      items: cached.items,
+      stale: true,
+      updatedAt: savedAt && Number.isFinite(savedAt.getTime()) ? savedAt : null,
+    };
   }
-  return { items: [], stale: false };
+  return { items: [], stale: false, updatedAt: new Date() };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,8 +245,18 @@ function tapUrl(items) {
   return rkey ? `${base}/logging/${rkey}` : `${base}/logging`;
 }
 
-// Uppercase, letter-spaced metadata label like the site's `.metadata` class.
-function addHeader(widget, stale) {
+// When this widget's data was last pulled. Compact = time only (for the small
+// widget); otherwise "Jul 6, 2:41 PM".
+function formatUpdated(date, compact) {
+  if (!date) return 'no data';
+  const df = new DateFormatter();
+  df.dateFormat = compact ? 'h:mm a' : 'MMM d, h:mm a';
+  return df.string(date);
+}
+
+// Header: the site's uppercase, letter-spaced metadata label on the left; the
+// last data-update stamp on the right.
+function addHeader(widget, updatedAt, { compact }) {
   const row = widget.addStack();
   row.layoutHorizontally();
   row.centerAlignContent();
@@ -252,9 +267,10 @@ function addHeader(widget, stale) {
 
   row.addSpacer();
 
-  const site = row.addText(stale ? 'offline' : 'dame.is');
-  site.font = mono(9);
-  site.textColor = theme.inkFaint;
+  const stamp = row.addText(`updated ${formatUpdated(updatedAt, compact)}`);
+  stamp.font = mono(9);
+  stamp.textColor = theme.inkFaint;
+  stamp.lineLimit = 1;
 }
 
 // A 1px hairline in the site's --rule color.
@@ -266,10 +282,13 @@ function addHairline(widget) {
 }
 
 // One status row: "dame.is" (faint) + body (ink) on the left, mono time right.
+// Bottom-aligned so the status sits on the same baseline as the "dame.is"
+// prefix. The body renders at full size (no scale-down) and wraps if long,
+// which keeps its type size matched to the prefix.
 function addStatusRow(widget, item, { size }) {
   const row = widget.addStack();
   row.layoutHorizontally();
-  row.topAlignContent();
+  row.bottomAlignContent();
   row.spacing = 6;
 
   const prefix = row.addText('dame.is');
@@ -280,8 +299,7 @@ function addStatusRow(widget, item, { size }) {
   const body = row.addText(item.status || '—');
   body.font = serif(size);
   body.textColor = theme.ink;
-  body.lineLimit = size >= 17 ? 3 : 2;
-  body.minimumScaleFactor = 0.7;
+  body.lineLimit = 2;
 
   row.addSpacer();
 
@@ -297,7 +315,7 @@ function addStatusRow(widget, item, { size }) {
 function renderSmall(widget, data) {
   const item = (data.items && data.items[0]) || { status: 'no updates yet', createdAt: null };
 
-  addHeader(widget, data.stale);
+  addHeader(widget, data.updatedAt, { compact: true });
   widget.addSpacer(10);
 
   const prefix = widget.addText('dame.is');
@@ -321,7 +339,7 @@ function renderSmall(widget, data) {
 }
 
 function renderList(widget, data, { big }) {
-  addHeader(widget, data.stale);
+  addHeader(widget, data.updatedAt, { compact: false });
   widget.addSpacer(big ? 12 : 9);
 
   if (!data.items.length) {


### PR DESCRIPTION
Follow-up to #94, addressing on-device feedback.

- **Header top-right:** drop the redundant `dame.is`; show the last data-update stamp instead — `updated h:mm a` on the small widget, `updated MMM d, h:mm a` on medium/large. The stamp reads the cache time when showing offline data, which doubles as the staleness signal.
- **Row alignment:** the status body was being shrunk by `minimumScaleFactor` to fit one line, so it rendered smaller than the `dame.is` prefix and floated to the top of the row. Removed the scale-down (statuses render full size and wrap to a second line if long) and bottom-align each row, so the status shares the `dame.is` baseline. Mono timestamps bottom-align to it too.

## Verification

`node --check` passes. Rendering is iOS-only; confirmed against the earlier on-device screenshot that this targets the two issues raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim)_