### PR TITLE
Custom scrollbar, full-conceal nav sheet, chrome depth + single divider

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ const Exploring = lazy(() => import('./pages/Exploring.jsx'));
 import ChromeBar from './components/ChromeBar.jsx';
 import ActionDock from './components/ActionDock.jsx';
 import Footer from './components/Footer.jsx';
+import WindowScrollbar from './components/WindowScrollbar.jsx';
 import RouteTransition from './components/RouteTransition.jsx';
 import { ActionDockProvider } from './hooks/useActionDock.jsx';
 import { ThemeProvider } from './hooks/useTheme.jsx';
@@ -139,6 +140,7 @@ export default function App() {
             </main>
             <Footer />
             <ActionDock />
+            <WindowScrollbar />
             <Analytics />
           </div>
       </WaypointsModalProvider>

--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -39,8 +39,12 @@
    scroll when a view (the route list, the debug dump) overflows. */
 .dock-panel {
   pointer-events: auto;
-  background: var(--surface-raised);
-  border-top: 1px solid var(--rule);
+  /* Deeper than the bar's --surface-raised so the expanded sheet reads
+     as its own layer above the toolbar. */
+  background: var(--surface-deep);
+  /* No border-top: the sheet's top edge butts against the top chrome's
+     own border-bottom, and a border here would double it into a 2px
+     line. The top chrome's hairline is the single divider. */
   /* Crisp divider between the expanded sheet and the button row below.
      Lives on the sheet's bottom edge (the sheet paints above the bar,
      z 31 > 30, so it wins over the bar's own hidden top border). */

--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -32,8 +32,11 @@
 
 /* .dock-panel: the visible surface. Matches the chrome bar's raised
    surface and hairlines so the sheet + bar read as one continuous
-   card. Capped in height with its own scroll so long views (the
-   route list, the debug dump) never push past the top bar. */
+   card. Its height is the exact gap between the top chrome (whatever
+   its live height — collapsed or atmosphere-expanded, via
+   --chrome-top-h) and the bottom bar, so the open sheet fully conceals
+   the page and its top edge butts cleanly against the top chrome. Own
+   scroll when a view (the route list, the debug dump) overflows. */
 .dock-panel {
   pointer-events: auto;
   background: var(--surface-raised);
@@ -43,10 +46,9 @@
      z 31 > 30, so it wins over the bar's own hidden top border). */
   border-bottom: 1px solid var(--rule);
   padding: var(--space-4);
-  max-height: min(72dvh, calc(100dvh - var(--chrome-h) - 4rem));
+  height: calc(100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   overscroll-behavior: contain;
-  box-shadow: 0 -8px 24px var(--shadow);
 }
 
 /* On wide screens the chrome bars float as a 65rem card with side

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -74,6 +74,9 @@
 
 .chrome-bar-secondary {
   border-top: 1px solid var(--rule-soft);
+  /* Deeper than the primary row's --surface-raised so the expanded
+     atmosphere row reads as its own layer (matches the nav sheet). */
+  background: var(--surface-deep);
   overflow: hidden;
 }
 

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, MoonStar, Search, SunDim } from 'lucide-react';
@@ -37,6 +37,25 @@ export default function ChromeBar() {
     setAvatarBroken(false);
   }, [avatar]);
 
+  // Publish the top bar's live rendered height as `--chrome-top-h` on
+  // <html>. The atmosphere-expand row grows the header, so this tracks
+  // that (and viewport-driven reflow) via ResizeObserver. Consumers:
+  // the action-dock sheet (fills from here down to the bottom bar so it
+  // fully conceals the page and butts against the top chrome) and the
+  // custom window scrollbar (inset to the content region between bars).
+  const topRef = useRef(null);
+  useEffect(() => {
+    const el = topRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const apply = () => {
+      document.documentElement.style.setProperty('--chrome-top-h', `${el.offsetHeight}px`);
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   // Tertiary chrome: a breadcrumb that slides down out of the top bar once
   // the page is scrolled away from its top, orienting you to where you are.
   // It only exists off the home page, and folds back up on the way to the top.
@@ -47,6 +66,7 @@ export default function ChromeBar() {
   return (
     <>
       <header
+        ref={topRef}
         className={`chrome-bar chrome-bar-top ${expanded ? 'is-expanded' : 'is-collapsed'}`}
         role="banner"
       >

--- a/src/components/WindowScrollbar.css
+++ b/src/components/WindowScrollbar.css
@@ -1,0 +1,57 @@
+/* Custom document scrollbar — a thin accent line inset to the content
+   region between the chrome bars, sitting below them (z 20 < the bars'
+   30) so it reads as tucked under the chrome. Hidden when the page
+   doesn't overflow. */
+.window-scrollbar {
+  position: fixed;
+  right: 3px;
+  top: calc(var(--chrome-top-h, var(--chrome-h)) + var(--space-2));
+  bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px) + var(--space-2));
+  width: 3px;
+  z-index: 20;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.window-scrollbar.is-visible {
+  opacity: 1;
+}
+
+.window-scrollbar-thumb {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  min-height: 32px;
+  border-radius: 3px;
+  background: var(--accent);
+  opacity: 0.55;
+  pointer-events: auto;
+  cursor: grab;
+  transition: opacity 140ms ease;
+  /* transform (translateY) is set inline by the component */
+}
+
+.window-scrollbar-thumb:hover {
+  opacity: 0.85;
+}
+
+.window-scrollbar-thumb:active {
+  opacity: 1;
+  cursor: grabbing;
+}
+
+/* Coarse pointers (touch) can't hover-drag a 3px target and get native
+   momentum scrolling anyway — show the line as a pure indicator. */
+@media (hover: none) {
+  .window-scrollbar-thumb {
+    pointer-events: none;
+  }
+}
+
+@media print {
+  .window-scrollbar {
+    display: none;
+  }
+}

--- a/src/components/WindowScrollbar.jsx
+++ b/src/components/WindowScrollbar.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react';
+import './WindowScrollbar.css';
+
+/**
+ * Custom scrollbar for the document scroll. Native scrollbars are
+ * hidden app-wide (see reset.css); this draws a thin accent line — the
+ * same moss/sage the compass button uses — in the content region
+ * between the top and bottom chrome bars, so it reads as tucked under
+ * the chrome rather than running edge to edge. The thumb is draggable.
+ *
+ * Purely visual/optional: it observes the document, so it needs no
+ * props and lives once at the app-shell level.
+ */
+export default function WindowScrollbar() {
+  const thumbRef = useRef(null);
+  const [scrollable, setScrollable] = useState(false);
+
+  useEffect(() => {
+    const doc = document.documentElement;
+    const thumb = thumbRef.current;
+    if (!thumb) return undefined;
+    const track = thumb.parentElement;
+    let raf = 0;
+
+    const measure = () => {
+      raf = 0;
+      const scrollH = doc.scrollHeight;
+      const viewH = window.innerHeight;
+      const range = scrollH - viewH;
+      if (range <= 1) {
+        setScrollable(false);
+        return;
+      }
+      setScrollable(true);
+      const trackH = track.clientHeight;
+      const thumbH = Math.max(32, Math.round(trackH * (viewH / scrollH)));
+      const y = Math.round((window.scrollY / range) * (trackH - thumbH));
+      thumb.style.height = `${thumbH}px`;
+      thumb.style.transform = `translateY(${y}px)`;
+    };
+
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(measure);
+    };
+
+    measure();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    const ro = new ResizeObserver(schedule);
+    ro.observe(doc);
+    return () => {
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      ro.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  // Drag the thumb to scroll: map vertical pointer travel across the
+  // free track space onto the document's scroll range.
+  const onPointerDown = (e) => {
+    const thumb = thumbRef.current;
+    if (!thumb) return;
+    e.preventDefault();
+    const track = thumb.parentElement;
+    const trackH = track.clientHeight;
+    const thumbH = thumb.offsetHeight;
+    const range = document.documentElement.scrollHeight - window.innerHeight;
+    const startY = e.clientY;
+    const startScroll = window.scrollY;
+    const free = trackH - thumbH;
+    const onMove = (ev) => {
+      if (free <= 0) return;
+      const delta = ((ev.clientY - startY) / free) * range;
+      window.scrollTo(0, startScroll + delta);
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  return (
+    <div className={`window-scrollbar ${scrollable ? 'is-visible' : ''}`} aria-hidden="true">
+      <div className="window-scrollbar-thumb" ref={thumbRef} onPointerDown={onPointerDown} />
+    </div>
+  );
+}

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -23,6 +23,21 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Hide native scrollbars everywhere — the document, menus, modals, and
+   any inner scroll region. Scrolling still works; only the visual bar
+   is removed. The page's document scroll gets a custom accent-colored
+   indicator instead (see <WindowScrollbar>). */
+* {
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* legacy Edge */
+}
+
+*::-webkit-scrollbar {          /* WebKit / Blink */
+  width: 0;
+  height: 0;
+  background: transparent;
+}
+
 img, picture, video, canvas, svg {
   display: block;
   max-width: 100%;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,6 +6,11 @@
   --page:        #f1ead4;   /* off-white with warm tan undertone */
   --page-edge:   #e6dec3;
   --surface-raised: #e3d8ba; /* tan, slightly deeper than --page-edge, for chrome bars + modal panels */
+  /* One step deeper than --surface-raised, for the EXPANDED chrome
+     panels (top atmosphere row, bottom nav sheet) so they read as a
+     distinct layer. Mixing --ink in auto-adapts per theme: darker on
+     light (dark ink), lighter on dark (off-white ink). */
+  --surface-deep: color-mix(in srgb, var(--surface-raised) 91%, var(--ink) 9%);
   --ink:         #1d2419;   /* dark greenish-black */
   --ink-soft:    #364034;
   --ink-muted:   #6f6e58;   /* tan-olive */


### PR DESCRIPTION
Two rounds of chrome/scroll refinement:

**Scrollbars**
- Hide native scrollbars app-wide (document, menus, modals, inner scroll regions) via a reset rule — scrolling still works, only the visual bar goes.
- The document scroll gets a custom indicator (`<WindowScrollbar>`): a thin line in `--accent` (the compass moss/sage) inset to the content region between the chrome bars and z-indexed below them (20 < 30) so it reads as tucked under the chrome. The thumb tracks scroll position and is draggable on fine pointers.

**Nav sheet fully conceals + connects to top chrome**
- The dock now expands to fill the exact gap between the top chrome and the bottom bar, covering all page content with its top edge butting against the top chrome.
- ChromeBar publishes the top bar's live height as `--chrome-top-h` (ResizeObserver), which the sheet and scrollbar both read, so neither overlaps an expanded atmosphere row.

**Single divider + depth**
- Dropped the sheet's `border-top` so it no longer doubles with the top chrome's `border-bottom` at the junction.
- The expanded chrome panels (top atmosphere row, bottom nav sheet) get a new `--surface-deep` background — a single `color-mix` toward `--ink` that auto-adapts per theme (darker on light, lighter on dark) — for depth/hierarchy.

Verified in light and dark against the production build; rebased onto the recent chrome/status changes on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu)_