### PR TITLE
Fix quick-edit sheet sizing; drive save/delete from the action bar

### DIFF
--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -105,6 +105,21 @@
   cursor: default;
 }
 
+/* Save is the primary commit action while quick-editing — fill it with the
+   accent so it reads as the main affordance among the bar's controls. */
+.edit-mode-bar-save {
+  color: var(--page);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.edit-mode-bar-save:hover:not(:disabled),
+.edit-mode-bar-save:focus-visible:not(:disabled) {
+  color: var(--page);
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+}
+
 /* Delete is the destructive primary — tint it so it's unmistakable, but keep
    it quiet until hovered so an accidental tap is less likely. */
 .edit-mode-bar-delete {

--- a/src/components/EditModeBar.jsx
+++ b/src/components/EditModeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
-import { FileEdit, PencilLine, Trash2, XCircle } from 'lucide-react';
+import { FileEdit, PencilLine, Save, Trash2, X, XCircle } from 'lucide-react';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { useActionDock } from '../hooks/useActionDock.jsx';
@@ -55,6 +55,9 @@ export default function EditModeBar() {
     markRemoved,
     openEditSheet,
     pageRecord,
+    editSheet,
+    sheetEditor,
+    closeEditSheet,
   } = useEditMode();
   const { agent, did } = useAtprotoSession();
   const { closeDock } = useActionDock();
@@ -83,6 +86,13 @@ export default function EditModeBar() {
     closeDock();
     openEditSheet(atUri);
   }
+
+  // While the quick-edit sheet is open, the bar hosts its Save / Delete
+  // controls (the sheet's own editor buttons are hidden) so editing the
+  // record's fields or JSON is committed straight from the action bar. The
+  // Save/Delete controls appear once the editor controller is published.
+  const editing = !!editSheet;
+  const busyEditor = sheetEditor?.saving || sheetEditor?.deleting;
 
   // Publish the bar's live height on <html> as `--edit-bar-h`. The nav dock
   // reads it to lift its sheet so it expands from on top of this bar rather
@@ -165,7 +175,9 @@ export default function EditModeBar() {
             aria-label="Edit mode actions"
           >
             <div className="edit-mode-bar-status">
-              {selectedCount > 0 ? (
+              {editing ? (
+                <span className="edit-mode-bar-count">Editing record</span>
+              ) : selectedCount > 0 ? (
                 <span className="edit-mode-bar-count">
                   <strong>{selectedCount}</strong> selected
                 </span>
@@ -175,50 +187,88 @@ export default function EditModeBar() {
               {error && <span className="edit-mode-bar-error">{error}</span>}
             </div>
             <div className="edit-mode-bar-actions">
-              {selectedCount > 0 && (
-                <button
-                  type="button"
-                  className="edit-mode-bar-btn edit-mode-bar-clear"
-                  onClick={clearSelection}
-                  disabled={busy}
-                >
-                  <XCircle size={15} strokeWidth={1.75} aria-hidden="true" />
-                  <span>Clear</span>
-                </button>
-              )}
-              {/* Quick-edit: the single selected record, or — with nothing
-                  selected — the current page's own record. */}
-              {selectedCount === 1 && selectedEditable && (
-                <button
-                  type="button"
-                  className="edit-mode-bar-btn"
-                  onClick={() => openSheet(selectedUri)}
-                  disabled={busy}
-                >
-                  <PencilLine size={15} strokeWidth={1.75} aria-hidden="true" />
-                  <span>Edit</span>
-                </button>
-              )}
-              {selectedCount === 0 && pageUri && (
-                <button
-                  type="button"
-                  className="edit-mode-bar-btn"
-                  onClick={() => openSheet(pageUri)}
-                >
-                  <FileEdit size={15} strokeWidth={1.75} aria-hidden="true" />
-                  <span>Edit page</span>
-                </button>
-              )}
-              {selectedCount > 0 && (
-                <button
-                  type="button"
-                  className="edit-mode-bar-btn edit-mode-bar-delete"
-                  onClick={handleDelete}
-                  disabled={busy}
-                >
-                  <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
-                  <span>{busy ? 'Deleting…' : 'Delete'}</span>
-                </button>
+              {editing ? (
+                <>
+                  <button
+                    type="button"
+                    className="edit-mode-bar-btn edit-mode-bar-clear"
+                    onClick={closeEditSheet}
+                    disabled={busyEditor}
+                  >
+                    <X size={15} strokeWidth={1.75} aria-hidden="true" />
+                    <span>Close</span>
+                  </button>
+                  {sheetEditor?.canDelete && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn edit-mode-bar-delete"
+                      onClick={() => sheetEditor.remove()}
+                      disabled={busyEditor || sheetEditor.loading}
+                    >
+                      <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>{sheetEditor.deleting ? 'Deleting…' : 'Delete'}</span>
+                    </button>
+                  )}
+                  {sheetEditor && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn edit-mode-bar-save"
+                      onClick={() => sheetEditor.save()}
+                      disabled={busyEditor || sheetEditor.loading}
+                    >
+                      <Save size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>{sheetEditor.saving ? 'Saving…' : 'Save'}</span>
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  {selectedCount > 0 && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn edit-mode-bar-clear"
+                      onClick={clearSelection}
+                      disabled={busy}
+                    >
+                      <XCircle size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>Clear</span>
+                    </button>
+                  )}
+                  {/* Quick-edit: the single selected record, or — with nothing
+                      selected — the current page's own record. */}
+                  {selectedCount === 1 && selectedEditable && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn"
+                      onClick={() => openSheet(selectedUri)}
+                      disabled={busy}
+                    >
+                      <PencilLine size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>Edit</span>
+                    </button>
+                  )}
+                  {selectedCount === 0 && pageUri && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn"
+                      onClick={() => openSheet(pageUri)}
+                    >
+                      <FileEdit size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>Edit page</span>
+                    </button>
+                  )}
+                  {selectedCount > 0 && (
+                    <button
+                      type="button"
+                      className="edit-mode-bar-btn edit-mode-bar-delete"
+                      onClick={handleDelete}
+                      disabled={busy}
+                    >
+                      <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
+                      <span>{busy ? 'Deleting…' : 'Delete'}</span>
+                    </button>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/src/components/EditSheet.css
+++ b/src/components/EditSheet.css
@@ -29,14 +29,17 @@
   flex-direction: column;
   background: var(--surface-deep);
   border-bottom: 1px solid var(--rule);
-  /* Cap the sheet to the space between the top chrome and the bars/edit bar,
-     then let the record editor scroll within it. Short records stay short. */
-  max-height: calc(
+  /* Fixed height (exactly like the nav dock): the gap between the top chrome
+     and the bottom bar + edit action bar. Because the height is deterministic
+     — not driven by the record's content — the height:0→auto reveal is smooth
+     (no jump when the record finishes loading), the sheet fills right up to
+     the top chrome (no gap), and its bottom butts against the edit action bar
+     (no gap). The record editor scrolls inside the fixed body. */
+  height: calc(
     100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) -
-      env(safe-area-inset-bottom, 0px) - var(--space-4)
+      env(safe-area-inset-bottom, 0px)
   );
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  overflow: hidden;
 }
 
 @media (min-width: 65rem) {
@@ -46,12 +49,10 @@
   }
 }
 
-/* Sticky header so the record label + close stay put while the editor body
-   scrolls under them. */
+/* Fixed header + footer with a scrolling body between them (flex column in a
+   fixed-height, overflow-hidden panel). */
 .edit-sheet-head {
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -109,12 +110,15 @@
 }
 
 .edit-sheet-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: var(--space-4);
 }
 
 .edit-sheet-foot {
-  position: sticky;
-  bottom: 0;
+  flex: 0 0 auto;
   padding: var(--space-3) var(--space-4);
   background: var(--surface-deep);
   border-top: 1px solid var(--rule-soft);

--- a/src/components/EditSheet.jsx
+++ b/src/components/EditSheet.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
@@ -25,10 +25,21 @@ function parseAtUri(uri) {
  * A footer link hands off to the full editor in the admin panel.
  */
 export default function EditSheet() {
-  const { editSheet, closeEditSheet, markRemoved, clearSelection, exit } = useEditMode();
+  const { editSheet, closeEditSheet, markRemoved, clearSelection, exit, setSheetEditor } =
+    useEditMode();
   const { agent, did } = useAtprotoSession();
   const { open: dockOpen } = useActionDock();
   const reduce = useReducedMotion();
+  // Imperative handle into the editor + its live status, so the edit action
+  // bar can host the Save / Delete controls instead of the sheet itself.
+  const editorRef = useRef(null);
+  const [editorStatus, setEditorStatus] = useState({
+    saving: false,
+    deleting: false,
+    loading: true,
+    isNew: false,
+  });
+  const handleStatus = useCallback((s) => setEditorStatus(s), []);
 
   // The nav dock and this sheet share the same slot above the chrome; if the
   // menu opens, fold the sheet away so they never stack.
@@ -46,14 +57,32 @@ export default function EditSheet() {
     return () => window.removeEventListener('keydown', onKey);
   }, [editSheet, closeEditSheet]);
 
-  if (typeof document === 'undefined') return null;
-
   const parts = editSheet ? parseAtUri(editSheet.atUri) : null;
   // Only the owner's own records are quick-editable here.
   const editable = parts && parts.repo === ME_DID && agent && did === ME_DID;
   const lex = parts ? lexiconFor(parts.collection) : null;
   const adminHref =
     parts && `/admin?c=${encodeURIComponent(parts.collection)}&r=${encodeURIComponent(parts.rkey)}`;
+
+  // Publish the editor controller (save/delete + status) to the action bar
+  // while an editable sheet is open; clear it otherwise and on unmount.
+  useEffect(() => {
+    if (!editSheet || !editable) {
+      setSheetEditor(null);
+      return undefined;
+    }
+    setSheetEditor({
+      save: () => editorRef.current?.save(),
+      remove: () => editorRef.current?.remove(),
+      saving: editorStatus.saving,
+      deleting: editorStatus.deleting,
+      loading: editorStatus.loading,
+      canDelete: !editorStatus.isNew,
+    });
+    return () => setSheetEditor(null);
+  }, [editSheet, editable, editorStatus, setSheetEditor]);
+
+  if (typeof document === 'undefined') return null;
 
   return createPortal(
     <>
@@ -101,11 +130,14 @@ export default function EditSheet() {
                 {editable ? (
                   <RecordEditor
                     key={editSheet.atUri}
+                    ref={editorRef}
                     agent={agent}
                     did={did}
                     collection={parts.collection}
                     rkey={parts.rkey}
                     compact
+                    hideActions
+                    onStatus={handleStatus}
                     onDeleted={() => {
                       markRemoved(editSheet.atUri);
                       clearSelection();

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import BlocksEditor from './blocks/BlocksEditor.jsx';
@@ -27,8 +27,16 @@ import '../pages/Admin.css';
  *   - onCreated:   called with `{ rkey }` after a successful create
  *   - initialMode: 'form' (default) or 'raw' — useful when callers want to
  *                  drop the user straight into JSON editing.
+ *   - hideActions: when true, the internal Save/Delete button row is not
+ *                  rendered — the caller drives save/delete via the imperative
+ *                  ref instead (see the quick-edit sheet's action bar).
+ *   - onStatus:    called with `{ saving, deleting, loading, isNew }` whenever
+ *                  those change, so an external controller can reflect state.
+ *
+ * Ref (imperative handle): `{ save(), remove() }` — trigger a save or delete
+ * from outside the component.
  */
-export default function RecordEditor({
+const RecordEditor = forwardRef(function RecordEditor({
   agent,
   did,
   collection,
@@ -39,7 +47,9 @@ export default function RecordEditor({
   onCreated,
   initialMode = 'form',
   initialValue = null,
-}) {
+  hideActions = false,
+  onStatus,
+}, ref) {
   const lex = lexiconFor(collection);
   const isNew = !rkey;
 
@@ -227,6 +237,26 @@ export default function RecordEditor({
     setRawMode((m) => !m);
   }
 
+  // Expose save/delete imperatively so an external controller (the quick-edit
+  // sheet's action bar) can drive them. Stable handle backed by refs so it
+  // always calls the latest closures.
+  const saveRef = useRef(null);
+  const deleteRef = useRef(null);
+  saveRef.current = handleSave;
+  deleteRef.current = handleDelete;
+  useImperativeHandle(
+    ref,
+    () => ({
+      save: () => saveRef.current?.(),
+      remove: () => deleteRef.current?.(),
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    onStatus?.({ saving, deleting, loading, isNew });
+  }, [saving, deleting, loading, isNew, onStatus]);
+
   if (loading) {
     return <p className="placeholder-card">Loading record…</p>;
   }
@@ -291,29 +321,33 @@ export default function RecordEditor({
       {error && <p className="admin-error">{error}</p>}
       {savedFlash && <p className="admin-success">Saved.</p>}
 
-      <div className="admin-actions">
-        <button
-          type="button"
-          className="admin-gate-button"
-          onClick={handleSave}
-          disabled={saving || deleting}
-        >
-          {saving ? 'Saving…' : isNew ? 'Create' : 'Save'}
-        </button>
-        {!isNew && (
+      {!hideActions && (
+        <div className="admin-actions">
           <button
             type="button"
-            className="admin-gate-button admin-danger"
-            onClick={handleDelete}
+            className="admin-gate-button"
+            onClick={handleSave}
             disabled={saving || deleting}
           >
-            {deleting ? 'Deleting…' : 'Delete'}
+            {saving ? 'Saving…' : isNew ? 'Create' : 'Save'}
           </button>
-        )}
-      </div>
+          {!isNew && (
+            <button
+              type="button"
+              className="admin-gate-button admin-danger"
+              onClick={handleDelete}
+              disabled={saving || deleting}
+            >
+              {deleting ? 'Deleting…' : 'Delete'}
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
-}
+});
+
+export default RecordEditor;
 
 /* ------------------------------------------------------------------ */
 /* Field renderers                                                      */

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -41,6 +41,10 @@ export function EditModeProvider({ children }) {
   const [pageRecord, setPageRecord] = useState(null);
   // The record currently open in the quick-edit sheet: { atUri } or null.
   const [editSheet, setEditSheet] = useState(null);
+  // A controller published by the open sheet's RecordEditor so the edit
+  // action bar can drive save/delete: { save, remove, saving, deleting,
+  // loading, canDelete } or null.
+  const [sheetEditor, setSheetEditor] = useState(null);
   const location = useLocation();
 
   const clearSelection = useCallback(() => {
@@ -152,6 +156,8 @@ export function EditModeProvider({ children }) {
       editSheet,
       openEditSheet,
       closeEditSheet,
+      sheetEditor,
+      setSheetEditor,
     }),
     [
       active,
@@ -171,6 +177,8 @@ export function EditModeProvider({ children }) {
       editSheet,
       openEditSheet,
       closeEditSheet,
+      sheetEditor,
+      setSheetEditor,
     ],
   );
 


### PR DESCRIPTION
Fixes two issues with the quick-edit sheet from #112.

## Sheet sizing (jump + gaps)
The sheet sized itself to its content, so the `height: 0 → auto` animation measured the short "Loading…" state and then jumped when the record loaded, and the content never reached the top bar. Switched it to a **fixed dock-style height** (the gap between the top chrome and the bottom bar + edit action bar), matching the nav dock:
- No abrupt jump — the height is deterministic, so the reveal animates smoothly regardless of when the record loads.
- No top gap — the panel fills up to the top chrome (verified `panelTop` = top-chrome height).
- No bottom gap — the panel bottom butts against the edit action bar (verified `panelBottom` = `barTop`).
- The record editor scrolls inside the fixed body (fixed header + footer).

## Save/Delete moved to the action bar
The sheet no longer renders its own SAVE/DELETE. `RecordEditor` gained a `hideActions` prop and exposes an imperative `save()`/`remove()` handle plus an `onStatus` callback. The sheet publishes that controller to edit mode, and while a sheet is open the **edit action bar** hosts Save (accent primary), Delete, and Close — committing field/JSON edits straight from the bar.

## Notes
- Rebased cleanly onto the redesigned Admin recently landed on `main`.
- `npm run build` passes; layout verified via headless measurement (panel flush to top chrome, zero gap to the action bar) and the bar's "Editing record / Close" state.
- The authenticated editor body + live Save/Delete round-trip need an owner OAuth session (shows a sign-in placeholder when signed out); worth a final confirm on the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4D4A63MwouXcwWYLEnqEc)_