### PR TITLE
Content-shaped skeleton for Mothing, drop research-grade state

### DIFF
--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -244,6 +244,110 @@
   height: 0.65rem;
 }
 
+/* Variant: mothing page skeleton. Mirrors the .mothing-stats row and the
+   per-session .mothing-grid of 1:1 cards so the snapshot lands without
+   reflowing the page. */
+.skeleton-mothing-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5) var(--space-6);
+  margin-bottom: var(--space-6);
+}
+
+.skeleton-mothing-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-mothing-stat-value {
+  height: 1.5rem;
+}
+
+.skeleton-mothing-stat-label {
+  width: 3.5rem;
+  height: 0.65rem;
+}
+
+.skeleton-mothing-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+}
+
+.skeleton-mothing-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.skeleton-mothing-headrow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.skeleton-mothing-num {
+  width: 4.5rem;
+  height: 0.7rem;
+}
+
+.skeleton-mothing-title {
+  height: 1.3em;
+}
+
+.skeleton-mothing-headstats {
+  width: 8rem;
+  height: 0.7rem;
+}
+
+.skeleton-mothing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: var(--space-5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.skeleton-mothing-cell {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-3);
+  overflow: hidden;
+  background: var(--page-edge);
+}
+
+.skeleton-mothing-thumb {
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  display: block;
+}
+
+.skeleton-mothing-meta {
+  padding: var(--space-3) var(--space-4) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-mothing-name {
+  height: 1.05em;
+}
+
+.skeleton-mothing-sci {
+  height: 0.85em;
+}
+
+.skeleton-mothing-sub {
+  width: 45%;
+  height: 0.7rem;
+}
+
 /* Variant: single-record / blog-post / work skeleton. Lives inside the
    page article so it gets the .record-page measure and gutters. */
 .skeleton-record {
@@ -318,16 +422,19 @@
 .skeleton-feed-item:nth-child(3n)       .skeleton,
 .skeleton-toc-entry:nth-child(3n)       .skeleton,
 .skeleton-grid-cell:nth-child(3n)       .skeleton,
+.skeleton-mothing-cell:nth-child(3n)    .skeleton,
 .skeleton-comments-item:nth-child(3n)   .skeleton { animation-delay: -0.5s; }
 
 .skeleton-feed-item:nth-child(3n + 1)     .skeleton,
 .skeleton-toc-entry:nth-child(3n + 1)     .skeleton,
 .skeleton-grid-cell:nth-child(3n + 1)     .skeleton,
+.skeleton-mothing-cell:nth-child(3n + 1)  .skeleton,
 .skeleton-comments-item:nth-child(3n + 1) .skeleton { animation-delay: -1.2s; }
 
 .skeleton-feed-item:nth-child(3n + 2)     .skeleton,
 .skeleton-toc-entry:nth-child(3n + 2)     .skeleton,
 .skeleton-grid-cell:nth-child(3n + 2)     .skeleton,
+.skeleton-mothing-cell:nth-child(3n + 2)  .skeleton,
 .skeleton-comments-item:nth-child(3n + 2) .skeleton { animation-delay: -1.9s; }
 
 /* -------------------------------------------------------------------- */

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -263,6 +263,64 @@ export function CreatingWorkSkeleton() {
 }
 
 /**
+ * Skeleton for the Mothing page. Mirrors the real layout so nothing
+ * reflows once the snapshot lands: a `.mothing-stats` row, then a couple
+ * of session blocks — each a `.mothing-session-head` above a
+ * `.mothing-grid` of 1:1 moth cards (thumb + name / sci / time meta).
+ */
+export function MothingSkeleton({ sessions = 2, cells = 4 }) {
+  return (
+    <SkeletonShell label="Loading moths">
+      <div className="skeleton-mothing-stats">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="skeleton-mothing-stat">
+            <Skeleton
+              className="skeleton-mothing-stat-value"
+              style={{ width: i === 3 ? '9rem' : `${2.5 + ((i * 5) % 3)}rem` }}
+            />
+            <Skeleton className="skeleton-mothing-stat-label" />
+          </div>
+        ))}
+      </div>
+      <div className="skeleton-mothing-sessions">
+        {Array.from({ length: sessions }, (_, s) => (
+          <section key={s} className="skeleton-mothing-session">
+            <div className="skeleton-mothing-head">
+              <div className="skeleton-mothing-headrow">
+                <Skeleton className="skeleton-mothing-num" />
+                <Skeleton
+                  className="skeleton-mothing-title"
+                  style={{ width: `${9 + ((s * 4) % 5)}rem` }}
+                />
+              </div>
+              <Skeleton className="skeleton-mothing-headstats" />
+            </div>
+            <ul className="skeleton-mothing-grid">
+              {Array.from({ length: cells }, (_, i) => (
+                <li key={i} className="skeleton-mothing-cell">
+                  <Skeleton className="skeleton-mothing-thumb" />
+                  <div className="skeleton-mothing-meta">
+                    <Skeleton
+                      className="skeleton-mothing-name"
+                      style={{ width: `${55 + ((i * 9) % 30)}%` }}
+                    />
+                    <Skeleton
+                      className="skeleton-mothing-sci"
+                      style={{ width: `${40 + ((i * 7) % 25)}%` }}
+                    />
+                    <Skeleton className="skeleton-mothing-sub" />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}
+
+/**
  * Skeleton for a comments tree. Mirrors the .comment layout (avatar +
  * byline + body) so the placeholder doesn't reflow once replies arrive.
  */

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import PageShell from '../components/PageShell.jsx';
+import { MothingSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchMothData, fetchMothSignature, photoUrl, buildSessions } from '../lib/inaturalist.js';
@@ -58,7 +59,6 @@ function MothCard({ obs }) {
           {showSci && <span className="mothing-sci">{sci}</span>}
           <span className="gutter mothing-sub">
             {obs.observedTime ? formatTime(obs.observedTime) : formatDate(obs.observedDate)}
-            {obs.qualityGrade === 'research' ? ' · Research grade' : ''}
           </span>
         </div>
       </a>
@@ -124,7 +124,6 @@ export default function Mothing() {
   const observations = items?.observations || [];
 
   const { sessions, orphans } = useMemo(() => buildSessions(observations), [observations]);
-  const grades = stats?.qualityGrades || {};
 
   return (
     <PageShell
@@ -138,7 +137,6 @@ export default function Mothing() {
           <StatBlock value={stats.sessionCount ?? sessions.length} label="sessions" />
           <StatBlock value={stats.observationCount} label="observations" />
           <StatBlock value={stats.speciesCount} label="species" />
-          <StatBlock value={grades.research} label="research grade" />
           {stats.earliestDate && (
             <div className="mothing-stat mothing-stat-range">
               <span className="mothing-stat-value mothing-stat-dates">
@@ -164,7 +162,7 @@ export default function Mothing() {
       )}
 
       {loading && observations.length === 0 ? (
-        <p className="placeholder-card">Loading moths&hellip;</p>
+        <MothingSkeleton sessions={2} cells={4} />
       ) : observations.length === 0 ? (
         <p className="feed-empty">No moth observations yet.</p>
       ) : (


### PR DESCRIPTION
Replaces the plain "Loading moths…" placeholder with a `MothingSkeleton` that mirrors the real layout — a stats row plus session blocks, each a session header above a grid of 1:1 moth cards — so the page doesn't reflow when the snapshot lands. The skeleton cards share the breathing stagger used by the other grid/feed skeletons and respect `prefers-reduced-motion`.

Also removes the "research grade" surface: the research-grade stat block and the per-card "· Research grade" annotation.

Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnaxipfGHVG9XW2n7zjeM)_