### PR TITLE
Add owner edit mode with feed selection + admin listening manager

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ const OauthCallback = lazy(() => import('./pages/OauthCallback.jsx'));
 const Exploring = lazy(() => import('./pages/Exploring.jsx'));
 import ChromeBar from './components/ChromeBar.jsx';
 import ActionDock from './components/ActionDock.jsx';
+import EditModeBar from './components/EditModeBar.jsx';
 import Footer from './components/Footer.jsx';
 import WindowScrollbar from './components/WindowScrollbar.jsx';
 import RouteTransition from './components/RouteTransition.jsx';
@@ -36,6 +37,7 @@ import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
 import { FeedFilterProvider } from './hooks/useFeedFilter.jsx';
 import { AtprotoSessionProvider } from './hooks/useAtprotoSession.jsx';
 import { WaypointsModalProvider } from './hooks/useWaypointsModal.jsx';
+import { EditModeProvider } from './hooks/useEditMode.jsx';
 
 /**
  * Verbs whose record page is handled by a bespoke page component (not the
@@ -84,6 +86,7 @@ export default function App() {
       <FeedFilterProvider>
       <ActionDockProvider>
       <WaypointsModalProvider>
+      <EditModeProvider>
           <div className="app-shell">
             <ChromeBar />
             <main className="layout">
@@ -140,9 +143,11 @@ export default function App() {
             </main>
             <Footer />
             <ActionDock />
+            <EditModeBar />
             <WindowScrollbar />
             <Analytics />
           </div>
+      </EditModeProvider>
       </WaypointsModalProvider>
       </ActionDockProvider>
       </FeedFilterProvider>

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, MoonStar, Search, SunDim, User } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, MoonStar, Pencil, Search, SunDim, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { ME_DID } from '../config.js';
 import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
@@ -270,6 +273,12 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const { available: filterAvailable, open: filterOpen, toggleModal: toggleFilter } = useFeedFilter();
   const { theme, cycle: cycleTheme } = useTheme();
   const ThemeIcon = THEME_ICON[theme] || SunDim;
+  // The edit-mode toggle only exists for the site owner. It sits beside the
+  // Info button and flips the site into a selectable "edit mode" (see
+  // EditModeBar + useEditMode).
+  const { did } = useAtprotoSession();
+  const { active: editActive, toggle: toggleEdit, exit: exitEdit } = useEditMode();
+  const isOwner = did === ME_DID;
   // Trigger buttons highlight when the corresponding URL state is
   // populated — search has a `?q=`, filter has a custom verb set.
   const searchActive = !!params.get('q');
@@ -392,6 +401,29 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 >
                   <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
+                {isOwner && (
+                  <button
+                    type="button"
+                    className={`chrome-nav chrome-edit-btn ${editActive ? 'is-open' : ''}`}
+                    onClick={toggleEdit}
+                    aria-pressed={editActive}
+                    aria-label={editActive ? 'Exit edit mode' : 'Enter edit mode'}
+                    title={editActive ? 'Exit edit mode' : 'Edit mode'}
+                  >
+                    <Pencil className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  </button>
+                )}
+                {isOwner && editActive && (
+                  <button
+                    type="button"
+                    className="chrome-nav chrome-edit-exit"
+                    onClick={exitEdit}
+                    aria-label="Close edit mode without saving"
+                    title="Close edit mode"
+                  >
+                    <X className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  </button>
+                )}
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -1,0 +1,105 @@
+/* Floating owner edit-mode action bar. Rides just above the fixed bottom
+   chrome bar, mirroring its centered 65rem card so the two read as one
+   stacked control surface. */
+.edit-mode-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px));
+  z-index: 31;
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  pointer-events: none;
+}
+
+.edit-mode-bar-inner {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: 2.75rem;
+  padding: var(--space-2) var(--space-4);
+  background: var(--surface-raised);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.edit-mode-bar-status {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.edit-mode-bar-count {
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.edit-mode-bar-count strong {
+  color: var(--accent);
+}
+
+.edit-mode-bar-hint {
+  color: var(--ink-soft);
+  font-size: 0.85rem;
+}
+
+.edit-mode-bar-error {
+  color: var(--tan);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 16rem;
+}
+
+.edit-mode-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.edit-mode-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: var(--page);
+  color: var(--ink-soft);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.edit-mode-bar-btn:hover:not(:disabled),
+.edit-mode-bar-btn:focus-visible:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
+  outline: none;
+}
+
+.edit-mode-bar-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Delete is the destructive primary — tint it so it's unmistakable, but keep
+   it quiet until hovered so an accidental tap is less likely. */
+.edit-mode-bar-delete {
+  color: var(--tan);
+  border-color: color-mix(in srgb, var(--tan) 45%, var(--rule));
+}
+
+.edit-mode-bar-delete:hover:not(:disabled),
+.edit-mode-bar-delete:focus-visible:not(:disabled) {
+  color: var(--page);
+  background: var(--tan);
+  border-color: var(--tan);
+}

--- a/src/components/EditModeBar.jsx
+++ b/src/components/EditModeBar.jsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { PencilLine, Trash2, XCircle } from 'lucide-react';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { ME_DID } from '../config.js';
+import './EditModeBar.css';
+
+/**
+ * Parse an `at://<repo>/<collection>/<rkey>` URI into its parts. Returns
+ * null for anything that isn't a full three-segment record URI.
+ */
+function parseAtUri(uri) {
+  const m = String(uri || '').match(/^at:\/\/([^/]+)\/([^/]+)\/([^/?#]+)/);
+  if (!m) return null;
+  return { repo: m[1], collection: m[2], rkey: m[3] };
+}
+
+/**
+ * A selected feed item may stand in for several underlying records — a
+ * collapsed listening session carries its `plays`. Expand those so a bulk
+ * delete removes every play in the batch, not just the representative row.
+ * Only records living in the owner's own repo are eligible for deletion.
+ */
+function deleteTargetsForItem(item) {
+  const uris =
+    Array.isArray(item?.plays) && item.plays.length
+      ? item.plays.map((p) => p?.atUri).filter(Boolean)
+      : item?.atUri
+        ? [item.atUri]
+        : [];
+  return uris
+    .map(parseAtUri)
+    .filter((t) => t && t.repo === ME_DID);
+}
+
+/**
+ * Floating action bar for owner edit mode. It rides just above the bottom
+ * chrome bar whenever edit mode is on, showing what's selected and the bulk
+ * actions available:
+ *   - Delete   — removes every selected record (batches expand to their
+ *                underlying plays) from the PDS, then filters them out of the
+ *                feed optimistically via `markRemoved`.
+ *   - Edit     — with exactly one row selected, jumps into the admin record
+ *                editor for that record.
+ */
+export default function EditModeBar() {
+  const { active, selectedItems, selectedCount, clearSelection, markRemoved, exit } = useEditMode();
+  const { agent, did } = useAtprotoSession();
+  const navigate = useNavigate();
+  const reduce = useReducedMotion();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const isOwner = did === ME_DID;
+
+  async function handleDelete() {
+    if (!agent || !isOwner || selectedCount === 0) return;
+    const targets = selectedItems.flatMap(deleteTargetsForItem);
+    if (targets.length === 0) return;
+    const noun = targets.length === 1 ? 'record' : 'records';
+    if (!window.confirm(`Delete ${targets.length} ${noun}? This cannot be undone.`)) return;
+
+    setBusy(true);
+    setError(null);
+    const removed = [];
+    try {
+      for (const t of targets) {
+        // Sequential keeps the PDS write load gentle and lets a mid-batch
+        // failure surface without leaving the rest in limbo.
+        // eslint-disable-next-line no-await-in-loop
+        await agent.com.atproto.repo.deleteRecord({
+          repo: t.repo,
+          collection: t.collection,
+          rkey: t.rkey,
+        });
+        removed.push(`at://${t.repo}/${t.collection}/${t.rkey}`);
+      }
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      // Filter out whatever DID get deleted, even on a partial failure, and
+      // also drop the selected rows' representative URIs so collapsed
+      // batches vanish from the feed too.
+      if (removed.length) {
+        markRemoved(removed);
+        markRemoved(selectedItems.map((i) => i.atUri).filter(Boolean));
+      }
+      clearSelection();
+      setBusy(false);
+    }
+  }
+
+  function handleEditSingle() {
+    if (selectedCount !== 1) return;
+    const parts = parseAtUri(selectedItems[0]?.atUri);
+    if (!parts) return;
+    exit();
+    navigate(
+      `/admin?c=${encodeURIComponent(parts.collection)}&r=${encodeURIComponent(parts.rkey)}`,
+    );
+  }
+
+  return (
+    <AnimatePresence>
+      {active && (
+        <motion.div
+          className="edit-mode-bar"
+          role="toolbar"
+          aria-label="Edit mode actions"
+          initial={reduce ? false : { opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reduce ? { opacity: 0 } : { opacity: 0, y: 12 }}
+          transition={{ duration: reduce ? 0 : 0.22, ease: [0.22, 0.61, 0.36, 1] }}
+        >
+          <div className="edit-mode-bar-inner">
+            <div className="edit-mode-bar-status">
+              {selectedCount > 0 ? (
+                <span className="edit-mode-bar-count">
+                  <strong>{selectedCount}</strong> selected
+                </span>
+              ) : (
+                <span className="edit-mode-bar-hint">Tap items to select</span>
+              )}
+              {error && <span className="edit-mode-bar-error">{error}</span>}
+            </div>
+            <div className="edit-mode-bar-actions">
+              {selectedCount > 0 && (
+                <button
+                  type="button"
+                  className="edit-mode-bar-btn edit-mode-bar-clear"
+                  onClick={clearSelection}
+                  disabled={busy}
+                >
+                  <XCircle size={15} strokeWidth={1.75} aria-hidden="true" />
+                  <span>Clear</span>
+                </button>
+              )}
+              {selectedCount === 1 && (
+                <button
+                  type="button"
+                  className="edit-mode-bar-btn"
+                  onClick={handleEditSingle}
+                  disabled={busy}
+                >
+                  <PencilLine size={15} strokeWidth={1.75} aria-hidden="true" />
+                  <span>Edit</span>
+                </button>
+              )}
+              <button
+                type="button"
+                className="edit-mode-bar-btn edit-mode-bar-delete"
+                onClick={handleDelete}
+                disabled={busy || selectedCount === 0}
+              >
+                <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
+                <span>{busy ? 'Deleting…' : 'Delete'}</span>
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -25,6 +25,45 @@
   border-bottom: none;
 }
 
+/* Owner edit mode: rows read as tappable selection targets. A quiet ring
+   in the row's own gutter marks the hit area; selecting fills it and tints
+   the row so a multi-select reads at a glance. */
+.feed-item-selectable {
+  position: relative;
+  cursor: pointer;
+  padding-left: calc(var(--space-5) + 4px);
+  border-radius: 4px;
+  transition: background 120ms ease;
+}
+
+.feed-item-selectable:hover {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.feed-item-selectable.is-selected {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.feed-item-select-mark {
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--accent-soft);
+  border-radius: 4px;
+  background: var(--page);
+  color: var(--page);
+}
+
+.feed-item-select-mark.is-selected {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
 /* Visual break between consecutive day sections. The outer feed-list
    gap already separates groups; this adds more breathing room so the
    day-header reads as a fresh section rather than continuous flow. */

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { CornerDownRight } from 'lucide-react';
+import { Check, CornerDownRight } from 'lucide-react';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import StatusEntry from './StatusEntry.jsx';
 import PostCard, { postCardShowsStandaloneTime } from './PostCard.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
@@ -86,11 +87,29 @@ function hrefFor(item) {
  */
 export default function FeedItem({ item }) {
   const navigate = useNavigate();
+  const edit = useEditMode();
   const cfg = verbConfig(item.verb);
   if (!cfg) return null;
   const Component = cfg.renderer ? RENDERERS[cfg.renderer] : null;
   if (!Component) return null;
   const href = hrefFor(item);
+
+  // Owner edit mode: rows become selectable instead of navigable. A tap
+  // anywhere on the row (including on nested links, intercepted in the
+  // capture phase) toggles selection; the EditModeBar handles the bulk
+  // delete / edit actions on whatever is selected.
+  const selectable = edit.active && !!item.atUri;
+  const selected = selectable && edit.isSelected(item.atUri);
+
+  function handleSelectCapture(e) {
+    if (!selectable) return;
+    // Let a deliberate text selection through rather than hijacking it.
+    const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+    if (sel && sel.toString().length > 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    edit.toggleSelect(item);
+  }
 
   // Make the whole row tappable as a convenience — handy on mobile where the
   // verb badge / timestamp are small hit targets. We bail when the click
@@ -159,6 +178,8 @@ export default function FeedItem({ item }) {
     item._thread?.isFirst ? 'feed-item-thread-first' : '',
     item._thread?.isLast ? 'feed-item-thread-last' : '',
     threadContinuation ? 'feed-item-thread-continuation' : '',
+    selectable ? 'feed-item-selectable' : '',
+    selected ? 'is-selected' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -168,8 +189,19 @@ export default function FeedItem({ item }) {
       data-verb={item.verb}
       data-thread-position={item._thread?.position}
       data-thread-length={item._thread?.length}
-      onClick={href ? handleRowClick : undefined}
+      onClickCapture={selectable ? handleSelectCapture : undefined}
+      onClick={!selectable && href ? handleRowClick : undefined}
+      role={selectable ? 'button' : undefined}
+      aria-pressed={selectable ? selected : undefined}
     >
+      {selectable && (
+        <span
+          className={`feed-item-select-mark${selected ? ' is-selected' : ''}`}
+          aria-hidden="true"
+        >
+          {selected && <Check size={12} strokeWidth={2.5} />}
+        </span>
+      )}
       {(() => {
         const verbEl = href ? (
           <Link className={verbClassName} to={href}>

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -1,0 +1,123 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+const EditModeContext = createContext(null);
+
+/**
+ * Owner-only "edit mode" for the live site.
+ *
+ * When the signed-in owner flips edit mode on (via the pencil button in the
+ * bottom chrome bar), feed rows become selectable rather than navigable:
+ * tapping a row toggles its selection, and the floating EditModeBar exposes
+ * bulk actions (delete the selected records from the PDS, or jump a single
+ * selection into the admin record editor).
+ *
+ * State held here (so the chrome bar, the feed rows, and the action bar all
+ * share one source of truth):
+ *   - active            — is edit mode on?
+ *   - selected          — Map<atUri, item> of currently-selected feed items
+ *   - removedUris        — atUris deleted this session, so feeds can filter
+ *                          them out optimistically before the next live fetch
+ *
+ * Edit mode is intentionally NOT persisted — it always starts off on reload.
+ * Selection clears whenever edit mode turns off or the route changes (a
+ * selection made on the home feed is meaningless on another page).
+ */
+export function EditModeProvider({ children }) {
+  const [active, setActive] = useState(false);
+  const [selected, setSelected] = useState(() => new Map());
+  const [removedUris, setRemovedUris] = useState(() => new Set());
+  const location = useLocation();
+
+  const clearSelection = useCallback(() => {
+    setSelected((prev) => (prev.size === 0 ? prev : new Map()));
+  }, []);
+
+  const enter = useCallback(() => setActive(true), []);
+  const exit = useCallback(() => {
+    setActive(false);
+    clearSelection();
+  }, [clearSelection]);
+  const toggle = useCallback(() => {
+    setActive((prev) => {
+      if (prev) clearSelection();
+      return !prev;
+    });
+  }, [clearSelection]);
+
+  // A selection from one page shouldn't linger onto the next. Clearing on
+  // pathname change keeps the action bar's count honest as you navigate.
+  const firstPath = useRef(location.pathname);
+  useEffect(() => {
+    if (firstPath.current === location.pathname) return;
+    firstPath.current = location.pathname;
+    clearSelection();
+  }, [location.pathname, clearSelection]);
+
+  const toggleSelect = useCallback((item) => {
+    const uri = item?.atUri;
+    if (!uri) return;
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(uri)) next.delete(uri);
+      else next.set(uri, item);
+      return next;
+    });
+  }, []);
+
+  const isSelected = useCallback((uri) => selected.has(uri), [selected]);
+
+  const markRemoved = useCallback((uris) => {
+    const list = Array.isArray(uris) ? uris : [uris];
+    setRemovedUris((prev) => {
+      const next = new Set(prev);
+      for (const u of list) if (u) next.add(u);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      active,
+      enter,
+      exit,
+      toggle,
+      selected,
+      selectedItems: Array.from(selected.values()),
+      selectedCount: selected.size,
+      isSelected,
+      toggleSelect,
+      clearSelection,
+      removedUris,
+      markRemoved,
+    }),
+    [
+      active,
+      enter,
+      exit,
+      toggle,
+      selected,
+      isSelected,
+      toggleSelect,
+      clearSelection,
+      removedUris,
+      markRemoved,
+    ],
+  );
+
+  return <EditModeContext.Provider value={value}>{children}</EditModeContext.Provider>;
+}
+
+export function useEditMode() {
+  const ctx = useContext(EditModeContext);
+  if (!ctx) throw new Error('useEditMode must be used inside <EditModeProvider>');
+  return ctx;
+}

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -243,6 +243,52 @@
   color: var(--ink);
 }
 
+/* Multi-select record management (e.g. the listening manager): a sticky-feeling
+   action row above a list of checkbox rows. */
+.admin-multiselect-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: var(--space-2);
+}
+
+.admin-multiselect-count {
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  margin-left: auto;
+}
+
+.admin-multiselect-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-2);
+}
+
+.admin-multiselect-row.is-selected {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.admin-multiselect-check {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.admin-multiselect-check .admin-record-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-multiselect-edit {
+  flex-shrink: 0;
+}
+
 .admin-form {
   display: flex;
   flex-direction: column;

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -63,6 +63,9 @@ export default function Admin() {
   if (view === 'pages') {
     return <PagesOverview agent={agent} did={did} />;
   }
+  if (view === 'listening') {
+    return <ListeningManager agent={agent} did={did} />;
+  }
   if (view === 'legacy-blogs') {
     return <LegacyBlogMigration agent={agent} did={did} />;
   }
@@ -182,6 +185,16 @@ function CollectionPicker() {
           <p className="admin-collection-summary">
             See which pages serve their title &amp; intro from the PDS vs hardcoded
             defaults, and migrate or revert them.
+          </p>
+        </li>
+        <li className="admin-collection-row">
+          <Link to="/admin?view=listening" className="admin-collection-link">
+            <span className="admin-collection-label">Listening (multi-select)</span>
+            <code className="admin-collection-nsid">{COLLECTIONS.listen}</code>
+          </Link>
+          <p className="admin-collection-summary">
+            Browse your plays with checkboxes — multi-select to bulk-delete, or
+            open any single play in the record editor.
           </p>
         </li>
         <li className="admin-collection-row">
@@ -640,6 +653,189 @@ function LegacyBlogMigration({ agent, did }) {
           );
         })}
       </ul>
+    </PageShell>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Listening manager (multi-select bulk edit / delete)                  */
+/* ------------------------------------------------------------------ */
+
+/** Short human label for a play record value: "Track · Artist". */
+function playLabel(value) {
+  if (!value || typeof value !== 'object') return '';
+  const track = value.trackName || value.track || '';
+  const artist = Array.isArray(value.artists)
+    ? value.artists.map((a) => a?.artistName).filter(Boolean).join(', ')
+    : value.artist || '';
+  return [track, artist].filter(Boolean).join(' · ') || '(untitled play)';
+}
+
+function ListeningManager({ agent, did }) {
+  const collection = COLLECTIONS.listen;
+  const [records, setRecords] = useState([]);
+  const [cursor, setCursor] = useState(undefined);
+  const [done, setDone] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  // Set of selected rkeys.
+  const [selected, setSelected] = useState(() => new Set());
+  const [deleting, setDeleting] = useState(false);
+
+  const loadPage = useCallback(
+    async (after) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await agent.com.atproto.repo.listRecords({
+          repo: did,
+          collection,
+          limit: 100,
+          cursor: after || undefined,
+        });
+        const next = res?.data || res;
+        const batch = next?.records || [];
+        setRecords((prev) => (after ? [...prev, ...batch] : batch));
+        setCursor(next?.cursor);
+        if (!next?.cursor || batch.length === 0) setDone(true);
+      } catch (err) {
+        setError(err?.message || String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [agent, did, collection],
+  );
+
+  useEffect(() => {
+    setRecords([]);
+    setCursor(undefined);
+    setDone(false);
+    setSelected(new Set());
+    loadPage(undefined);
+  }, [loadPage]);
+
+  const toggle = useCallback((rkey) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(rkey)) next.delete(rkey);
+      else next.add(rkey);
+      return next;
+    });
+  }, []);
+
+  const allRkeys = useMemo(() => records.map((r) => rkeyFromUri(r.uri)), [records]);
+  const allSelected = allRkeys.length > 0 && allRkeys.every((k) => selected.has(k));
+
+  const toggleAll = useCallback(() => {
+    setSelected((prev) => {
+      if (allRkeys.length > 0 && allRkeys.every((k) => prev.has(k))) return new Set();
+      return new Set(allRkeys);
+    });
+  }, [allRkeys]);
+
+  async function bulkDelete() {
+    const rkeys = Array.from(selected);
+    if (rkeys.length === 0) return;
+    const noun = rkeys.length === 1 ? 'play' : 'plays';
+    if (!window.confirm(`Delete ${rkeys.length} ${noun}? This cannot be undone.`)) return;
+    setDeleting(true);
+    setError(null);
+    const deleted = new Set();
+    try {
+      for (const rkey of rkeys) {
+        // eslint-disable-next-line no-await-in-loop
+        await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey });
+        deleted.add(rkey);
+      }
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setRecords((prev) => prev.filter((r) => !deleted.has(rkeyFromUri(r.uri))));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const k of deleted) next.delete(k);
+        return next;
+      });
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <PageShell
+      title="Listening"
+      intro="Every play on your PDS. Select rows to bulk-delete, or open one in the record editor."
+      headTitle="Listening — Admin — Dame is…"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <code className="admin-collection-nsid">{collection}</code>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+
+      <div className="admin-multiselect-toolbar">
+        <label className="admin-checkbox">
+          <input
+            type="checkbox"
+            checked={allSelected}
+            onChange={toggleAll}
+            disabled={records.length === 0}
+          />
+          <span>{allSelected ? 'Deselect all' : 'Select all loaded'}</span>
+        </label>
+        <span className="admin-multiselect-count">
+          {selected.size > 0 ? `${selected.size} selected` : `${records.length} loaded`}
+        </span>
+        <button
+          type="button"
+          className="admin-gate-button admin-gate-button-tight admin-danger"
+          onClick={bulkDelete}
+          disabled={deleting || selected.size === 0}
+        >
+          {deleting ? 'Deleting…' : `Delete${selected.size ? ` (${selected.size})` : ''}`}
+        </button>
+      </div>
+
+      {records.length === 0 && !loading && !error && (
+        <p className="placeholder-card">No plays yet.</p>
+      )}
+
+      <ul className="admin-record-list">
+        {records.map((rec) => {
+          const rkey = rkeyFromUri(rec.uri);
+          const checked = selected.has(rkey);
+          return (
+            <li
+              key={rec.uri}
+              className={`admin-record-row admin-multiselect-row${checked ? ' is-selected' : ''}`}
+            >
+              <label className="admin-checkbox admin-multiselect-check">
+                <input type="checkbox" checked={checked} onChange={() => toggle(rkey)} />
+                <span className="admin-record-preview">{playLabel(rec.value)}</span>
+              </label>
+              <Link
+                to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(rkey)}`}
+                className="admin-link-subtle admin-multiselect-edit"
+              >
+                Edit →
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      {!done && records.length > 0 && (
+        <button
+          type="button"
+          className="admin-gate-button admin-gate-button-tight"
+          disabled={loading}
+          onClick={() => loadPage(cursor)}
+        >
+          {loading ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+      {loading && records.length === 0 && <p className="placeholder-card">Loading plays…</p>}
     </PageShell>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,6 +25,7 @@ import { resolvePds } from '../lib/atproto.js';
 import { buildUnifiedFeed } from '../lib/feedBuilder.js';
 import { groupSelfReplyThreads, threadAwareDateKey } from '../lib/threadGrouping.js';
 import { subscribeRefreshTick } from '../lib/refreshTick.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
@@ -467,7 +468,15 @@ export default function Home() {
     return { counts: out, estimatedVerbs: est };
   }, [liveCounts, snapshotCounts, liveVerbs]);
 
-  const filtered = useMemo(() => filterFeed(safeFeed, params, ME_DID), [safeFeed, params]);
+  // Records the owner deleted this session are dropped optimistically so
+  // the feed reflects the change immediately, ahead of the next live fetch
+  // (which won't return them anyway).
+  const { removedUris } = useEditMode();
+  const filtered = useMemo(() => {
+    const base = filterFeed(safeFeed, params, ME_DID);
+    if (!removedUris || removedUris.size === 0) return base;
+    return base.filter((item) => !removedUris.has(item.atUri));
+  }, [safeFeed, params, removedUris]);
   // "Load more" pagination — the user only sees the first `visibleCount`
   // filtered items at a time. Slicing here (before threading / day
   // grouping) means thread chains never get split mid-conversation: each

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -7,6 +7,7 @@ import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import { groupByDay } from '../lib/time.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
@@ -27,11 +28,13 @@ export default function Listening() {
     mapItems: toListeningItems,
   });
 
+  const { removedUris } = useEditMode();
   const loading = status === 'loading';
   const safeItems = items || [];
   const filtered = useMemo(
     () =>
       safeItems.filter((i) => {
+        if (removedUris.has(i.atUri)) return false;
         const p = i.payload || {};
         const hay = [
           p.trackName,
@@ -43,7 +46,7 @@ export default function Listening() {
           .join(' ');
         return matchesQuery(hay, q);
       }),
-    [safeItems, q],
+    [safeItems, q, removedUris],
   );
   const groups = groupByDay(filtered, (i) => i.createdAt);
 


### PR DESCRIPTION
Introduces an owner-only **edit mode** and a dedicated **listening manager** in the admin panel.

## Edit mode (bottom chrome bar)
- A pencil button appears beside the Info icon in the bottom chrome bar, visible only when signed in as the site owner (`did === ME_DID`).
- Activating it flips the site into edit mode; while active, an `X` appears next to the pencil to close edit mode without saving.
- State lives in a new `EditModeProvider` (`src/hooks/useEditMode.jsx`); it's in-memory only (always starts off on reload) and clears its selection on route change or exit.

## Home-feed selection + delete
- In edit mode, feed rows become selection targets — tapping toggles selection instead of navigating (inner-link clicks intercepted in the capture phase), with a check mark + tint on selected rows.
- A floating `EditModeBar` above the bottom bar exposes bulk actions:
  - **Delete** — removes every selected record from the PDS via `deleteRecord` (one-by-one or multi-select). Collapsed listening sessions expand to all underlying plays; a repo guard ensures only the owner's own records are targeted.
  - **Edit** (single selection) — jumps into the admin record editor for that record.
  - **Clear** — deselects.
- Deleted records are filtered from the Home and public Listening feeds optimistically, ahead of the next live fetch.

## Admin listening manager
- New view at `/admin?view=listening` (linked from the collection picker) with checkbox multi-select, select-all, bulk delete, and per-row edit links.

## Notes
- Inline in-place page-content editing (pencil → save) is scaffolded via the toggle/exit UX but not yet implemented as live editing — that's the larger future piece.
- `npm run build` passes; browser smoke test across `/`, `/listening`, `/admin`, `/admin?view=listening` showed no runtime errors and confirmed the edit button stays hidden when signed out. The full authenticated owner delete/select flow requires OAuth + live PDS network and should be confirmed on a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4D4A63MwouXcwWYLEnqEc)_