### PR TITLE
Animate menu collapse when bottom-bar home is tapped

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -386,6 +386,12 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
             to="/"
             className="chrome-nav chrome-home-btn"
             aria-label="Go home"
+            onClick={() => {
+              // Collapse the open menu on the way home so it animates
+              // out (via the dock's AnimatePresence exit) instead of
+              // being left open over the freshly-loaded home page.
+              if (dockOpen) toggleDock();
+            }}
           >
             <Home className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
           </Link>


### PR DESCRIPTION
The bottom-bar home button navigated home but left the dock menu open, spread over the freshly-loaded home page. It now closes the dock when it's open — going through the dock's open state runs the `AnimatePresence` exit, so the sheet collapses smoothly instead of lingering. Matches the in-menu Home link, which already closes on tap.

Verified both close paths animate identically (compass and home: height shrinks to 0 over ~300ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFFyd6ftKdNpSssUVmawQu)_