### PR TITLE
Align row timestamps to the status first-line baseline

### DIFF
--- a/scripts/scriptable/dame-now-widget.js
+++ b/scripts/scriptable/dame-now-widget.js
@@ -314,8 +314,15 @@ function addStatusRow(widget, item, { size }) {
 
   const t = relativeTime(item.createdAt);
   if (t) {
-    const time = row.addText(t);
-    time.font = mono(Math.max(9, size - 7));
+    // The mono timestamp is smaller than the serif status, so top-aligning it
+    // would leave its baseline floating above the text. Wrap it in a column
+    // with a small top spacer that drops it onto the status's first-line
+    // baseline. The offset ≈ the ascent gap between the two fonts.
+    const col = row.addStack();
+    col.layoutVertically();
+    col.addSpacer(Math.max(2, Math.round(size * 0.28)));
+    const time = col.addText(t);
+    time.font = mono(9);
     time.textColor = theme.inkFaint;
     time.lineLimit = 1;
   }


### PR DESCRIPTION
Follow-up to #98.

The mono timestamps are smaller than the serif status text, so top-aligning them left their baseline floating above the status. Each timestamp is now wrapped in a column with a small top spacer (≈ the ascent gap between the two fonts) so it drops onto the status's first-line baseline — while the status text still top-aligns and wraps downward with `dame.is` on the first line.

## Verification

`node --check` passes. Rendering is iOS-only; the vertical offset is a computed estimate (`size * 0.28`) that may need a small tweak after previewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim)_