### PR TITLE
Typography + feed polish: drop caps, list markers, thread spacing, doc descriptions

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -176,6 +176,15 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
   padding-bottom: var(--space-2);
 }
 
+/* Pull a self-reply continuation up toward its parent. The feed list's
+   uniform space-5 gap is too airy for posts that belong to one thread, so
+   trim most of it back — the pair reads as a grouped conversation, not two
+   unrelated rows. (Flex `gap` can't be set per item, hence the negative
+   margin.) The parent already drops its bottom rule + padding above. */
+.feed-item-thread-continuation {
+  margin-top: calc(-1 * var(--space-4));
+}
+
 .feed-item-thread-continuation .feed-item-verb-thread {
   color: var(--ink-faint);
 }

--- a/src/components/LeafletDocument.css
+++ b/src/components/LeafletDocument.css
@@ -104,8 +104,33 @@
   padding-left: 1.5em;
 }
 
+/* Restore list markers — the global reset strips list-style from every
+   ul/ol, which left leaflet list blocks rendering as plain indented text.
+   The same class serves both ordered and unordered lists (see ListBlock). */
+ul.leaflet-list {
+  list-style: disc outside;
+}
+
+ol.leaflet-list {
+  list-style: decimal outside;
+}
+
+/* Vary the bullet by nesting depth the way browsers do by default. */
+ul.leaflet-list ul.leaflet-list {
+  list-style-type: circle;
+}
+
+ul.leaflet-list ul.leaflet-list ul.leaflet-list {
+  list-style-type: square;
+}
+
 .leaflet-list li {
+  display: list-item;
   margin-bottom: var(--space-2);
+}
+
+.leaflet-list li::marker {
+  color: var(--accent-soft);
 }
 
 /* Website / link card — visual cousin of post-embed-link-card. */

--- a/src/pages/About.css
+++ b/src/pages/About.css
@@ -89,13 +89,4 @@
   margin-top: var(--space-6);
 }
 
-.about-longform > p:first-of-type::first-letter {
-  font-family: var(--serif);
-  font-weight: 600;
-  font-size: 4.2em;
-  float: left;
-  line-height: 0.85;
-  padding-right: 0.08em;
-  padding-top: 0.12em;
-  color: var(--accent);
-}
+/* The first-paragraph drop cap is defined once, globally, in typography.css. */

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -142,7 +142,6 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
   const created = value.publishedAt || value.createdAt;
   const dayNum = created ? dayOfLife(created) : null;
   const title = value.title || id;
-  const description = value.description;
 
   return (
     <PageShell
@@ -163,7 +162,9 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
           {created && <span>· {relativeTime(created)}</span>}
           <span className="blog-article-tag">standard.site</span>
         </div>
-        {description && <p className="blog-article-description">{description}</p>}
+        {/* The `description` field is intentionally not rendered here — it's the
+            open-graph / feed-summary blurb, and on the post itself it just
+            duplicated the opening lines of the body. */}
         <LeafletDocument doc={value.content} />
         {commentsUri && (
           <Comments

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -169,17 +169,8 @@
   color: var(--accent-soft);
 }
 
-.blog-prose .first-paragraph::first-letter,
-.blog-prose > p:first-of-type::first-letter {
-  font-family: var(--serif);
-  font-weight: 600;
-  font-size: 4.2em;
-  float: left;
-  line-height: 0.85;
-  padding-right: 0.08em;
-  padding-top: 0.12em;
-  color: var(--accent);
-}
+/* The first-paragraph drop cap is defined once, globally, in
+   typography.css (shared with the resume summary and about page). */
 
 @media (max-width: 700px) {
   .blogging-toc-link {

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -112,14 +112,6 @@
   color: var(--accent);
 }
 
-.blog-article-description {
-  font-family: var(--serif);
-  font-size: var(--text-md);
-  font-style: italic;
-  color: var(--ink-soft);
-  margin: 0 0 var(--space-5);
-}
-
 .blog-prose {
   font-family: var(--serif);
   font-size: 1.05rem;

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -102,8 +102,11 @@ export default function CreatingWork() {
           )}
           {v?.createdAt && <span>· {formatDateLong(v.createdAt)}</span>}
         </div>
-        {(v?.summary || v?.description) && (
-          <p className="page-intro">{v.summary || v.description}</p>
+        {/* Only the legacy `summary` shows as an on-page intro. The standard.site
+            `description` is the open-graph / feed-summary blurb and isn't
+            rendered on the work itself. */}
+        {v?.summary && (
+          <p className="page-intro">{v.summary}</p>
         )}
         {v?.content?.pages ? (
           <LeafletDocument doc={v.content} />

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -111,15 +111,44 @@ blockquote {
   }
 }
 
-.dropcap::first-letter {
+/* Drop cap — the shared treatment behind every first-paragraph initial
+   letter (blog posts, the resume summary, the about page). Centralized here
+   so all three surfaces stay in lockstep.
+
+   `initial-letter` is the metric-correct tool for this: it sizes AND sinks
+   the letter to an exact number of line boxes — cap-height flush with the
+   first line's cap, baseline resting on the third line's baseline — so the
+   cap occupies the same visual height (three lines) at every viewport size,
+   independent of the serif's own proportions. A plain `font-size` float can't
+   promise that: its height is whatever the glyph's em box happens to be. */
+.dropcap::first-letter,
+.blog-prose > p:first-of-type::first-letter,
+.blog-prose .first-paragraph::first-letter,
+.about-longform > p:first-of-type::first-letter {
   font-family: var(--serif);
   font-weight: 600;
-  font-size: 4.2em;
-  float: left;
-  line-height: 0.85;
-  padding-right: 0.08em;
-  padding-top: 0.12em;
   color: var(--accent);
+  -webkit-initial-letter: 3;
+  initial-letter: 3;
+  /* Gap between the cap and the text that wraps around it. */
+  margin-right: 0.1em;
+}
+
+/* Firefox has no `initial-letter` support yet — approximate with the classic
+   float. Sized in `em` so it still scales with the paragraph text at every
+   breakpoint (just without the exact-line-count guarantee above). */
+@supports not ((initial-letter: 3) or (-webkit-initial-letter: 3)) {
+  .dropcap::first-letter,
+  .blog-prose > p:first-of-type::first-letter,
+  .blog-prose .first-paragraph::first-letter,
+  .about-longform > p:first-of-type::first-letter {
+    float: left;
+    font-size: 3.3em;
+    line-height: 0.82;
+    padding-top: 0.02em;
+    padding-right: 0.08em;
+    margin-right: 0;
+  }
 }
 
 .hairline {


### PR DESCRIPTION
Four small, independent polish fixes.

## Drop cap → exact three-line height
The first-paragraph drop cap (blog posts, resume summary, about) was an oversized `font-size` float, so its height was whatever the glyph's em box happened to be — it never lined up with a whole number of lines and drifted per viewport. Switched to the `initial-letter` property, which sizes **and** sinks the cap to exactly three line boxes (cap-height flush with line 1, baseline on line 3), identical at every screen size. Kept the float as a Firefox fallback, and de-duplicated the rule (it lived in three files) into `typography.css`.

## Leaflet document list markers
Unordered/ordered list blocks rendered as plain indented text — `.leaflet-list` set the indent but never restored `list-style`, so the global reset's `list-style: none` stripped the bullets/numbers. Restored accent-tinted disc/decimal markers, with disc → circle → square by nesting depth.

## Tighter thread-continuation spacing
Self-reply "continuing" rows sat a full `space-5` below their parent — the same gap as unrelated items — so a thread read as two separate rows. Pulled continuations up with a negative top margin (box gap 24px → 8px) so the pair groups as one conversation; unrelated items keep their full gap + hairline.

## Document description no longer shown on the page
The `description` on a `site.standard.document` is the open-graph / feed-summary blurb — on the post/work page it just duplicated the opening lines of the body. Removed it from `BlogPost`, and `CreatingWork` now shows only the legacy `summary` (not the standard.site `description`). Feeds/cards are unaffected.

## Verification
Each change exercised in a headless browser (drop cap at two widths, list markers incl. nesting, thread gap measured at 8px vs 24px). Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRV2d3n36yZsqjXGoK4UT5)_