### PR TITLE
Expand search/filter/info up from the bottom chrome as one system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import Footer from './components/Footer.jsx';
 import WindowScrollbar from './components/WindowScrollbar.jsx';
 import RouteTransition from './components/RouteTransition.jsx';
 import { ActionDockProvider } from './hooks/useActionDock.jsx';
+import { ChromePanelProvider } from './hooks/useChromePanel.jsx';
 import { ThemeProvider } from './hooks/useTheme.jsx';
 import { DensityProvider } from './hooks/useDensity.jsx';
 import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
@@ -86,6 +87,7 @@ export default function App() {
       <AtprotoSessionProvider>
       <FeedFilterProvider>
       <ActionDockProvider>
+      <ChromePanelProvider>
       <WaypointsModalProvider>
       <EditModeProvider>
           <div className="app-shell">
@@ -151,6 +153,7 @@ export default function App() {
           </div>
       </EditModeProvider>
       </WaypointsModalProvider>
+      </ChromePanelProvider>
       </ActionDockProvider>
       </FeedFilterProvider>
       </AtprotoSessionProvider>

--- a/src/components/BottomSheet.css
+++ b/src/components/BottomSheet.css
@@ -1,0 +1,74 @@
+/* Shared bottom-chrome sheet — see BottomSheet.jsx. Positioning + surface
+   mirror the nav dock (ActionDock.css) and edit sheet (EditSheet.css) so
+   every upward-expanding chrome surface reads as one system.
+
+   .bottom-sheet-backdrop: a transparent, non-dimming click-catcher below the
+   chrome bars (z 29 < bars' 30) so tapping the page closes the panel while
+   the toolbar buttons stay live. No visual tint — the panel reads as part of
+   the chrome, like the top-bar expansions do. */
+.bottom-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+  background: transparent;
+}
+
+/* The animated clip box, pinned directly on top of the bottom bar — and
+   above the owner edit action bar when it's open (--edit-bar-h, else 0) —
+   centered on the same 65rem card. Framer animates its height 0 ↔ auto;
+   overflow:hidden means the panel inside unfurls upward out of the bar.
+   Sits above the bars (z 31) so its top edge overlaps the page cleanly. */
+.bottom-sheet-wrap {
+  position: fixed;
+  bottom: calc(var(--chrome-h) + var(--edit-bar-h, 0px) + env(safe-area-inset-bottom, 0px));
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-width: 65rem;
+  margin: 0 auto;
+  z-index: 31;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bottom-sheet-panel {
+  pointer-events: auto;
+  /* Deeper than the bar's --surface-raised so the expanded panel reads as
+     its own layer above the toolbar. */
+  background: var(--surface-deep);
+  /* Crisp divider between the panel and the button row below. */
+  border-bottom: 1px solid var(--rule);
+}
+
+/* Compact: content-height, capped to the gap between top + bottom chrome so
+   a tall panel scrolls instead of growing under the top bar. A top hairline
+   divides it from the page showing above. */
+.bottom-sheet-panel-compact {
+  border-top: 1px solid var(--rule);
+  max-height: calc(
+    100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) -
+      env(safe-area-inset-bottom, 0px)
+  );
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* Fill: occupies the whole gap up to the top chrome, butting its border
+   (no top hairline — the top chrome's own border-bottom is the divider). */
+.bottom-sheet-panel-fill {
+  height: calc(
+    100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) -
+      env(safe-area-inset-bottom, 0px)
+  );
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* On wide screens the chrome bars float as a 65rem card with side hairlines;
+   the panel closes its box to match. */
+@media (min-width: 65rem) {
+  .bottom-sheet-panel {
+    border-left: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+  }
+}

--- a/src/components/BottomSheet.jsx
+++ b/src/components/BottomSheet.jsx
@@ -1,0 +1,90 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import './BottomSheet.css';
+
+/**
+ * The shared "expand up out of the bottom chrome" surface — the single
+ * mechanism behind the search / filter / info panels, mirroring how the
+ * nav ActionDock and owner EditSheet unfurl from the same edge.
+ *
+ * A fixed clip box is pinned directly on top of the bottom bar (and above
+ * the owner edit action bar via `--edit-bar-h`); framer animates its height
+ * 0 ↔ auto with overflow hidden, so the panel inside grows upward out of the
+ * bar rather than overlaying as a centered modal. A transparent, non-dimming
+ * backdrop below the bars catches outside clicks so the toolbar itself stays
+ * live. Portalled to <body> so no transformed feed ancestor can trap the
+ * fixed positioning.
+ *
+ * Sizing:
+ *   - 'compact' (default): the panel is content-height (capped to the gap
+ *     between the top and bottom chrome, then scrolls) and carries a top
+ *     hairline dividing it from the page above. Right for a search field,
+ *     a filter grid, a short primer.
+ *   - 'fill': the panel fills the whole gap up to the top chrome, butting
+ *     its border, for full-surface sheets.
+ */
+export default function BottomSheet({
+  open,
+  onClose,
+  label,
+  id,
+  size = 'compact',
+  className = '',
+  closeOnEscape = true,
+  children,
+}) {
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    if (!open || !closeOnEscape) return undefined;
+    function onKey(e) {
+      if (e.key === 'Escape') onClose?.();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, closeOnEscape, onClose]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="bottom-sheet-backdrop"
+            className="bottom-sheet-backdrop"
+            onClick={onClose}
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.2 }}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="bottom-sheet"
+            className="bottom-sheet-wrap"
+            initial={{ height: 0 }}
+            animate={{ height: 'auto' }}
+            exit={{ height: 0 }}
+            transition={{ duration: reduce ? 0 : 0.34, ease: [0.32, 0.72, 0, 1] }}
+          >
+            <div
+              id={id}
+              className={`bottom-sheet-panel bottom-sheet-panel-${size} ${className}`.trim()}
+              role="dialog"
+              aria-label={label}
+            >
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>,
+    document.body,
+  );
+}

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -6,6 +6,7 @@ import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -14,8 +15,8 @@ import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
 import DensityToggle from './DensityToggle.jsx';
-import SearchModal from './SearchModal.jsx';
-import InfoModal from './InfoModal.jsx';
+import SearchSheet from './SearchSheet.jsx';
+import InfoSheet from './InfoSheet.jsx';
 import './ChromeBar.css';
 
 // Per-theme glyph for the toggle button: sun for light, moon for dark.
@@ -265,12 +266,17 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const location = useLocation();
   const navigate = useNavigate();
   const { view, setView } = useActionDock();
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [infoOpen, setInfoOpen] = useState(false);
+  // Search / filter / info all expand up out of this bar as mutually
+  // exclusive panels coordinated by useChromePanel (which also folds the
+  // nav dock away, and vice versa) — see BottomSheet + useChromePanel.
+  const { panel, togglePanel, closePanel } = useChromePanel();
+  const searchPanelOpen = panel === 'search';
+  const filterPanelOpen = panel === 'filter';
+  const infoPanelOpen = panel === 'info';
   const reduce = useReducedMotion();
   const atTop = useAtTopOfPage();
   const scrolledPast = useScrolledPastFeedItems();
-  const { available: filterAvailable, open: filterOpen, toggleModal: toggleFilter } = useFeedFilter();
+  const { available: filterAvailable } = useFeedFilter();
   const { theme, cycle: cycleTheme } = useTheme();
   const ThemeIcon = THEME_ICON[theme] || Sun;
   // The edit-mode toggle only exists for the site owner. It sits beside the
@@ -284,6 +290,14 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const searchActive = !!params.get('q');
   const filterCustomized = params.has('verbs');
   const onHomePage = location.pathname === '/';
+
+  // If the route stops exposing filters while the filter panel is open
+  // (e.g. navigating away from a feed), fold it away — the trigger button
+  // is about to disappear from the bar.
+  useEffect(() => {
+    if (!filterAvailable && filterPanelOpen) closePanel();
+  }, [filterAvailable, filterPanelOpen, closePanel]);
+
   // A "sub page" is anything nested one level deeper than a section index
   // (e.g. /curating/:slug, /creating/:slug) — those get a back handle in
   // the bottom bar that walks up to the section index (the breadcrumb parent).
@@ -372,31 +386,31 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 {filterAvailable && (
                   <button
                     type="button"
-                    className={`chrome-nav chrome-filter ${filterOpen || filterCustomized ? 'is-open' : ''}`}
-                    onClick={toggleFilter}
-                    aria-expanded={filterOpen}
-                    aria-haspopup="dialog"
-                    aria-label={filterOpen ? 'Close filters' : 'Open filters'}
+                    className={`chrome-nav chrome-filter ${filterPanelOpen || filterCustomized ? 'is-open' : ''}`}
+                    onClick={() => togglePanel('filter')}
+                    aria-expanded={filterPanelOpen}
+                    aria-controls="chrome-filter-sheet"
+                    aria-label={filterPanelOpen ? 'Close filters' : 'Open filters'}
                   >
                     <ListFilterPlus className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                   </button>
                 )}
                 <button
                   type="button"
-                  className={`chrome-nav chrome-search-btn ${searchOpen || searchActive ? 'is-open' : ''}`}
-                  onClick={() => setSearchOpen(true)}
-                  aria-expanded={searchOpen}
-                  aria-haspopup="dialog"
+                  className={`chrome-nav chrome-search-btn ${searchPanelOpen || searchActive ? 'is-open' : ''}`}
+                  onClick={() => togglePanel('search')}
+                  aria-expanded={searchPanelOpen}
+                  aria-controls="chrome-search-sheet"
                   aria-label={searchActive ? `Search (current query: ${params.get('q')})` : 'Open search'}
                 >
                   <Search className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
                 <button
                   type="button"
-                  className={`chrome-nav chrome-info-btn ${infoOpen ? 'is-open' : ''}`}
-                  onClick={() => setInfoOpen(true)}
-                  aria-expanded={infoOpen}
-                  aria-haspopup="dialog"
+                  className={`chrome-nav chrome-info-btn ${infoPanelOpen ? 'is-open' : ''}`}
+                  onClick={() => togglePanel('info')}
+                  aria-expanded={infoPanelOpen}
+                  aria-controls="chrome-info-sheet"
                   aria-label="About this site"
                 >
                   <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
@@ -405,7 +419,12 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                   <button
                     type="button"
                     className={`chrome-nav chrome-edit-btn ${editActive ? 'is-open' : ''}`}
-                    onClick={toggleEdit}
+                    onClick={() => {
+                      // Entering/leaving edit mode owns the bottom chrome —
+                      // fold any open search/filter/info panel away first.
+                      closePanel();
+                      toggleEdit();
+                    }}
                     aria-pressed={editActive}
                     aria-label={editActive ? 'Exit edit mode' : 'Enter edit mode'}
                     title={editActive ? 'Exit edit mode' : 'Edit mode'}
@@ -492,8 +511,8 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           <Compass className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
         </button>
       </div>
-      <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />
-      <InfoModal open={infoOpen} onClose={() => setInfoOpen(false)} />
+      <SearchSheet />
+      <InfoSheet />
     </div>
   );
 }

--- a/src/components/CreatingFilters.jsx
+++ b/src/components/CreatingFilters.jsx
@@ -1,7 +1,8 @@
 import { useSearchParams } from 'react-router-dom';
 import { X } from 'lucide-react';
-import Modal from './Modal.jsx';
-import { useFeedFilter, useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import BottomSheet from './BottomSheet.jsx';
+import { useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { matchesQuery } from './FeedSearch.jsx';
 import { workCategory, workSlug } from '../lib/publications.js';
 import './FeedFilters.css';
@@ -14,7 +15,8 @@ import './FeedFilters.css';
  */
 export default function CreatingFilters({ kinds, counts }) {
   const [params, setParams] = useSearchParams();
-  const { open, closeModal } = useFeedFilter();
+  const { panel, closePanel } = useChromePanel();
+  const open = panel === 'filter';
   useRegisterFeedFilter();
 
   const active = resolveActiveKinds(params, kinds);
@@ -66,19 +68,13 @@ export default function CreatingFilters({ kinds, counts }) {
   if (!kinds || kinds.length < 2) return null;
 
   return (
-    <Modal
-      open={open}
-      onClose={closeModal}
-      label="Filter projects"
-      className="feed-filter-modal-panel"
-      scrimLabel="Close filter"
-    >
+    <BottomSheet open={open} onClose={closePanel} label="Filter projects" id="chrome-filter-sheet" className="feed-filter-sheet-panel">
       <div className="feed-filter-modal-header">
         <span className="small-caps">filter by kind</span>
         <button
           type="button"
           className="feed-filter-modal-close"
-          onClick={closeModal}
+          onClick={closePanel}
           aria-label="Close"
         >
           <X size={16} aria-hidden="true" />
@@ -137,7 +133,7 @@ export default function CreatingFilters({ kinds, counts }) {
           );
         })}
       </div>
-    </Modal>
+    </BottomSheet>
   );
 }
 

--- a/src/components/FeedFilters.css
+++ b/src/components/FeedFilters.css
@@ -102,21 +102,16 @@
 
 /* Filter sheet ------------------------------------------------------- */
 
-/* Wrapped in <Modal variant="centered">; the Modal owns positioning,
-   scrim, surface, and animation. Only the interior layout (padding,
-   internal spacing, header/grid) lives here. */
-.feed-filter-modal-panel {
-  width: min(480px, 100%);
-  padding: var(--space-5);
+/* Interior of the filter bottom sheet. BottomSheet owns positioning, the
+   surface, and the expand animation; only the interior layout (padding,
+   internal spacing, header/grid) lives here. Full-width — it fills the
+   65rem chrome card rather than sitting as a narrow centered modal. */
+.feed-filter-sheet-panel {
+  width: 100%;
+  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-}
-
-@media (max-width: 540px) {
-  .feed-filter-modal-panel {
-    padding: var(--space-4);
-  }
 }
 
 .feed-filter-modal-header {

--- a/src/components/FeedFilters.jsx
+++ b/src/components/FeedFilters.jsx
@@ -3,8 +3,9 @@ import { CornerDownRight, X } from 'lucide-react';
 import { VERBS, DEFAULT_HOME_VERBS } from '../lib/verbRegistry.js';
 import { selfThreadMembers } from '../lib/threadGrouping.js';
 import VerbIcon from './VerbIcon.jsx';
-import Modal from './Modal.jsx';
-import { useFeedFilter, useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import BottomSheet from './BottomSheet.jsx';
+import { useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import './FeedFilters.css';
 
 // Sentinel for "show none" so an empty `verbs=` doesn't resolve back to
@@ -28,7 +29,8 @@ const FILTER_KEYS = [REPLYING, ...VERBS];
  */
 export default function FeedFilters({ counts, estimatedVerbs }) {
   const [params, setParams] = useSearchParams();
-  const { open, closeModal } = useFeedFilter();
+  const { panel, closePanel } = useChromePanel();
+  const open = panel === 'filter';
   useRegisterFeedFilter();
 
   const activeVerbs = resolveActiveVerbs(params);
@@ -95,7 +97,7 @@ export default function FeedFilters({ counts, estimatedVerbs }) {
       onSelectAll={selectAll}
       onSelectNone={selectNone}
       onReset={resetToDefault}
-      onClose={closeModal}
+      onClose={closePanel}
     />
   );
 }
@@ -116,13 +118,7 @@ function FilterModal({
   const allActive = !usingDefaults && activeVerbs.size === FILTER_KEYS.length;
   const noneActive = !usingDefaults && activeVerbs.size === 0;
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      label="Filter feed"
-      className="feed-filter-modal-panel"
-      scrimLabel="Close filter"
-    >
+    <BottomSheet open={open} onClose={onClose} label="Filter feed" id="chrome-filter-sheet" className="feed-filter-sheet-panel">
       <div className="feed-filter-modal-header">
         <span className="small-caps">filter by type</span>
         <button
@@ -207,7 +203,7 @@ function FilterModal({
           );
         })}
       </div>
-    </Modal>
+    </BottomSheet>
   );
 }
 

--- a/src/components/InfoSheet.css
+++ b/src/components/InfoSheet.css
@@ -1,14 +1,13 @@
-/* Wrapped in <Modal variant="centered">; the Modal owns positioning,
-   scrim, surface, and motion. Only the interior layout lives here. */
-.info-modal-panel {
-  width: min(560px, 100%);
-  padding: var(--space-5);
+/* Interior of the info bottom sheet. BottomSheet owns positioning, the
+   surface, and the expand animation; only the prose layout lives here. */
+.info-sheet-panel {
+  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
 }
 
-.info-modal-header {
+.info-sheet-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -19,7 +18,7 @@
   color: var(--ink-faint);
 }
 
-.info-modal-close {
+.info-sheet-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -28,21 +27,21 @@
   padding: 0;
   border: 1px solid var(--rule);
   border-radius: 0;
-  background: transparent;
+  background: var(--page);
   color: var(--ink-soft);
   cursor: pointer;
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
-.info-modal-close:hover,
-.info-modal-close:focus-visible {
+.info-sheet-close:hover,
+.info-sheet-close:focus-visible {
   color: var(--accent);
   border-color: var(--accent-soft);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
   outline: none;
 }
 
-.info-modal-body {
+.info-sheet-body {
   font-family: var(--serif);
   color: var(--ink-soft);
   display: flex;
@@ -50,16 +49,16 @@
   gap: var(--space-4);
 }
 
-.info-modal-body p {
+.info-sheet-body p {
   margin: 0;
   line-height: var(--leading);
 }
 
-.info-modal-body strong {
+.info-sheet-body strong {
   color: var(--ink);
 }
 
-.info-modal-body h3 {
+.info-sheet-body h3 {
   font-family: var(--sans);
   font-variant: all-small-caps;
   letter-spacing: 0.14em;

--- a/src/components/InfoSheet.jsx
+++ b/src/components/InfoSheet.jsx
@@ -1,35 +1,33 @@
 import { X } from 'lucide-react';
-import Modal from './Modal.jsx';
-import './InfoModal.css';
+import BottomSheet from './BottomSheet.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
+import './InfoSheet.css';
 
 /**
- * "What is this site?" modal opened from the bottom chrome bar's
- * info button. Plain prose — atmosphere, atproto, PDS, what you can
- * actually do here. Written as a primer for first-time visitors who
- * don't yet have the vocabulary for any of it.
+ * "What is this site?" primer, expanded up out of the bottom chrome bar's
+ * info button (see useChromePanel). Plain prose — atmosphere, atproto, PDS,
+ * what you can actually do here — written for first-time visitors who don't
+ * yet have the vocabulary for any of it.
  */
-export default function InfoModal({ open, onClose }) {
+export default function InfoSheet() {
+  const { panel, closePanel } = useChromePanel();
+  const open = panel === 'info';
+
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      label="About this site"
-      className="info-modal-panel"
-      scrimLabel="Close info"
-    >
-      <div className="info-modal-header">
+    <BottomSheet open={open} onClose={closePanel} label="About this site" id="chrome-info-sheet" className="info-sheet-panel">
+      <div className="info-sheet-header">
         <span className="small-caps">about this site</span>
         <button
           type="button"
-          className="info-modal-close"
-          onClick={onClose}
+          className="info-sheet-close"
+          onClick={closePanel}
           aria-label="Close"
         >
           <X size={16} aria-hidden="true" />
         </button>
       </div>
 
-      <div className="info-modal-body">
+      <div className="info-sheet-body">
         <p>
           <strong>dame.is</strong> is a personal website built on top
           of the <em>AT Protocol</em>. It's where Dame writes, posts,
@@ -67,6 +65,6 @@ export default function InfoModal({ open, onClose }) {
           move PDSes or build another frontend.
         </p>
       </div>
-    </Modal>
+    </BottomSheet>
   );
 }

--- a/src/components/PostingFilters.jsx
+++ b/src/components/PostingFilters.jsx
@@ -1,7 +1,8 @@
 import { useSearchParams } from 'react-router-dom';
 import { FileText, Image, Link, Quote, Reply, X } from 'lucide-react';
-import Modal from './Modal.jsx';
-import { useFeedFilter, useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import BottomSheet from './BottomSheet.jsx';
+import { useRegisterFeedFilter } from '../hooks/useFeedFilter.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { matchesQuery } from './FeedSearch.jsx';
 import './FeedFilters.css';
 
@@ -37,7 +38,8 @@ const TYPE_ICONS = {
  */
 export default function PostingFilters({ counts }) {
   const [params, setParams] = useSearchParams();
-  const { open, closeModal } = useFeedFilter();
+  const { panel, closePanel } = useChromePanel();
+  const open = panel === 'filter';
   useRegisterFeedFilter();
 
   const activeTypes = resolveActivePostingTypes(params);
@@ -86,19 +88,13 @@ export default function PostingFilters({ counts }) {
   const noneActive = !usingDefaults && activeTypes.size === 0;
 
   return (
-    <Modal
-      open={open}
-      onClose={closeModal}
-      label="Filter posts"
-      className="feed-filter-modal-panel"
-      scrimLabel="Close filter"
-    >
+    <BottomSheet open={open} onClose={closePanel} label="Filter posts" id="chrome-filter-sheet" className="feed-filter-sheet-panel">
       <div className="feed-filter-modal-header">
         <span className="small-caps">filter by post type</span>
         <button
           type="button"
           className="feed-filter-modal-close"
-          onClick={closeModal}
+          onClick={closePanel}
           aria-label="Close"
         >
           <X size={16} aria-hidden="true" />
@@ -162,7 +158,7 @@ export default function PostingFilters({ counts }) {
           );
         })}
       </div>
-    </Modal>
+    </BottomSheet>
   );
 }
 

--- a/src/components/SearchSheet.css
+++ b/src/components/SearchSheet.css
@@ -1,26 +1,25 @@
-/* Wrapped in <Modal variant="centered">; the Modal owns positioning,
-   scrim, surface, and motion. Only the interior layout lives here. */
-.search-modal-panel {
-  width: min(560px, 100%);
-  padding: var(--space-5);
+/* Interior of the search bottom sheet. BottomSheet owns positioning, the
+   surface, and the expand animation; only the field layout lives here. */
+.search-sheet-panel {
+  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
 }
 
-.search-modal-form {
+.search-sheet-form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
-.search-modal-field {
+.search-sheet-field {
   position: relative;
   display: flex;
   align-items: center;
 }
 
-.search-modal-field input {
+.search-sheet-field input {
   appearance: none;
   -webkit-appearance: none;
   width: 100%;
@@ -36,13 +35,13 @@
   color: var(--ink);
 }
 
-.search-modal-field input:focus {
+.search-sheet-field input:focus {
   outline: none;
   border-color: var(--accent-soft);
   background: var(--page);
 }
 
-.search-modal-icon {
+.search-sheet-icon {
   position: absolute;
   left: 0.85em;
   top: 50%;
@@ -51,11 +50,11 @@
   pointer-events: none;
 }
 
-.search-modal-field:focus-within .search-modal-icon {
+.search-sheet-field:focus-within .search-sheet-icon {
   color: var(--ink-soft);
 }
 
-.search-modal-clear {
+.search-sheet-clear {
   position: absolute;
   right: 0.5em;
   top: 50%;
@@ -72,21 +71,20 @@
   cursor: pointer;
 }
 
-.search-modal-clear:hover,
-.search-modal-clear:focus-visible {
+.search-sheet-clear:hover,
+.search-sheet-clear:focus-visible {
   color: var(--accent);
   outline: none;
 }
 
-.search-modal-hint {
+.search-sheet-hint {
   font-family: var(--sans);
   font-size: var(--text-xs);
   color: var(--ink-faint);
-  text-align: center;
   margin: 0;
 }
 
-.search-modal-hint kbd {
+.search-sheet-hint kbd {
   font-family: var(--mono, var(--sans));
   font-size: 0.95em;
   padding: 0.1em 0.4em;

--- a/src/components/SearchSheet.jsx
+++ b/src/components/SearchSheet.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { Search, X } from 'lucide-react';
-import Modal from './Modal.jsx';
-import './SearchModal.css';
+import BottomSheet from './BottomSheet.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
+import './SearchSheet.css';
 
 // Routes whose page component reads `?q=` and filters its own list. On
 // any other route, submitting the search instead jumps to `/?q=…` so the
@@ -10,20 +11,18 @@ import './SearchModal.css';
 const SEARCHABLE_ROUTES = new Set(['/', '/posting', '/logging', '/blogging', '/creating']);
 
 /**
- * Search palette opened from the bottom chrome bar's search button.
+ * Global search, expanded up out of the bottom chrome bar's search button
+ * (see useChromePanel). Rather than a centered modal, the field unfurls from
+ * the bar itself — the same motion as the nav dock and the other chrome
+ * panels — so every bottom-chrome affordance behaves alike.
  *
- * The input sits inside a modal (rather than directly in the bar) for
- * two reasons:
- *   1. Tapping a tiny input in a fixed bottom bar triggers iOS's
- *      focus-zoom whenever the field is below 16px, and the bar's
- *      typography otherwise wants to stay smaller than that.
- *   2. A modal gives the input the space + scale of a real search
- *      surface, matching how the filter modal works.
- *
- * Query is committed to the URL on submit (not on every keystroke) so
- * the page behind the scrim isn't churning while the user types.
+ * The field keeps a 16px/1rem font so iOS Safari doesn't auto-zoom on focus.
+ * Query is committed to the URL on submit (not on every keystroke) so the
+ * page behind the panel isn't churning while the user types.
  */
-export default function SearchModal({ open, onClose }) {
+export default function SearchSheet() {
+  const { panel, closePanel } = useChromePanel();
+  const open = panel === 'search';
   const navigate = useNavigate();
   const location = useLocation();
   const [params, setParams] = useSearchParams();
@@ -31,18 +30,17 @@ export default function SearchModal({ open, onClose }) {
   const [draft, setDraft] = useState(currentQ);
   const inputRef = useRef(null);
 
-  // Re-sync draft whenever the modal opens so the field reflects any
-  // ?q= changes that happened while it was closed (e.g. user cleared
-  // search via the back/forward buttons).
+  // Re-sync draft whenever the panel opens so the field reflects any ?q=
+  // changes that happened while it was closed (e.g. cleared via back/forward).
   useEffect(() => {
     if (open) setDraft(currentQ);
   }, [open, currentQ]);
 
-  // Auto-focus the input on open. Slight delay so the panel's mount
-  // animation can complete before the keyboard slides up on mobile.
+  // Auto-focus the input on open. Slight delay so the panel's expand
+  // animation can settle before the keyboard slides up on mobile.
   useEffect(() => {
-    if (!open) return;
-    const id = setTimeout(() => inputRef.current?.focus(), 80);
+    if (!open) return undefined;
+    const id = setTimeout(() => inputRef.current?.focus(), 120);
     return () => clearTimeout(id);
   }, [open]);
 
@@ -64,7 +62,7 @@ export default function SearchModal({ open, onClose }) {
         { replace: true },
       );
     }
-    onClose?.();
+    closePanel();
   }
 
   function handleSubmit(e) {
@@ -78,16 +76,10 @@ export default function SearchModal({ open, onClose }) {
   }
 
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      label="Search"
-      className="search-modal-panel"
-      scrimLabel="Close search"
-    >
-      <form className="search-modal-form" onSubmit={handleSubmit} role="search">
-        <div className="search-modal-field">
-          <Search size={18} aria-hidden="true" className="search-modal-icon" />
+    <BottomSheet open={open} onClose={closePanel} label="Search" id="chrome-search-sheet" className="search-sheet-panel">
+      <form className="search-sheet-form" onSubmit={handleSubmit} role="search">
+        <div className="search-sheet-field">
+          <Search size={18} aria-hidden="true" className="search-sheet-icon" />
           <input
             ref={inputRef}
             type="search"
@@ -104,7 +96,7 @@ export default function SearchModal({ open, onClose }) {
           {draft && (
             <button
               type="button"
-              className="search-modal-clear"
+              className="search-sheet-clear"
               onClick={handleClear}
               aria-label="Clear search"
             >
@@ -112,10 +104,10 @@ export default function SearchModal({ open, onClose }) {
             </button>
           )}
         </div>
-        <p className="search-modal-hint gutter">
+        <p className="search-sheet-hint gutter">
           Press <kbd>Enter</kbd> to search · <kbd>Esc</kbd> to close
         </p>
       </form>
-    </Modal>
+    </BottomSheet>
   );
 }

--- a/src/hooks/useChromePanel.jsx
+++ b/src/hooks/useChromePanel.jsx
@@ -1,0 +1,66 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useActionDock } from './useActionDock.jsx';
+
+/**
+ * Coordinator for the transient panels that expand up out of the bottom
+ * chrome bar — search, filter, and info.
+ *
+ * The bottom chrome hosts a family of upward-expanding surfaces:
+ *   - the nav ActionDock (its own richer, persisted sheet)
+ *   - the owner EditSheet (owner-only quick edit)
+ *   - these lightweight panels (search / filter / info)
+ *
+ * They must never stack on top of each other. This context owns a single
+ * `panel` string so opening one transient panel closes any other for free,
+ * and it coordinates with the dock: opening a panel folds the dock away,
+ * and opening the dock folds any panel away. The result is a clear
+ * one-at-a-time rule across every bottom-chrome expansion.
+ */
+const ChromePanelContext = createContext(null);
+
+// The known transient panels. Kept as a constant so callers and tests can
+// reason about the full set without magic strings scattered around.
+export const CHROME_PANELS = ['search', 'filter', 'info'];
+
+export function ChromePanelProvider({ children }) {
+  const { open: dockOpen, closeDock } = useActionDock();
+  const [panel, setPanel] = useState(null);
+
+  const openPanel = useCallback(
+    (name) => {
+      // The dock and a transient panel share the same slot above the bar;
+      // opening a panel wins, so fold the dock away first.
+      closeDock();
+      setPanel(name);
+    },
+    [closeDock],
+  );
+
+  const closePanel = useCallback(() => setPanel(null), []);
+
+  const togglePanel = useCallback(
+    (name) => {
+      closeDock();
+      setPanel((prev) => (prev === name ? null : name));
+    },
+    [closeDock],
+  );
+
+  // The dock opening wins the bottom chrome — fold any open panel away so the
+  // two never coexist. (The reverse direction lives in openPanel/togglePanel.)
+  useEffect(() => {
+    if (dockOpen) setPanel(null);
+  }, [dockOpen]);
+
+  const value = useMemo(
+    () => ({ panel, openPanel, closePanel, togglePanel }),
+    [panel, openPanel, closePanel, togglePanel],
+  );
+  return <ChromePanelContext.Provider value={value}>{children}</ChromePanelContext.Provider>;
+}
+
+export function useChromePanel() {
+  const ctx = useContext(ChromePanelContext);
+  if (!ctx) throw new Error('useChromePanel must be used inside <ChromePanelProvider>');
+  return ctx;
+}

--- a/src/hooks/useFeedFilter.jsx
+++ b/src/hooks/useFeedFilter.jsx
@@ -1,25 +1,22 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 /**
- * Feed-filter affordance state.
+ * Feed-filter *availability* state.
  *
- * The verb-filter modal is triggered from the bottom chrome bar so it
- * needs a way to (a) know whether the current route exposes filters
- * (only `Home` does today) and (b) signal "open" / "close" without
- * directly importing each other.
+ * The verb-filter panel is triggered from the bottom chrome bar, so the bar
+ * needs to know whether the current route exposes filters (only certain
+ * feed pages do). Pages that own filterable lists call
+ * `useRegisterFeedFilter` while mounted; the chrome bar renders its filter
+ * button only while at least one is registered.
  *
- * Pages that own filterable lists call `useRegisterFeedFilter` so the
- * chrome bar can render its filter button only while one is mounted.
+ * The open/closed state of the panel itself lives in `useChromePanel`
+ * (`panel === 'filter'`) alongside search and info, so all three bottom-chrome
+ * panels obey one mutual-exclusion rule.
  */
 const FeedFilterContext = createContext(null);
 
 export function FeedFilterProvider({ children }) {
-  const [open, setOpen] = useState(false);
   const [registered, setRegistered] = useState(0);
-
-  const openModal = useCallback(() => setOpen(true), []);
-  const closeModal = useCallback(() => setOpen(false), []);
-  const toggleModal = useCallback(() => setOpen((prev) => !prev), []);
 
   // Track registration as a count so concurrent mounts (e.g. during a
   // route crossfade) don't accidentally mark filtering unavailable.
@@ -28,22 +25,9 @@ export function FeedFilterProvider({ children }) {
     return () => setRegistered((n) => Math.max(0, n - 1));
   }, []);
 
-  // The trigger only makes sense while a filterable page is mounted;
-  // if the user navigates away while the modal is open, drop it.
-  useEffect(() => {
-    if (registered === 0 && open) setOpen(false);
-  }, [registered, open]);
-
   const value = useMemo(
-    () => ({
-      available: registered > 0,
-      open,
-      openModal,
-      closeModal,
-      toggleModal,
-      register,
-    }),
-    [registered, open, openModal, closeModal, toggleModal, register],
+    () => ({ available: registered > 0, register }),
+    [registered, register],
   );
   return <FeedFilterContext.Provider value={value}>{children}</FeedFilterContext.Provider>;
 }


### PR DESCRIPTION
## Why

The bottom chrome already hosts a family of surfaces that expand upward out of the bar — the nav ActionDock and the owner EditSheet. Search, filter, and info were the holdouts: centered modals that could overlap those sheets. This unifies them into one clean, mutually-exclusive system so every bottom-chrome affordance behaves alike.

## What

**New primitives**
- **`BottomSheet`** — the shared "expand up out of the bottom chrome" component, factoring out the proven dock/edit-sheet mechanics (portal, transparent click-catcher backdrop, `height 0↔auto` clip pinned above the bottom bar *and* the owner edit action bar, Esc-to-close, `role="dialog"`). Compact (content-height) and fill sizes.
- **`useChromePanel`** — a coordinator owning the single open transient panel (`search | filter | info`), so opening one closes the others for free, and it folds the nav dock away on open (and vice versa) — one at a time across every bottom-chrome expansion.

**Migrations**
- Search: `SearchModal` → `SearchSheet`, unfurling a compact bar up from the search button instead of a centered modal. Info likewise (`InfoModal` → `InfoSheet`).
- Filter: the three filter hosts (home / posting / creating) now render in a `BottomSheet` driven by `useChromePanel`; `useFeedFilter` is trimmed to availability/registration only.
- `ChromeBar` drives search/filter/info via `togglePanel`; entering edit mode folds any open panel away.

## Verification

Exercised in a headless browser against the dev server:
- Search unfurls as a compact bar sitting on top of the bottom bar (expanding up, not centered), auto-focuses, and closes on Esc and backdrop click.
- Opening the nav dock closes search; opening info closes search — mutual exclusion confirmed.
- Filter opens the same way with its chip grid.
- Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRV2d3n36yZsqjXGoK4UT5)_