### PR TITLE
Add a quick-edit sheet that expands from the bottom chrome

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ const Exploring = lazy(() => import('./pages/Exploring.jsx'));
 import ChromeBar from './components/ChromeBar.jsx';
 import ActionDock from './components/ActionDock.jsx';
 import EditModeBar from './components/EditModeBar.jsx';
+import EditSheet from './components/EditSheet.jsx';
 import Footer from './components/Footer.jsx';
 import WindowScrollbar from './components/WindowScrollbar.jsx';
 import RouteTransition from './components/RouteTransition.jsx';
@@ -144,6 +145,7 @@ export default function App() {
             <Footer />
             <ActionDock />
             <EditModeBar />
+            <EditSheet />
             <WindowScrollbar />
             <Analytics />
           </div>

--- a/src/components/EditModeBar.jsx
+++ b/src/components/EditModeBar.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
-import { PencilLine, Trash2, XCircle } from 'lucide-react';
+import { FileEdit, PencilLine, Trash2, XCircle } from 'lucide-react';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { useActionDock } from '../hooks/useActionDock.jsx';
 import { ME_DID } from '../config.js';
 import './EditModeBar.css';
 
@@ -46,15 +47,42 @@ function deleteTargetsForItem(item) {
  *                editor for that record.
  */
 export default function EditModeBar() {
-  const { active, selectedItems, selectedCount, clearSelection, markRemoved, exit } = useEditMode();
+  const {
+    active,
+    selectedItems,
+    selectedCount,
+    clearSelection,
+    markRemoved,
+    openEditSheet,
+    pageRecord,
+  } = useEditMode();
   const { agent, did } = useAtprotoSession();
-  const navigate = useNavigate();
+  const { closeDock } = useActionDock();
+  const location = useLocation();
   const reduce = useReducedMotion();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
   const innerRef = useRef(null);
 
   const isOwner = did === ME_DID;
+
+  // The single selected record, if exactly one is chosen and it lives in the
+  // owner's repo (only those are quick-editable here).
+  const selectedUri = selectedCount === 1 ? selectedItems[0]?.atUri : null;
+  const selectedEditable = selectedUri && parseAtUri(selectedUri)?.repo === ME_DID;
+  // The current page's own record — offered when nothing is selected so the
+  // owner can quick-edit "this page" (blog post, home page record, …). Guard
+  // on the stamped path so a stale value can't leak across a route change.
+  const pageUri =
+    pageRecord && pageRecord.path === location.pathname && parseAtUri(pageRecord.atUri)?.repo === ME_DID
+      ? pageRecord.atUri
+      : null;
+
+  function openSheet(atUri) {
+    if (!atUri) return;
+    closeDock();
+    openEditSheet(atUri);
+  }
 
   // Publish the bar's live height on <html> as `--edit-bar-h`. The nav dock
   // reads it to lift its sheet so it expands from on top of this bar rather
@@ -120,16 +148,6 @@ export default function EditModeBar() {
     }
   }
 
-  function handleEditSingle() {
-    if (selectedCount !== 1) return;
-    const parts = parseAtUri(selectedItems[0]?.atUri);
-    if (!parts) return;
-    exit();
-    navigate(
-      `/admin?c=${encodeURIComponent(parts.collection)}&r=${encodeURIComponent(parts.rkey)}`,
-    );
-  }
-
   return (
     <AnimatePresence initial={false}>
       {active && (
@@ -168,26 +186,40 @@ export default function EditModeBar() {
                   <span>Clear</span>
                 </button>
               )}
-              {selectedCount === 1 && (
+              {/* Quick-edit: the single selected record, or — with nothing
+                  selected — the current page's own record. */}
+              {selectedCount === 1 && selectedEditable && (
                 <button
                   type="button"
                   className="edit-mode-bar-btn"
-                  onClick={handleEditSingle}
+                  onClick={() => openSheet(selectedUri)}
                   disabled={busy}
                 >
                   <PencilLine size={15} strokeWidth={1.75} aria-hidden="true" />
                   <span>Edit</span>
                 </button>
               )}
-              <button
-                type="button"
-                className="edit-mode-bar-btn edit-mode-bar-delete"
-                onClick={handleDelete}
-                disabled={busy || selectedCount === 0}
-              >
-                <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
-                <span>{busy ? 'Deleting…' : 'Delete'}</span>
-              </button>
+              {selectedCount === 0 && pageUri && (
+                <button
+                  type="button"
+                  className="edit-mode-bar-btn"
+                  onClick={() => openSheet(pageUri)}
+                >
+                  <FileEdit size={15} strokeWidth={1.75} aria-hidden="true" />
+                  <span>Edit page</span>
+                </button>
+              )}
+              {selectedCount > 0 && (
+                <button
+                  type="button"
+                  className="edit-mode-bar-btn edit-mode-bar-delete"
+                  onClick={handleDelete}
+                  disabled={busy}
+                >
+                  <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
+                  <span>{busy ? 'Deleting…' : 'Delete'}</span>
+                </button>
+              )}
             </div>
           </div>
         </motion.div>

--- a/src/components/EditSheet.css
+++ b/src/components/EditSheet.css
@@ -1,0 +1,137 @@
+/* Quick-edit sheet. Built exactly like the nav dock (see ActionDock.css): a
+   fixed clip box pinned above the bottom chrome — and above the edit action
+   bar (--edit-bar-h) — animating height 0 ↔ auto so the panel unfurls upward.
+   Sits a layer above the dock/edit-bar (z 32) since it's the frontmost
+   interaction when open. */
+.edit-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+  background: color-mix(in srgb, var(--ink) 22%, transparent);
+}
+
+.edit-sheet-wrap {
+  position: fixed;
+  bottom: calc(var(--chrome-h) + var(--edit-bar-h, 0px) + env(safe-area-inset-bottom, 0px));
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  z-index: 32;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.edit-sheet-panel {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-deep);
+  border-bottom: 1px solid var(--rule);
+  /* Cap the sheet to the space between the top chrome and the bars/edit bar,
+     then let the record editor scroll within it. Short records stay short. */
+  max-height: calc(
+    100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) -
+      env(safe-area-inset-bottom, 0px) - var(--space-4)
+  );
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+@media (min-width: 65rem) {
+  .edit-sheet-panel {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
+}
+
+/* Sticky header so the record label + close stay put while the editor body
+   scrolls under them. */
+.edit-sheet-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-deep);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.edit-sheet-titles {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.edit-sheet-title {
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.16em;
+  font-size: var(--text-sm);
+  color: var(--ink);
+}
+
+.edit-sheet-rkey {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edit-sheet-close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: var(--page);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.edit-sheet-close:hover,
+.edit-sheet-close:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
+  outline: none;
+}
+
+.edit-sheet-body {
+  padding: var(--space-4);
+}
+
+.edit-sheet-foot {
+  position: sticky;
+  bottom: 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-deep);
+  border-top: 1px solid var(--rule-soft);
+}
+
+.edit-sheet-admin-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.edit-sheet-admin-link:hover,
+.edit-sheet-admin-link:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}

--- a/src/components/EditSheet.jsx
+++ b/src/components/EditSheet.jsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { ExternalLink, X } from 'lucide-react';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { useActionDock } from '../hooks/useActionDock.jsx';
+import RecordEditor from './RecordEditor.jsx';
+import { lexiconFor } from '../lib/lexicons.js';
+import { ME_DID } from '../config.js';
+import './EditSheet.css';
+
+function parseAtUri(uri) {
+  const m = String(uri || '').match(/^at:\/\/([^/]+)\/([^/]+)\/([^/?#]+)/);
+  if (!m) return null;
+  return { repo: m[1], collection: m[2], rkey: m[3] };
+}
+
+/**
+ * Quick-edit sheet for owner edit mode. Like the nav dock, it expands UPWARD
+ * out of the bottom chrome (from on top of the edit action bar) and lets the
+ * owner edit the contents / metadata of a record inline — either the actively
+ * selected record or the current page's own record — without leaving the page.
+ * A footer link hands off to the full editor in the admin panel.
+ */
+export default function EditSheet() {
+  const { editSheet, closeEditSheet, markRemoved, clearSelection, exit } = useEditMode();
+  const { agent, did } = useAtprotoSession();
+  const { open: dockOpen } = useActionDock();
+  const reduce = useReducedMotion();
+
+  // The nav dock and this sheet share the same slot above the chrome; if the
+  // menu opens, fold the sheet away so they never stack.
+  useEffect(() => {
+    if (dockOpen && editSheet) closeEditSheet();
+  }, [dockOpen, editSheet, closeEditSheet]);
+
+  // Esc closes the sheet.
+  useEffect(() => {
+    if (!editSheet) return undefined;
+    function onKey(e) {
+      if (e.key === 'Escape') closeEditSheet();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [editSheet, closeEditSheet]);
+
+  if (typeof document === 'undefined') return null;
+
+  const parts = editSheet ? parseAtUri(editSheet.atUri) : null;
+  // Only the owner's own records are quick-editable here.
+  const editable = parts && parts.repo === ME_DID && agent && did === ME_DID;
+  const lex = parts ? lexiconFor(parts.collection) : null;
+  const adminHref =
+    parts && `/admin?c=${encodeURIComponent(parts.collection)}&r=${encodeURIComponent(parts.rkey)}`;
+
+  return createPortal(
+    <>
+      <AnimatePresence>
+        {editSheet && (
+          <motion.div
+            key="edit-sheet-backdrop"
+            className="edit-sheet-backdrop"
+            onClick={closeEditSheet}
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.2 }}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence initial={false}>
+        {editSheet && (
+          <motion.div
+            key="edit-sheet"
+            className="edit-sheet-wrap"
+            initial={{ height: 0 }}
+            animate={{ height: 'auto' }}
+            exit={{ height: 0 }}
+            transition={{ duration: reduce ? 0 : 0.34, ease: [0.32, 0.72, 0, 1] }}
+          >
+            <div className="edit-sheet-panel" role="dialog" aria-label="Quick edit record">
+              <div className="edit-sheet-head">
+                <div className="edit-sheet-titles">
+                  <span className="edit-sheet-title">{lex?.label || 'Record'}</span>
+                  {parts && <code className="edit-sheet-rkey">{parts.rkey}</code>}
+                </div>
+                <button
+                  type="button"
+                  className="edit-sheet-close"
+                  onClick={closeEditSheet}
+                  aria-label="Close quick edit"
+                >
+                  <X size={16} strokeWidth={1.75} aria-hidden="true" />
+                </button>
+              </div>
+
+              <div className="edit-sheet-body">
+                {editable ? (
+                  <RecordEditor
+                    key={editSheet.atUri}
+                    agent={agent}
+                    did={did}
+                    collection={parts.collection}
+                    rkey={parts.rkey}
+                    compact
+                    onDeleted={() => {
+                      markRemoved(editSheet.atUri);
+                      clearSelection();
+                      closeEditSheet();
+                    }}
+                  />
+                ) : (
+                  <p className="placeholder-card">
+                    {agent
+                      ? 'This record lives in another repo and can’t be edited here.'
+                      : 'Sign in as the owner to edit this record.'}
+                  </p>
+                )}
+              </div>
+
+              {adminHref && (
+                <div className="edit-sheet-foot">
+                  <Link
+                    to={adminHref}
+                    className="edit-sheet-admin-link"
+                    onClick={() => {
+                      // Leaving for the full editor ends edit mode so we don't
+                      // land on the admin page still in a selection state.
+                      // (The Link handles the navigation itself.)
+                      exit();
+                    }}
+                  >
+                    Open in full editor
+                    <ExternalLink size={13} strokeWidth={1.75} aria-hidden="true" />
+                  </Link>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>,
+    document.body,
+  );
+}

--- a/src/components/PageShell.jsx
+++ b/src/components/PageShell.jsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react';
 import AtUriHead from './AtUriHead.jsx';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 
 /**
  * Shared page container — optional title + intro (each only renders when
  * provided), plus the AT URI <head> hints for the route's backing record.
  */
 export default function PageShell({ title, intro, atUri, cid, children, headTitle, eyebrow }) {
+  // Publish the route's backing record to edit mode so the owner's quick-edit
+  // sheet can target "this page" (a blog post, the home page record, etc.).
+  const { registerPageRecord } = useEditMode();
+  useEffect(() => {
+    registerPageRecord(atUri ? { atUri, cid } : null);
+  }, [atUri, cid, registerPageRecord]);
+
   return (
     <article className="page">
       <AtUriHead atUri={atUri} cid={cid} title={headTitle} />

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -35,23 +35,47 @@ export function EditModeProvider({ children }) {
   const [active, setActive] = useState(false);
   const [selected, setSelected] = useState(() => new Map());
   const [removedUris, setRemovedUris] = useState(() => new Set());
+  // The record backing the current page (from PageShell's `atUri`), tagged
+  // with the path it was registered on so a stale value from a mid-transition
+  // page never leaks onto the next route. Used by the quick-edit sheet.
+  const [pageRecord, setPageRecord] = useState(null);
+  // The record currently open in the quick-edit sheet: { atUri } or null.
+  const [editSheet, setEditSheet] = useState(null);
   const location = useLocation();
 
   const clearSelection = useCallback(() => {
     setSelected((prev) => (prev.size === 0 ? prev : new Map()));
   }, []);
 
+  const closeEditSheet = useCallback(() => setEditSheet(null), []);
+  const openEditSheet = useCallback((atUri) => {
+    if (atUri) setEditSheet({ atUri });
+  }, []);
+
   const enter = useCallback(() => setActive(true), []);
   const exit = useCallback(() => {
     setActive(false);
     clearSelection();
+    setEditSheet(null);
   }, [clearSelection]);
   const toggle = useCallback(() => {
     setActive((prev) => {
-      if (prev) clearSelection();
+      if (prev) {
+        clearSelection();
+        setEditSheet(null);
+      }
       return !prev;
     });
   }, [clearSelection]);
+
+  // PageShell calls this with its backing record (or null). We stamp the
+  // current pathname so consumers can confirm the record actually belongs to
+  // the route they're on.
+  const pathRef = useRef(location.pathname);
+  pathRef.current = location.pathname;
+  const registerPageRecord = useCallback((rec) => {
+    setPageRecord(rec && rec.atUri ? { ...rec, path: pathRef.current } : null);
+  }, []);
 
   // A selection from one page shouldn't linger onto the next. Clearing on
   // pathname change keeps the action bar's count honest as you navigate.
@@ -60,6 +84,9 @@ export function EditModeProvider({ children }) {
     if (firstPath.current === location.pathname) return;
     firstPath.current = location.pathname;
     clearSelection();
+    // A quick-edit sheet is tied to the record it opened for; close it when
+    // the route changes so it never hangs over an unrelated page.
+    setEditSheet(null);
   }, [location.pathname, clearSelection]);
 
   const toggleSelect = useCallback((item) => {
@@ -120,6 +147,11 @@ export function EditModeProvider({ children }) {
       clearSelection,
       removedUris,
       markRemoved,
+      pageRecord,
+      registerPageRecord,
+      editSheet,
+      openEditSheet,
+      closeEditSheet,
     }),
     [
       active,
@@ -134,6 +166,11 @@ export function EditModeProvider({ children }) {
       clearSelection,
       removedUris,
       markRemoved,
+      pageRecord,
+      registerPageRecord,
+      editSheet,
+      openEditSheet,
+      closeEditSheet,
     ],
   );
 


### PR DESCRIPTION
Adds an expandable quick-edit sheet to owner edit mode (builds on #110, #111).

## What it does
Like the nav dock and the edit action bar, the sheet unfurls upward out of the bottom chrome — a fixed clip box animating `height: 0 ↔ auto`, stacked on top of the edit action bar (offset by `--edit-bar-h`), with a dimmed backdrop that closes it on outside tap or Esc. It lets the owner edit a record's contents / metadata inline without leaving the page.

It targets one of two records:
- **The current page's record** — `PageShell` now registers its backing `atUri` into edit mode (stamped with the route path so a stale value can't leak across a transition). With nothing selected, the action bar shows an **"Edit page"** button.
- **The actively selected record** — with one row selected, the action bar's **"Edit"** opens the sheet for it rather than jumping straight to admin.

Inside the sheet: the compact `RecordEditor` (the same editor used by admin/debug) for inline editing with save/delete, a sticky header (lexicon label + rkey + close), and a sticky footer **"Open in full editor ↗"** linking to `/admin?c=<nsid>&r=<rkey>`.

## Verification
- `npm run build` passes; no runtime errors on `/`, `/listening`, `/admin`.
- Screenshot-verified: the "Edit page" trigger appears; the sheet opens attached above the edit bar (wrap bottom = `56 + 53px` = chrome + edit-bar height); title/rkey resolve from the lexicon (`Page content` / `home`); admin link correct (`/admin?c=is.dame.page&r=home`).
- The editor body requires an owner session (shows a sign-in placeholder when signed out); the owner-authenticated save path needs OAuth + live PDS and should be confirmed on the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4D4A63MwouXcwWYLEnqEc)_