### PR TITLE
Slim nav menu, relocate tools to chrome, tidy now-playing

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { NavLink } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { Bug, ChevronLeft, User } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 import { useActionDock } from '../hooks/useActionDock.jsx';
-import DensityToggle from './DensityToggle.jsx';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
@@ -12,31 +11,21 @@ import './ActionDock.css';
 const ROUTES = [
   { to: '/', label: 'Home' },
   { to: '/about', label: 'About' },
-  { to: '/posting', label: 'Posting' },
-  { to: '/logging', label: 'Logging' },
-  { to: '/listening', label: 'Listening' },
   { to: '/blogging', label: 'Blogging' },
   { to: '/creating', label: 'Creating' },
   { to: '/curating', label: 'Curating' },
   { to: '/mothing', label: 'Mothing' },
   { to: '/resume', label: 'Resume' },
-  { to: '/sharing', label: 'Sharing' },
-  { to: '/exploring', label: 'Exploring' },
-  { to: '/admin', label: 'Admin' },
 ];
 
 export default function ActionDock() {
-  const { open, openDock, closeDock } = useActionDock();
   // Sheet-replace navigation: the dock has three interchangeable views.
-  // 'menu' is the root; the User icon pushes to 'account' and the Bug
-  // icon pushes to 'debug'. Each sub-view has a back chevron header.
-  const [view, setView] = useState('menu');
+  // 'menu' is the root; the tool buttons (now relocated into the bottom
+  // chrome bar) push to 'account' and 'debug'. Each sub-view has a back
+  // chevron header. `view`/`setView` live in the dock context so the bar
+  // can drive them.
+  const { open, view, setView, openDock, closeDock } = useActionDock();
   const reduce = useReducedMotion();
-
-  // Always start at the menu view when the dock reopens.
-  useEffect(() => {
-    if (!open) setView('menu');
-  }, [open]);
 
   // Esc pops the sub-view first; only closes the dock once we're back
   // at the root menu. The Modal's built-in Esc handler is disabled
@@ -143,33 +132,6 @@ export default function ActionDock() {
                     </NavLink>
                   ))}
                 </nav>
-              </div>
-
-              <hr className="dock-rule" />
-
-              <div className="dock-section">
-                <div className="dock-heading">Tools</div>
-                <div className="dock-display-row">
-                  <DensityToggle />
-                  <button
-                    type="button"
-                    className="dock-tool-icon"
-                    onClick={() => setView('debug')}
-                    aria-label="Open atmosphere debug"
-                    title="Atmosphere debug"
-                  >
-                    <Bug aria-hidden="true" strokeWidth={1.75} />
-                  </button>
-                  <button
-                    type="button"
-                    className="dock-tool-icon"
-                    onClick={() => setView('account')}
-                    aria-label="Open account"
-                    title="Account"
-                  >
-                    <User aria-hidden="true" strokeWidth={1.75} />
-                  </button>
-                </div>
               </div>
             </motion.div>
           )}

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -433,6 +433,25 @@
   display: none;
 }
 
+/* Left cluster of the bottom bar. Holds one of two interchangeable button
+   groups: the page controls (theme/filter/search/info) or — while the nav
+   dock is open — the dock's tools (density/debug/account). They cross-fade
+   in place via AnimatePresence (mode="wait"), so only one occupies the slot
+   at a time and the right-hand cluster (pinned past the flex spacer) never
+   shifts. */
+.chrome-bottom-left {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.chrome-bottom-cluster {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
 /* Push the right-hand action cluster (filter + menu) away from the
    search button on the left without forcing every layout to be a flex
    space-between (which would also stretch the buttons themselves). */
@@ -504,6 +523,9 @@
     gap: var(--space-2);
   }
   .chrome-bottom-row {
+    gap: var(--space-2);
+  }
+  .chrome-bottom-cluster {
     gap: var(--space-2);
   }
   /* `.main` tightens to `var(--space-4)` at this width — track it so the

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, MoonStar, Search, SunDim } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, MoonStar, Search, SunDim, User } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
@@ -10,6 +10,7 @@ import { useTheme } from '../hooks/useTheme.jsx';
 import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
+import DensityToggle from './DensityToggle.jsx';
 import SearchModal from './SearchModal.jsx';
 import InfoModal from './InfoModal.jsx';
 import './ChromeBar.css';
@@ -260,6 +261,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const [params] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
+  const { view, setView } = useActionDock();
   const [searchOpen, setSearchOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
   const reduce = useReducedMotion();
@@ -302,47 +304,98 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   return (
     <div className="chrome-bar chrome-bar-bottom" role="toolbar" aria-label="Global actions">
       <div className="chrome-bottom-row">
-        <button
-          type="button"
-          className="chrome-nav chrome-theme-toggle"
-          onClick={cycleTheme}
-          aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme (current: ${theme})`}
-          title={`Theme: ${theme} — tap to switch`}
-        >
-          <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-        </button>
-        {filterAvailable && (
-          <button
-            type="button"
-            className={`chrome-nav chrome-filter ${filterOpen || filterCustomized ? 'is-open' : ''}`}
-            onClick={toggleFilter}
-            aria-expanded={filterOpen}
-            aria-haspopup="dialog"
-            aria-label={filterOpen ? 'Close filters' : 'Open filters'}
-          >
-            <ListFilterPlus className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-          </button>
-        )}
-        <button
-          type="button"
-          className={`chrome-nav chrome-search-btn ${searchOpen || searchActive ? 'is-open' : ''}`}
-          onClick={() => setSearchOpen(true)}
-          aria-expanded={searchOpen}
-          aria-haspopup="dialog"
-          aria-label={searchActive ? `Search (current query: ${params.get('q')})` : 'Open search'}
-        >
-          <Search className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-        </button>
-        <button
-          type="button"
-          className={`chrome-nav chrome-info-btn ${infoOpen ? 'is-open' : ''}`}
-          onClick={() => setInfoOpen(true)}
-          aria-expanded={infoOpen}
-          aria-haspopup="dialog"
-          aria-label="About this site"
-        >
-          <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-        </button>
+        {/* Left cluster. While the nav dock is open, the page-level controls
+            (theme / filter / search / info) hand off to the dock's tools
+            (density / debug / account) — they animate in and temporarily
+            take the same spot, then swap back when the dock closes. The
+            debug/account tools drive the open sheet's sub-view. */}
+        <div className="chrome-bottom-left">
+          <AnimatePresence mode="wait" initial={false}>
+            {dockOpen ? (
+              <motion.div
+                key="tools"
+                className="chrome-bottom-cluster"
+                initial={reduce ? false : { opacity: 0, y: 5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, y: 5 }}
+                transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
+              >
+                <DensityToggle />
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-tool-debug ${view === 'debug' ? 'is-open' : ''}`}
+                  onClick={() => setView(view === 'debug' ? 'menu' : 'debug')}
+                  aria-pressed={view === 'debug'}
+                  aria-label="Atmosphere debug"
+                  title="Atmosphere debug"
+                >
+                  <Bug className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-tool-account ${view === 'account' ? 'is-open' : ''}`}
+                  onClick={() => setView(view === 'account' ? 'menu' : 'account')}
+                  aria-pressed={view === 'account'}
+                  aria-label="Account"
+                  title="Account"
+                >
+                  <User className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="default"
+                className="chrome-bottom-cluster"
+                initial={reduce ? false : { opacity: 0, y: 5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, y: 5 }}
+                transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
+              >
+                <button
+                  type="button"
+                  className="chrome-nav chrome-theme-toggle"
+                  onClick={cycleTheme}
+                  aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme (current: ${theme})`}
+                  title={`Theme: ${theme} — tap to switch`}
+                >
+                  <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+                {filterAvailable && (
+                  <button
+                    type="button"
+                    className={`chrome-nav chrome-filter ${filterOpen || filterCustomized ? 'is-open' : ''}`}
+                    onClick={toggleFilter}
+                    aria-expanded={filterOpen}
+                    aria-haspopup="dialog"
+                    aria-label={filterOpen ? 'Close filters' : 'Open filters'}
+                  >
+                    <ListFilterPlus className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-search-btn ${searchOpen || searchActive ? 'is-open' : ''}`}
+                  onClick={() => setSearchOpen(true)}
+                  aria-expanded={searchOpen}
+                  aria-haspopup="dialog"
+                  aria-label={searchActive ? `Search (current query: ${params.get('q')})` : 'Open search'}
+                >
+                  <Search className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-info-btn ${infoOpen ? 'is-open' : ''}`}
+                  onClick={() => setInfoOpen(true)}
+                  aria-expanded={infoOpen}
+                  aria-haspopup="dialog"
+                  aria-label="About this site"
+                >
+                  <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
         <div className="chrome-bottom-spacer" aria-hidden="true" />
         {isSubPage && (
           <button

--- a/src/components/NowPlaying.jsx
+++ b/src/components/NowPlaying.jsx
@@ -15,12 +15,12 @@ export default function NowPlaying() {
     );
   }
   const ago = play.playedAt ? relativeTime(play.playedAt) : '';
-  const tooltip = `${play.track}${play.artist ? ' · ' + play.artist : ''}${ago ? ' · ' + ago : ''}`;
+  const tooltip = `${play.track}${play.artist ? ' by ' + play.artist : ''}${ago ? ' · ' + ago : ''}`;
   const href = recordPathFromAtUri(play.atUri);
   const inner = (
     <>
       <strong>{play.track}</strong>
-      {play.artist ? ` · ${play.artist}` : ''}
+      {play.artist ? ` by ${play.artist}` : ''}
     </>
   );
   return (

--- a/src/components/SignInPanel.jsx
+++ b/src/components/SignInPanel.jsx
@@ -75,6 +75,12 @@ export default function SignInPanel({ onAction }) {
             <code className="signin-did" title={did || ''}>{shortDid(did)}</code>
           )}
         </div>
+        {isOwner && (
+          <Link to="/admin" className="dock-tool" onClick={onAction}>
+            <span className="dock-tool-label">Admin</span>
+            <span className="dock-tool-key">↗</span>
+          </Link>
+        )}
         <button type="button" className="dock-tool" onClick={handleSignOut}>
           <span className="dock-tool-label">Sign out</span>
           <span className="dock-tool-key">×</span>

--- a/src/hooks/useActionDock.jsx
+++ b/src/hooks/useActionDock.jsx
@@ -9,6 +9,11 @@ export function ActionDockProvider({ children }) {
     const stored = localStorage.getItem(STORAGE_KEY);
     return stored === '1';
   });
+  // The dock's active sub-view ('menu' | 'account' | 'debug'). It lives here,
+  // not inside <ActionDock>, so the bottom chrome bar's relocated tool
+  // buttons can drive it too — tapping Account/Debug down in the bar swaps
+  // the open sheet's view.
+  const [view, setView] = useState('menu');
 
   useEffect(() => {
     try {
@@ -16,11 +21,20 @@ export function ActionDockProvider({ children }) {
     } catch {}
   }, [open]);
 
+  // Always fall back to the root menu once the dock is closed, so it reopens
+  // at the top level rather than a stale sub-view.
+  useEffect(() => {
+    if (!open) setView('menu');
+  }, [open]);
+
   const openDock = useCallback(() => setOpen(true), []);
   const closeDock = useCallback(() => setOpen(false), []);
   const toggle = useCallback(() => setOpen((prev) => !prev), []);
 
-  const value = useMemo(() => ({ open, openDock, closeDock, toggle }), [open, openDock, closeDock, toggle]);
+  const value = useMemo(
+    () => ({ open, view, setView, openDock, closeDock, toggle }),
+    [open, view, openDock, closeDock, toggle],
+  );
   return <ActionDockContext.Provider value={value}>{children}</ActionDockContext.Provider>;
 }
 


### PR DESCRIPTION
Three navigation/chrome changes:

**Slim the nav menu** — the dock's Pages list is now Home / About / Blogging / Creating / Curating / Mothing / Resume. Sharing and Exploring are removed; Posting, Logging, and Listening are temporarily hidden. Routes stay registered in the app, so the pages remain directly reachable.

**Admin → account screen** — Admin moves out of the top-level nav into the account view, shown only when signed in as the site owner (surfacing the `isOwner` branch `SignInPanel` already computed but never rendered).

**Tools relocate into the bottom chrome** — when the nav dock is open, its tools (density / debug / account) animate into the bottom chrome's left cluster, temporarily replacing the theme/filter/search/info controls and swapping back on close. The dock's own Tools section is removed, so the sheet shows only Pages. The dock's active sub-view is lifted into the `ActionDock` context so the relocated bar buttons can drive it.

**Now-playing wording** — the top chrome's listening signal reads "listening to _Song_ by Artist" (was "Song · Artist").

Verified end-to-end with a headless browser: sheet shows only the trimmed Pages list, opening/closing the dock swaps the left cluster to/from the tools, and the bar's account/debug tools drive the sheet's sub-view. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnaxipfGHVG9XW2n7zjeM)_