### PR TITLE
Give the primary home CTA a same-hue darker border

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -234,16 +234,17 @@
 
 .home-hero-cta-primary {
   background: var(--accent);
-  /* Keep the same contrasting hairline every other button carries, rather
-     than a border the colour of the fill (which reads as borderless). */
-  border-color: var(--rule);
+  /* Border is a slightly darker shade of the fill itself (not a contrasting
+     tan hairline) so it reads as a soft edge on the same colour rather than
+     an outline in a different hue. Mixing toward black keeps it theme-aware. */
+  border-color: color-mix(in srgb, var(--accent) 80%, #000);
   color: var(--page);
 }
 
 .home-hero-cta-primary:hover,
 .home-hero-cta-primary:focus-visible {
   background: var(--accent-soft);
-  border-color: var(--rule);
+  border-color: color-mix(in srgb, var(--accent-soft) 80%, #000);
   color: var(--page);
 }
 


### PR DESCRIPTION
The filled "Browse Projects" CTA on the home hero carried the tan `--rule` hairline every other button uses, so its border read as a different colour outlining the green fill.

Make the border a slightly darker shade of the fill itself (`--accent` mixed toward black), in both the base and hover states, so it reads as a soft edge on the same colour. Mixing toward black keeps it theme-aware — dark mode's brighter accent gets a matching darker edge.

Verified in-browser: computed border resolves to `rgb(75, 98, 57)` against the `rgb(94, 122, 71)` fill; secondary buttons keep their tan hairline. Offline build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRV2d3n36yZsqjXGoK4UT5)_