### PR TITLE
Chrome depth: fix shade direction; fold breadcrumb into height + depth

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -108,7 +108,9 @@
 }
 
 .chrome-bar-tertiary {
-  background: var(--surface-raised);
+  /* Deeper than the bars, matching the other expanded chrome panels
+     (atmosphere row, nav sheet). */
+  background: var(--surface-deep);
   border-top: 1px solid var(--rule-soft);
   border-bottom: 1px solid var(--rule);
   min-height: 0;

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -37,24 +37,8 @@ export default function ChromeBar() {
     setAvatarBroken(false);
   }, [avatar]);
 
-  // Publish the top bar's live rendered height as `--chrome-top-h` on
-  // <html>. The atmosphere-expand row grows the header, so this tracks
-  // that (and viewport-driven reflow) via ResizeObserver. Consumers:
-  // the action-dock sheet (fills from here down to the bottom bar so it
-  // fully conceals the page and butts against the top chrome) and the
-  // custom window scrollbar (inset to the content region between bars).
   const topRef = useRef(null);
-  useEffect(() => {
-    const el = topRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
-    const apply = () => {
-      document.documentElement.style.setProperty('--chrome-top-h', `${el.offsetHeight}px`);
-    };
-    apply();
-    const ro = new ResizeObserver(apply);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  const crumbRef = useRef(null);
 
   // Tertiary chrome: a breadcrumb that slides down out of the top bar once
   // the page is scrolled away from its top, orienting you to where you are.
@@ -62,6 +46,31 @@ export default function ChromeBar() {
   const crumbs = buildCrumbs(location.pathname);
   const scrolledDown = useScrolledDown();
   const showBreadcrumb = crumbs.length > 0 && scrolledDown;
+
+  // Publish the top chrome's live occupied height as `--chrome-top-h` on
+  // <html>. This is the header (primary row + the atmosphere-expand row)
+  // PLUS the breadcrumb strip when it's shown — the strip is absolutely
+  // positioned below the header, so it doesn't grow the header box and
+  // has to be added explicitly. Consumers: the action-dock sheet (fills
+  // from here down to the bottom bar so it fully conceals the page and
+  // butts against the whole top chrome) and the custom window scrollbar
+  // (inset to the content region between the bars). Re-runs on
+  // showBreadcrumb changes and on any size change (ResizeObserver).
+  useEffect(() => {
+    const el = topRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const apply = () => {
+      let h = el.offsetHeight;
+      const crumb = crumbRef.current;
+      if (showBreadcrumb && crumb) h += crumb.offsetHeight;
+      document.documentElement.style.setProperty('--chrome-top-h', `${h}px`);
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(el);
+    if (crumbRef.current) ro.observe(crumbRef.current);
+    return () => ro.disconnect();
+  }, [showBreadcrumb]);
 
   return (
     <>
@@ -169,6 +178,7 @@ export default function ChromeBar() {
             on the wrap) instead of growing the box. */}
         {crumbs.length > 0 && (
           <div
+            ref={crumbRef}
             id="chrome-bar-tertiary"
             className="chrome-bar-tertiary-wrap"
             inert={showBreadcrumb ? undefined : ''}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,11 +6,10 @@
   --page:        #f1ead4;   /* off-white with warm tan undertone */
   --page-edge:   #e6dec3;
   --surface-raised: #e3d8ba; /* tan, slightly deeper than --page-edge, for chrome bars + modal panels */
-  /* One step deeper than --surface-raised, for the EXPANDED chrome
-     panels (top atmosphere row, bottom nav sheet) so they read as a
-     distinct layer. Mixing --ink in auto-adapts per theme: darker on
-     light (dark ink), lighter on dark (off-white ink). */
-  --surface-deep: color-mix(in srgb, var(--surface-raised) 91%, var(--ink) 9%);
+  /* A distinct layer for the EXPANDED chrome panels (top atmosphere
+     row, bottom nav sheet). Lighter than the bars on light (lifts
+     toward the page); the dark theme sets its own darker value. */
+  --surface-deep: #ede4c9;
   --ink:         #1d2419;   /* dark greenish-black */
   --ink-soft:    #364034;
   --ink-muted:   #6f6e58;   /* tan-olive */
@@ -87,6 +86,9 @@
   --page:        #1d2419;   /* dark greenish-black */
   --page-edge:   #161c12;
   --surface-raised: #13180f; /* darker green-black, slightly deeper than --page-edge, for chrome bars + modal panels */
+  /* Expanded chrome panels go darker than the bars on dark — sinking
+     below the raised surface toward black for depth. */
+  --surface-deep: #0c0f08;
   --ink:         #ece4cb;   /* warm off-white */
   --ink-soft:    #d2c9ac;
   --ink-muted:   #9a9377;


### PR DESCRIPTION
Follow-up refinements to the expanded-chrome depth work:

- **Depth direction + shades.** The auto `color-mix --surface-deep` read poorly and went the wrong way. Replaced with hand-picked per-theme values in the natural direction: on light the expanded panels lift **lighter** toward the page (`#ede4c9`); on dark they sink **darker** below the raised surface (`#0c0f08`). Framing the panel between the mid-tone bars and the luminance extreme also lifts text/hairline contrast versus the previous shades.
- **Breadcrumb folded into `--chrome-top-h`.** The scroll breadcrumb is a top-chrome element too but is absolutely positioned below the header (doesn't grow the header box), so its strip height is now added explicitly when shown, and the measurement re-runs on breadcrumb toggle. The nav sheet and window scrollbar both read `--chrome-top-h`, so the open menu now starts below the breadcrumb instead of overlapping it.
- **Breadcrumb depth color.** The breadcrumb strip gets `--surface-deep`, matching the atmosphere row and nav sheet, so all three expanded panels share one depth layer.

Verified in light and dark against the production build (menu top lands at the breadcrumb's bottom, breadcrumb takes the depth color, no console errors). Rebased onto the latest chrome changes on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu)_