### PR TITLE
Chrome/button polish and a minimal home refresh indicator

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -84,16 +84,21 @@
   border-color: var(--rule-soft);
 }
 
+/* The page list reads like ruled notebook paper: a hairline opens the
+   list and each entry sits on its own rule, with the page label riding
+   the line on the left and its path on the right like a ledger column. */
 .dock-routes {
   display: flex;
   flex-direction: column;
+  border-top: 1px solid var(--rule-soft);
 }
 
 .dock-route {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  padding: var(--space-1) 0;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--rule-soft);
   border-radius: var(--radius-2);
   text-decoration: none;
   color: var(--ink);

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -332,6 +332,15 @@
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
+/* The bottom bar's icon buttons carry a lighter chip fill so they read as
+   raised buttons instead of blending into the chrome: --page sits a step
+   up from the bar's own --surface-raised in both themes. Every visible
+   .chrome-nav lives in the bottom bar; the top atmosphere chevron is
+   .chrome-expand, which keeps its flush, transparent treatment. */
+.chrome-nav {
+  background: var(--page);
+}
+
 .chrome-expand {
   margin-right: calc(-1 * var(--space-2));
 }
@@ -346,10 +355,18 @@
   outline: none;
 }
 
+/* Over the chip fill, hover/active must stay an opaque lighten — a
+   see-through accent tint would let the darker bar show through and read
+   as the button getting *darker* on hover. Mix the accent into --page. */
+.chrome-nav:hover,
+.chrome-nav:focus-visible {
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
+}
+
 .chrome-nav.is-open {
   color: var(--accent);
   border-color: var(--accent-soft);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  background: color-mix(in srgb, var(--accent) 20%, var(--page));
 }
 
 /* The compass nav button is the menu trigger — promote it to a filled,
@@ -357,20 +374,22 @@
    bottom-bar controls. */
 .chrome-nav.chrome-nav-bottom {
   background: var(--accent);
-  border-color: var(--accent);
+  /* Contrasting hairline (matching every other bottom-bar button) instead
+     of a border the colour of the accent fill. */
+  border-color: var(--rule);
   color: var(--page);
 }
 
 .chrome-nav.chrome-nav-bottom:hover,
 .chrome-nav.chrome-nav-bottom:focus-visible {
   background: var(--accent-soft);
-  border-color: var(--accent-soft);
+  border-color: var(--rule);
   color: var(--page);
 }
 
 .chrome-nav.chrome-nav-bottom.is-open {
   background: var(--accent-soft);
-  border-color: var(--accent-soft);
+  border-color: var(--rule);
   color: var(--page);
 }
 

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -686,64 +686,38 @@ a.post-card-author-link:focus-visible {
   text-align: center;
 }
 
-/* "Checking for recent activity" notice — shown above the feed while a
-   live refresh confirms whether what's displayed (snapshot / cache, or
-   nothing yet on a cold load) is up to date. Just a small spinner +
-   message; no skeleton placeholder. Its mount/unmount is animated by
-   Motion in Home.jsx (height + opacity collapse), so the margin lives on
-   this inner element where the collapsing wrapper can absorb it. */
-.feed-checking {
-  margin-bottom: var(--space-5);
-}
-
-.feed-checking-msg {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
+/* Live-refresh indicator. Rather than a separate banner above the feed,
+   the most recent day's summary line reads "Fetching latest activity…"
+   while a refresh confirms the latest, then cross-fades to that day's
+   real stats (see DayActivityMeta in Home.jsx). On a cold load — before
+   any day group exists — the same copy stands alone in the feed region.
+   Both stay in the quiet meta voice so the signal takes minimal space. */
+.feed-activity-standalone {
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
   margin: 0;
 }
 
-.feed-checking-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  min-width: 0;
+.feed-activity-fetching {
+  color: var(--ink-muted);
+  animation: feed-activity-pulse 1.6s ease-in-out infinite;
 }
 
-.feed-checking-title {
-  font-family: var(--sans);
-  letter-spacing: 0.14em;
-  color: var(--ink-soft);
-  font-size: var(--text-xs);
+.feed-activity-standalone {
+  animation: feed-activity-pulse 1.6s ease-in-out infinite;
 }
 
-.feed-checking-sub {
-  color: var(--ink-faint);
-  font-size: var(--text-xs);
-}
-
-.feed-checking-spinner {
-  flex: 0 0 auto;
-  width: 0.85em;
-  height: 0.85em;
-  margin-top: 0.15em;
-  border: 1.5px solid var(--rule);
-  border-top-color: var(--accent);
-  border-radius: 50%;
-  animation: feed-checking-spin 0.8s linear infinite;
-}
-
-@keyframes feed-checking-spin {
-  to {
-    transform: rotate(360deg);
-  }
+@keyframes feed-activity-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .feed-checking-spinner {
+  .feed-activity-fetching,
+  .feed-activity-standalone {
     animation: none;
-    border-top-color: var(--accent);
-    opacity: 0.7;
   }
 }
 

--- a/src/components/SignInPanel.jsx
+++ b/src/components/SignInPanel.jsx
@@ -78,7 +78,7 @@ export default function SignInPanel({ onAction }) {
         {isOwner && (
           <Link to="/admin" className="dock-tool" onClick={onAction}>
             <span className="dock-tool-label">Admin</span>
-            <span className="dock-tool-key">↗</span>
+            <span className="dock-tool-key">&rsaquo;</span>
           </Link>
         )}
         <button type="button" className="dock-tool" onClick={handleSignOut}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -114,6 +114,41 @@ function dayStatsLine(items) {
   return parts.join(' · ');
 }
 
+/**
+ * The most recent day's summary line doubles as the live-refresh
+ * indicator. While a refresh is confirming the latest activity the line
+ * reads "Fetching latest activity…"; once the live result lands it
+ * cross-fades to that day's real engagement/stats. This keeps the signal
+ * to a single quiet line under the date instead of a separate banner.
+ */
+function DayActivityMeta({ checking, stats, reduce }) {
+  const fade = {
+    initial: reduce ? false : { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: reduce ? 0 : 0.28, ease: 'easeOut' },
+  };
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      {checking ? (
+        <motion.span
+          key="fetching"
+          className="feed-activity-fetching"
+          role="status"
+          aria-live="polite"
+          {...fade}
+        >
+          Fetching latest activity&hellip;
+        </motion.span>
+      ) : (
+        <motion.span key="stats" {...fade}>
+          {stats}
+        </motion.span>
+      )}
+    </AnimatePresence>
+  );
+}
+
 function collapseListens(items) {
   const out = [];
   let openBatch = null;
@@ -483,51 +518,33 @@ export default function Home() {
 
       <section className="home-latest">
         <FeedFilters counts={counts} estimatedVerbs={estimatedVerbs} />
-        {/* The notice + feed list share one flex child so the notice
-            isn't a direct child of `.home-latest` — otherwise the parent's
-            flex `gap` around it can't animate and snaps shut when the
-            notice unmounts. Inside here the notice's collapse is the only
-            thing that moves, and its spacing rides along in the wrapper. */}
+        {/* One flex child holds the whole feed body (or the cold-load
+            fetching line) so its spacing rides in the wrapper rather than
+            in the parent's animatable flex `gap`. */}
         <div className="home-feed-region">
-          <AnimatePresence initial={false}>
-            {checking && (
-              <motion.div
-                key="feed-checking"
-                initial={reduce ? false : { opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                exit={reduce ? { opacity: 0 } : { opacity: 0, height: 0 }}
-                transition={{ duration: reduce ? 0.15 : 0.32, ease: [0.22, 0.61, 0.36, 1] }}
-                style={{ overflow: 'hidden' }}
-              >
-                <div className="feed-checking">
-                  <p className="feed-checking-msg" role="status" aria-live="polite">
-                    <span className="feed-checking-spinner" aria-hidden="true" />
-                    <span className="feed-checking-copy">
-                      <span className="feed-checking-title small-caps">
-                        Checking for recent activity&hellip;
-                      </span>
-                      {!loading && filtered.length > 0 && (
-                        <span className="feed-checking-sub">
-                          Showing saved activity below — it may not be the latest yet.
-                        </span>
-                      )}
-                    </span>
-                  </p>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          {loading ? null : filtered.length === 0 ? (
-            checking ? null : (
-              <p className="feed-empty">No records match these filters.</p>
-            )
+          {loading || (checking && filtered.length === 0) ? (
+            <p className="feed-activity-standalone" role="status" aria-live="polite">
+              Fetching latest activity&hellip;
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="feed-empty">No records match these filters.</p>
           ) : (
             <ol className="feed-list reveal-stagger">
-            {groups.map((group) => (
+            {groups.map((group, gi) => (
               <li key={group.dateKey} className="feed-day-group">
                 <DayOfLifeHeader
                   date={group.date}
-                  meta={dayStatsLine(group.items)}
+                  meta={
+                    gi === 0 ? (
+                      <DayActivityMeta
+                        checking={checking}
+                        stats={dayStatsLine(group.items)}
+                        reduce={reduce}
+                      />
+                    ) : (
+                      dayStatsLine(group.items)
+                    )
+                  }
                 />
                 <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
                   <AnimatePresence initial={false}>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17,6 +17,19 @@
   stroke-width: 1.5;
 }
 
+/* iOS Safari zooms the viewport in whenever a focused text field's
+   font-size is under 16px. Hold every form control at 16px on phone
+   widths so tapping into an input never triggers that jarring zoom.
+   !important so it wins over the per-field type-scale sizes (e.g. the
+   sign-in field's --text-sm) without having to touch each one. */
+@media (max-width: 700px) {
+  input,
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
 .layout {
   flex: 1;
   display: flex;
@@ -221,14 +234,16 @@
 
 .home-hero-cta-primary {
   background: var(--accent);
-  border-color: var(--accent);
+  /* Keep the same contrasting hairline every other button carries, rather
+     than a border the colour of the fill (which reads as borderless). */
+  border-color: var(--rule);
   color: var(--page);
 }
 
 .home-hero-cta-primary:hover,
 .home-hero-cta-primary:focus-visible {
   background: var(--accent-soft);
-  border-color: var(--accent-soft);
+  border-color: var(--rule);
   color: var(--page);
 }
 


### PR DESCRIPTION
A batch of chrome, button, and home-feed refinements:

**Now-playing wording** — the top chrome's listening signal reads "listening to _Song_ by Artist" (was "Song · Artist").

**Bottom-bar icon buttons** get a lighter `--page` chip fill so they read as buttons against the chrome surface instead of blending in; hover/active stay an opaque lighten over that fill.

**Contrasting borders on primary CTAs** — "Browse Projects" and the chrome compass now carry the same `--rule` hairline every other button has, instead of a border the colour of their accent fill (which read as borderless).

**Ruled nav list** — the expanded Pages list emulates notebook paper: a hairline opens the list and each page entry sits on its own rule.

**Account Admin link** — drops the emoji arrow (it rendered with emoji presentation) for a plain text chevron.

**Mobile input zoom** — form controls are held at 16px on phone widths so focusing a text field never triggers iOS Safari's zoom-in.

**Home refresh indicator** — replaces the "Checking for recent activity" banner with a minimal inline signal: the most recent day's summary line reads "Fetching latest activity…" while a refresh is in flight, then cross-fades in place to that day's real engagement/stats. Cold loads show the same quiet copy standalone.

Verified in a headless browser (button fills/borders, ruled list, mobile input font-size, and both states of the home indicator). Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnaxipfGHVG9XW2n7zjeM)_