### PR TITLE
Hold Creating/Curating skeletons until cover images are ready

### DIFF
--- a/src/hooks/useImagesReady.js
+++ b/src/hooks/useImagesReady.js
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Preload a set of image URLs and report when they've all settled (loaded
+ * or errored), so a page can hold its skeleton until its cover images are
+ * actually ready to paint instead of swapping the skeleton for a grid of
+ * blank cells that pop in as they download.
+ *
+ * A timeout caps the wait so a single slow or broken image can't strand
+ * the skeleton indefinitely. Readiness is tied to the exact URL set: when
+ * the set changes the hook reports not-ready until the new set settles
+ * (so a stale "ready" from a previous set can't leak through for a frame).
+ *
+ * Pass a bounded slice (e.g. the first couple of rows) rather than every
+ * cover — that's enough for a clean first paint, and the rest keep
+ * lazy-loading in the grid as usual.
+ */
+export function useImagesReady(urls, { timeout = 6000 } = {}) {
+  const list = Array.isArray(urls) ? urls.filter(Boolean) : [];
+  const key = list.join('\n');
+  const [state, setState] = useState(() => ({ key, ready: list.length === 0 }));
+
+  useEffect(() => {
+    const items = key ? key.split('\n') : [];
+    if (items.length === 0) {
+      setState({ key, ready: true });
+      return undefined;
+    }
+    setState({ key, ready: false });
+
+    let cancelled = false;
+    let settled = 0;
+    const imgs = [];
+    const bump = () => {
+      settled += 1;
+      if (!cancelled && settled >= items.length) setState({ key, ready: true });
+    };
+    for (const url of items) {
+      const img = new Image();
+      let once = false;
+      const settle = () => {
+        if (once) return;
+        once = true;
+        bump();
+      };
+      img.onload = settle;
+      img.onerror = settle;
+      img.src = url;
+      // A cached image is already complete the instant src is set — onload
+      // won't fire again, so count it now.
+      if (img.complete) settle();
+      imgs.push(img);
+    }
+
+    const timer = setTimeout(() => {
+      if (!cancelled) setState({ key, ready: true });
+    }, timeout);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      for (const img of imgs) {
+        img.onload = null;
+        img.onerror = null;
+      }
+    };
+  }, [key, timeout]);
+
+  // Only treat as ready when the settled set matches the current urls.
+  return state.key === key && state.ready;
+}

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import CreatingFilters, { filterCreatingItems } from '../components/CreatingFilters.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
@@ -16,6 +17,11 @@ import '../components/FeedFilters.css';
 import './Creating.css';
 
 const STANDARD_DOC = 'site.standard.document';
+
+// How many leading covers to preload before revealing the grid — roughly
+// the first couple of rows, enough for a clean first paint. The rest keep
+// lazy-loading in the grid.
+const COVER_WAIT = 12;
 
 /**
  * Creative works now live as `site.standard.document` records in the
@@ -79,6 +85,21 @@ export default function Creating() {
     [safeWorks, params, kinds],
   );
 
+  // Hold the skeleton until the first rows' cover images are ready, so the
+  // grid doesn't swap in with blank cells that pop as they download. Once
+  // revealed we stay revealed — later filter/search changes just re-render
+  // the grid (their covers are already cached) rather than re-skeletoning.
+  const coverUrls = useMemo(
+    () => filtered.slice(0, COVER_WAIT).map((r) => coverThumb(r.value)?.url).filter(Boolean),
+    [filtered],
+  );
+  const coversReady = useImagesReady(coverUrls);
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    if (!loading && coversReady) setRevealed(true);
+  }, [loading, coversReady]);
+  const showSkeleton = loading || (filtered.length > 0 && !revealed);
+
   return (
     <PageShell
       title={title}
@@ -87,7 +108,7 @@ export default function Creating() {
       headTitle="Creating — Dame is&hellip;"
     >
       <CreatingFilters kinds={kinds} counts={counts} />
-      {loading ? (
+      {showSkeleton ? (
         <CreatingGridSkeleton cells={6} />
       ) : filtered.length === 0 ? (
         <p className="feed-empty">

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -1,7 +1,9 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
@@ -9,6 +11,10 @@ import { fetchChannelMeta, fetchChannelPage, normalizeBlock } from '../lib/arena
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Curating.css';
+
+// How many leading covers to preload before revealing the grid — roughly
+// the first couple of rows. The rest keep lazy-loading in the grid.
+const COVER_WAIT = 12;
 
 /**
  * Which galleries exist is an `is.dame.arena.channel` record per channel
@@ -73,6 +79,20 @@ export default function Curating() {
   const loading = status === 'loading';
   const list = galleries || [];
 
+  // Hold the skeleton until the first rows' gallery covers are ready, so
+  // the grid doesn't swap in with blank cells that pop as they download.
+  // Once revealed we stay revealed.
+  const coverUrls = useMemo(
+    () => list.slice(0, COVER_WAIT).map((g) => g.cover?.src).filter(Boolean),
+    [list],
+  );
+  const coversReady = useImagesReady(coverUrls);
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    if (!loading && coversReady) setRevealed(true);
+  }, [loading, coversReady]);
+  const showSkeleton = loading || (list.length > 0 && !revealed);
+
   return (
     <PageShell
       title={title}
@@ -80,7 +100,7 @@ export default function Curating() {
       atUri={`at://${ME_DID}/is.dame.page/curating`}
       headTitle="Curating — Dame is&hellip;"
     >
-      {loading ? (
+      {showSkeleton ? (
         <CreatingGridSkeleton cells={6} />
       ) : list.length === 0 ? (
         <p className="feed-empty">No galleries yet.</p>


### PR DESCRIPTION
The Creating (projects) and Curating grids used to swap in the moment their records loaded, so cover images popped into blank cells as they downloaded.

- New `useImagesReady` hook preloads a bounded set of cover URLs (via `new Image()`) and reports ready only once they've all settled (loaded or errored). Readiness is tied to the exact URL set so a stale "ready" can't leak through for a frame, and a 6s timeout caps the wait so a slow/broken cover can't strand the skeleton.
- Creating and Curating preload the first ~2 rows of covers and keep the skeleton up until those are ready. The reveal latches, so later filter/search changes re-render the grid instead of re-skeletoning.

Verified with a headless browser (delaying image responses): at 600ms the skeleton is still up while covers download, and by ~2.8s the grid has revealed. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnaxipfGHVG9XW2n7zjeM)_