### PR TITLE
Add optional shortcut param to run an Apple Shortcut on tap

### DIFF
--- a/scripts/scriptable/README.md
+++ b/scripts/scriptable/README.md
@@ -39,6 +39,7 @@ In **Edit Widget → Parameter**, pass `key=value` pairs separated by `;`:
 | `did` | `did:plc:gq4fo3u6tqzzdkjlwzpb23tj` | The repo (DID) whose `now` records to read. |
 | `count` | `4` | How many updates to show (medium/large). |
 | `site` | `https://dame.is` | Where a tap opens (deep-links to the record when possible). |
+| `shortcut` | *(none)* | Name of an Apple Shortcut to run on tap instead of opening `site`. |
 
 Example — show five updates:
 
@@ -46,6 +47,19 @@ Example — show five updates:
 count=5
 ```
 
+### Run a Shortcut on tap
+
+Set `shortcut` to the exact name of a Shortcut and tapping the widget runs it
+(via the `shortcuts://run-shortcut` URL scheme) instead of opening the site.
+The latest status text is passed as the Shortcut's input (available as
+"Shortcut Input" inside the Shortcut). Note: this briefly foregrounds the
+Shortcuts app — a Scriptable widget can't run a Shortcut silently in the
+background the way a native App Intent widget can.
+
+```
+shortcut=Log a status
+```
+
 The PDS host is always resolved live from the PLC directory, so a PDS migration
 needs no edit. The last successful fetch is cached on-device, so the widget
-still shows something when offline (marked `offline`).
+still shows something when offline.

--- a/scripts/scriptable/dame-now-widget.js
+++ b/scripts/scriptable/dame-now-widget.js
@@ -40,6 +40,9 @@ const DEFAULTS = {
   collection: 'is.dame.now',
   count: 4, // how many recent updates to show in medium/large widgets
   site: 'https://dame.is', // tapping opens here (record page when possible)
+  // Optional: name of an Apple Shortcut to run on tap instead of opening the
+  // site. When set, the latest status text is passed as the shortcut's input.
+  shortcut: '',
 };
 
 const PLC_DIRECTORY = 'https://plc.directory';
@@ -243,6 +246,15 @@ async function loadItems() {
 // ---------------------------------------------------------------------------
 
 function tapUrl(items) {
+  // Opt-in: run an Apple Shortcut on tap (foregrounds the Shortcuts app),
+  // passing the latest status as its input. Falls back to opening the site.
+  if (cfg.shortcut) {
+    const latest = (items[0] && items[0].status) || '';
+    return (
+      `shortcuts://run-shortcut?name=${encodeURIComponent(cfg.shortcut)}` +
+      `&input=text&text=${encodeURIComponent(latest)}`
+    );
+  }
   const base = cfg.site.replace(/\/$/, '');
   const rkey = items[0] && items[0].rkey;
   return rkey ? `${base}/logging/${rkey}` : `${base}/logging`;


### PR DESCRIPTION
Follow-up to #97.

Adds an opt-in `shortcut` widget parameter. When set to a Shortcut's name, tapping the widget runs that Apple Shortcut via the `shortcuts://run-shortcut` URL scheme, passing the latest status text as the Shortcut's input. When unset, tapping opens the site as before.

- `scripts/scriptable/dame-now-widget.js` — `shortcut` default + `tapUrl` branch.
- `scripts/scriptable/README.md` — documents the parameter and the "briefly foregrounds Shortcuts" caveat.

## Verification

`node --check` passes. Rendering/tap behavior is iOS-only; the tap URL is a standard `shortcuts://run-shortcut?name=…&input=text&text=…` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim)_