### PR TITLE
Attach edit action bar to bottom chrome; add per-song listen selection

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -19,7 +19,10 @@
    and shadow overlap the page cleanly. */
 .dock-sheet-wrap {
   position: fixed;
-  bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px));
+  /* Sits above the bottom bar AND above the owner edit-mode bar when it's
+     open (--edit-bar-h, else 0), so the sheet expands from on top of the
+     edit bar rather than overlapping it. */
+  bottom: calc(var(--chrome-h) + var(--edit-bar-h, 0px) + env(safe-area-inset-bottom, 0px));
   left: 0;
   right: 0;
   width: 100%;
@@ -50,7 +53,7 @@
      z 31 > 30, so it wins over the bar's own hidden top border). */
   border-bottom: 1px solid var(--rule);
   padding: var(--space-4);
-  height: calc(100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - env(safe-area-inset-bottom, 0px));
+  height: calc(100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   overscroll-behavior: contain;
 }

--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -1,7 +1,10 @@
-/* Floating owner edit-mode action bar. Rides just above the fixed bottom
-   chrome bar, mirroring its centered 65rem card so the two read as one
-   stacked control surface. */
-.edit-mode-bar {
+/* Owner edit-mode action bar. Like the nav dock, it's a sheet that expands
+   UPWARD out of the bottom chrome bar: the wrap is a fixed clip box pinned
+   directly on top of the bar and centered on the same 65rem card; Framer
+   animates its height 0 ↔ auto and `overflow: hidden` unfurls the surface
+   inside upward so it reads as an extension of the bar rather than a floating
+   panel. */
+.edit-mode-bar-wrap {
   position: fixed;
   left: 0;
   right: 0;
@@ -10,6 +13,7 @@
   width: 100%;
   max-width: 65rem;
   margin: 0 auto;
+  overflow: hidden;
   pointer-events: none;
 }
 
@@ -21,9 +25,20 @@
   gap: var(--space-3);
   min-height: 2.75rem;
   padding: var(--space-2) var(--space-4);
+  /* Match the bottom bar's own raised surface + hairlines so the expanded
+     strip looks continuous with the chrome it grows out of. */
   background: var(--surface-raised);
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
+}
+
+/* On wide screens the chrome bars float as a 65rem card with side hairlines;
+   close the strip's box to match. */
+@media (min-width: 65rem) {
+  .edit-mode-bar-inner {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
 }
 
 .edit-mode-bar-status {

--- a/src/components/EditModeBar.jsx
+++ b/src/components/EditModeBar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { PencilLine, Trash2, XCircle } from 'lucide-react';
@@ -52,8 +52,36 @@ export default function EditModeBar() {
   const reduce = useReducedMotion();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
+  const innerRef = useRef(null);
 
   const isOwner = did === ME_DID;
+
+  // Publish the bar's live height on <html> as `--edit-bar-h`. The nav dock
+  // reads it to lift its sheet so it expands from on top of this bar rather
+  // than straight off the bottom chrome. Measured from the inner surface
+  // (full height regardless of the wrap's height-clip animation); reset to 0
+  // whenever edit mode is off so the dock falls back to the bar.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!active) {
+      root.style.setProperty('--edit-bar-h', '0px');
+      return undefined;
+    }
+    const el = innerRef.current;
+    const apply = () => {
+      const h = el ? el.getBoundingClientRect().height : 0;
+      root.style.setProperty('--edit-bar-h', `${Math.max(0, Math.ceil(h))}px`);
+    };
+    apply();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(apply) : null;
+    if (ro && el) ro.observe(el);
+    window.addEventListener('resize', apply);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', apply);
+      root.style.setProperty('--edit-bar-h', '0px');
+    };
+  }, [active]);
 
   async function handleDelete() {
     if (!agent || !isOwner || selectedCount === 0) return;
@@ -103,18 +131,21 @@ export default function EditModeBar() {
   }
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {active && (
         <motion.div
-          className="edit-mode-bar"
-          role="toolbar"
-          aria-label="Edit mode actions"
-          initial={reduce ? false : { opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={reduce ? { opacity: 0 } : { opacity: 0, y: 12 }}
-          transition={{ duration: reduce ? 0 : 0.22, ease: [0.22, 0.61, 0.36, 1] }}
+          className="edit-mode-bar-wrap"
+          initial={{ height: 0 }}
+          animate={{ height: 'auto' }}
+          exit={{ height: 0 }}
+          transition={{ duration: reduce ? 0 : 0.34, ease: [0.32, 0.72, 0, 1] }}
         >
-          <div className="edit-mode-bar-inner">
+          <div
+            className="edit-mode-bar-inner"
+            ref={innerRef}
+            role="toolbar"
+            aria-label="Edit mode actions"
+          >
             <div className="edit-mode-bar-status">
               {selectedCount > 0 ? (
                 <span className="edit-mode-bar-count">

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -446,6 +446,64 @@ a.post-card-author-link:focus-visible {
   gap: var(--space-3);
 }
 
+/* Owner edit-mode selection for plays. The group header and each song row
+   read as tappable targets, each with a leading check box: filled when
+   selected, a dash on the group when only some of its songs are. */
+.listen-row-selectable .listen-row-head {
+  cursor: pointer;
+  align-items: center;
+}
+
+.listen-row-selectable.is-selected {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.listen-row-select-mark {
+  flex: 0 0 auto;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.95rem;
+  height: 0.95rem;
+  border: 1px solid var(--accent-soft);
+  border-radius: 4px;
+  background: var(--page);
+  color: var(--page);
+}
+
+.listen-row-select-mark.is-all {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.listen-row-select-dash {
+  width: 0.5rem;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
+.listen-row-child {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.listen-row-child > .listen-row-child-row {
+  flex: 1;
+  min-width: 0;
+}
+
+.listen-row-selectable .listen-row-child {
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.listen-row-child.is-selected {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 .listen-row-text {
   flex: 1;
   min-width: 0;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -98,7 +98,13 @@ export default function FeedItem({ item }) {
   // anywhere on the row (including on nested links, intercepted in the
   // capture phase) toggles selection; the EditModeBar handles the bulk
   // delete / edit actions on whatever is selected.
-  const selectable = edit.active && !!item.atUri;
+  //
+  // Listening rows are the exception: a batch stands in for many teal play
+  // records, so ListenRow owns its own per-song / whole-group selection and
+  // FeedItem steps aside (no row-level select, and the verb badge stops
+  // linking so nothing navigates out mid-selection).
+  const listeningEdit = edit.active && item.verb === 'listening';
+  const selectable = edit.active && !!item.atUri && !listeningEdit;
   const selected = selectable && edit.isSelected(item.atUri);
 
   function handleSelectCapture(e) {
@@ -190,7 +196,7 @@ export default function FeedItem({ item }) {
       data-thread-position={item._thread?.position}
       data-thread-length={item._thread?.length}
       onClickCapture={selectable ? handleSelectCapture : undefined}
-      onClick={!selectable && href ? handleRowClick : undefined}
+      onClick={!selectable && !listeningEdit && href ? handleRowClick : undefined}
       role={selectable ? 'button' : undefined}
       aria-pressed={selectable ? selected : undefined}
     >
@@ -203,7 +209,7 @@ export default function FeedItem({ item }) {
         </span>
       )}
       {(() => {
-        const verbEl = href ? (
+        const verbEl = href && !listeningEdit ? (
           <Link className={verbClassName} to={href}>
             {verbInner}
           </Link>

--- a/src/components/ListenRow.jsx
+++ b/src/components/ListenRow.jsx
@@ -1,28 +1,102 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Check } from 'lucide-react';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { formatTime } from '../lib/time.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+
+/** The individually-addressable teal play records behind a row: a collapsed
+ *  batch exposes them as `plays`; a lone row is its own single play. */
+function playItemsOf({ payload, atUri, plays, createdAt }) {
+  if (Array.isArray(plays) && plays.length) return plays;
+  if (atUri) return [{ verb: 'listening', atUri, payload, createdAt: createdAt || payload?.playedTime }];
+  return [];
+}
+
+/** A small check box shown beside a selectable play (or play group) in edit
+ *  mode: filled when fully selected, a dash when only some of a group is. */
+function SelectMark({ state }) {
+  return (
+    <span className={`listen-row-select-mark is-${state}`} aria-hidden="true">
+      {state === 'all' && <Check size={11} strokeWidth={2.5} />}
+      {state === 'some' && <span className="listen-row-select-dash" />}
+    </span>
+  );
+}
 
 /**
  * Single play row. The unified feed collapses runs of consecutive plays into
  * a single row with a `count` and a `plays` array of the underlying records —
  * see `collapseListens` in pages/Home.jsx. When `plays` is present and
  * `count > 1`, the row exposes an inline expand/collapse affordance.
+ *
+ * In owner edit mode the row becomes selectable: tapping the group selects
+ * every teal play record behind it at once (and reveals the song list), or
+ * you can expand and tap individual songs to select them one by one.
  */
-export default function ListenRow({ payload, atUri, count, plays }) {
+export default function ListenRow(props) {
+  const { payload, atUri, count, plays } = props;
+  const edit = useEditMode();
   const [expanded, setExpanded] = useState(false);
 
   const recordHref = recordPathFromAtUri(atUri);
   const canExpand = (count || 0) > 1 && Array.isArray(plays) && plays.length > 1;
 
+  const playItems = playItemsOf(props);
+  const isBatch = canExpand;
+  const selectable = edit.active && playItems.length > 0;
+  // A batch auto-reveals its songs in edit mode so each is tappable; a manual
+  // expand still works when not selecting.
+  const showChildren = isBatch && (expanded || (selectable && isBatch));
+
+  const selectedInGroup = selectable
+    ? playItems.filter((p) => p.atUri && edit.isSelected(p.atUri)).length
+    : 0;
+  const groupState =
+    selectedInGroup === 0 ? 'none' : selectedInGroup === playItems.length ? 'all' : 'some';
+
+  function toggleGroup(e) {
+    if (!selectable) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (isBatch) {
+      if (groupState === 'all') edit.deselectMany(playItems.map((p) => p.atUri).filter(Boolean));
+      else edit.selectMany(playItems);
+    } else {
+      edit.toggleSelect(playItems[0]);
+    }
+  }
+
+  function toggleOne(play, e) {
+    if (!selectable) return;
+    e.preventDefault();
+    e.stopPropagation();
+    edit.toggleSelect(play);
+  }
+
+  const articleClass = [
+    'listen-row',
+    'feed-card',
+    selectable ? 'listen-row-selectable' : '',
+    selectable && groupState === 'all' ? 'is-selected' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <article className="listen-row feed-card" data-at-uri={atUri}>
-      <div className="listen-row-head">
+    <article className={articleClass} data-at-uri={atUri}>
+      <div
+        className="listen-row-head"
+        onClickCapture={selectable ? toggleGroup : undefined}
+        role={selectable ? 'button' : undefined}
+        aria-pressed={selectable ? groupState !== 'none' : undefined}
+      >
+        {selectable && <SelectMark state={groupState} />}
         <span className="listen-row-text">
           <TrackLabel payload={payload} href={recordHref} plays={plays} />
         </span>
         {count > 1 && (
-          canExpand ? (
+          canExpand && !selectable ? (
             <button
               type="button"
               className="listen-row-toggle gutter"
@@ -41,13 +115,23 @@ export default function ListenRow({ payload, atUri, count, plays }) {
         )}
       </div>
 
-      {expanded && canExpand && (
+      {showChildren && (
         <ol className="listen-row-children">
-          {plays.map((play) => (
-            <li key={play.atUri || play.cid} className="listen-row-child">
-              <ChildPlay item={play} />
-            </li>
-          ))}
+          {plays.map((play) => {
+            const childSelected = selectable && play.atUri && edit.isSelected(play.atUri);
+            return (
+              <li
+                key={play.atUri || play.cid}
+                className={`listen-row-child${childSelected ? ' is-selected' : ''}`}
+                onClickCapture={selectable ? (e) => toggleOne(play, e) : undefined}
+                role={selectable ? 'button' : undefined}
+                aria-pressed={selectable ? !!childSelected : undefined}
+              >
+                {selectable && <SelectMark state={childSelected ? 'all' : 'none'} />}
+                <ChildPlay item={play} />
+              </li>
+            );
+          })}
         </ol>
       )}
     </article>

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -73,6 +73,26 @@ export function EditModeProvider({ children }) {
     });
   }, []);
 
+  // Add every item in a group to the selection (e.g. all the plays behind a
+  // collapsed listening batch), keyed by atUri.
+  const selectMany = useCallback((items) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      for (const it of items || []) {
+        if (it?.atUri) next.set(it.atUri, it);
+      }
+      return next;
+    });
+  }, []);
+
+  const deselectMany = useCallback((uris) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      for (const u of uris || []) next.delete(u);
+      return next;
+    });
+  }, []);
+
   const isSelected = useCallback((uri) => selected.has(uri), [selected]);
 
   const markRemoved = useCallback((uris) => {
@@ -95,6 +115,8 @@ export function EditModeProvider({ children }) {
       selectedCount: selected.size,
       isSelected,
       toggleSelect,
+      selectMany,
+      deselectMany,
       clearSelection,
       removedUris,
       markRemoved,
@@ -107,6 +129,8 @@ export function EditModeProvider({ children }) {
       selected,
       isSelected,
       toggleSelect,
+      selectMany,
+      deselectMany,
       clearSelection,
       removedUris,
       markRemoved,


### PR DESCRIPTION
Refines the owner edit mode shipped in #110.

## Edit action bar attaches to the bottom chrome
The action bar now uses the same mechanism as the nav dock: a fixed clip box pinned on top of the bottom bar that animates `height: 0 ↔ auto` with `overflow: hidden`, so it unfurls upward out of the chrome instead of sliding in as a floating panel. It matches the bar's raised surface + hairlines (with side borders on wide screens) so it reads as a continuous extension of the bottom chrome.

## Nav menu expands from on top of the edit bar
The edit bar publishes its live height as `--edit-bar-h`; the nav dock offsets its sheet by that amount (and subtracts it from the sheet height), so opening the menu while the edit bar is up expands it from the edit bar's top edge rather than overlapping it.

## Per-song / whole-group listen selection
`ListenRow` now owns its own edit-mode selection (FeedItem steps aside for listening rows so nothing navigates out mid-selection):
- Tapping a collapsed batch selects every teal play record behind it at once and reveals the song list.
- Tapping individual songs toggles them one by one.
- The group check box fills when the whole batch is selected and shows a partial dash when only some songs are; the action bar count and the delete target follow the individual play records.

## Verification
- `npm run build` passes; no runtime errors on `/`, `/listening`, `/admin`.
- Dock-lift geometry checked against real CSS (dock bottom `56px` → `100px` with a 44px edit bar).
- Screenshot-verified the listen selection flow: group-select fills all songs + header, single-select shows the header partial dash and the correct "N selected" count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4D4A63MwouXcwWYLEnqEc)_