### PR TITLE
Rename nav pages to fit the "Dame is…" framing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,7 @@ export default function App() {
               <div className="main">
                 <RouteTransition>
                   <Route path="/" element={<Home />} />
-                  <Route path="/about" element={<About />} />
+                  <Route path="/themself" element={<About />} />
                   <Route path="/posting" element={<Posting />} />
                   <Route path="/logging" element={<Logging />} />
                   <Route path="/listening" element={<Listening />} />
@@ -108,8 +108,8 @@ export default function App() {
                   <Route path="/creating/:slug" element={<CreatingWork />} />
                   <Route path="/curating" element={<Curating />} />
                   <Route path="/curating/:slug" element={<CuratingChannel />} />
-                  <Route path="/resume" element={<Resume />} />
-                  <Route path="/resume/:slug" element={<Resume />} />
+                  <Route path="/for-hire" element={<Resume />} />
+                  <Route path="/for-hire/:slug" element={<Resume />} />
                   <Route path="/sharing" element={<Sharing />} />
                   <Route path="/mothing" element={<Mothing />} />
                   {generatedRecordRoutes()}

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -9,13 +9,13 @@ import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
 
 const ROUTES = [
-  { to: '/', label: 'Home' },
-  { to: '/about', label: 'About' },
-  { to: '/blogging', label: 'Blogging' },
-  { to: '/creating', label: 'Creating' },
-  { to: '/curating', label: 'Curating' },
-  { to: '/mothing', label: 'Mothing' },
-  { to: '/resume', label: 'Resume' },
+  { to: '/', label: 'home' },
+  { to: '/themself', label: 'themself' },
+  { to: '/for-hire', label: 'for hire' },
+  { to: '/blogging', label: 'blogging' },
+  { to: '/creating', label: 'creating' },
+  { to: '/curating', label: 'curating' },
+  { to: '/mothing', label: 'mothing' },
 ];
 
 export default function ActionDock() {
@@ -117,7 +117,7 @@ export default function ActionDock() {
               transition={{ duration: reduce ? 0 : 0.18, ease: [0.22, 0.61, 0.36, 1] }}
             >
               <div className="dock-section">
-                <div className="dock-heading">Pages</div>
+                <div className="dock-heading">Dame is&hellip;</div>
                 <nav className="dock-routes">
                   {ROUTES.map((r) => (
                     <NavLink

--- a/src/hooks/useAtUri.js
+++ b/src/hooks/useAtUri.js
@@ -179,7 +179,7 @@ function deriveFromRoute(pathname, override) {
       route: pathname,
     };
   }
-  if (pathname === '/about') {
+  if (pathname === '/themself') {
     return {
       atUri: `at://${ME_DID}/${COLLECTIONS.profile}/self`,
       cid: null,

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -141,7 +141,7 @@ export const LEXICONS = {
 
   [COLLECTIONS.profile]: {
     label: 'About',
-    summary: 'The extended profile — a single record with rkey "self" that backs /about.',
+    summary: 'The extended profile — a single record with rkey "self" that backs /themself.',
     rkeyMode: 'fixed',
     rkeyPlaceholder: 'self',
     rkeyDefault: 'self',
@@ -247,7 +247,7 @@ export const LEXICONS = {
     typeFieldValue: COLLECTIONS.resume,
     fields: [
       { key: 'title', label: 'Title', type: 'text', required: true, placeholder: 'Primary résumé' },
-      { key: 'slug', label: 'Slug', type: 'text', required: true, hint: 'Should match the record key; drives /resume/<slug>.' },
+      { key: 'slug', label: 'Slug', type: 'text', required: true, hint: 'Should match the record key; drives /for-hire/<slug>.' },
       { key: 'headline', label: 'Headline', type: 'text' },
       { key: 'summary', label: 'Summary (Markdown)', type: 'markdown' },
       {
@@ -259,7 +259,7 @@ export const LEXICONS = {
           { value: 'private', label: 'Private — not rendered on the site' },
         ],
       },
-      { key: 'featured', label: 'Featured (default at /resume)', type: 'boolean', default: false },
+      { key: 'featured', label: 'Featured (default at /for-hire)', type: 'boolean', default: false },
       {
         key: 'entries', label: 'Entries (jobs)', type: 'json',
         hint: 'Array of { job: at-uri, highlightIds?: string[], titleOverride?, summaryOverride? }, in display order.',

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -73,8 +73,8 @@ export const PAGE_REGISTRY = {
   },
   resume: {
     slug: 'resume',
-    label: 'Resume',
-    title: 'Resume',
+    label: 'For hire',
+    title: 'For hire',
     intro: 'A decade of building social software, brands, and communities. Each entry backlinks to a job record on my PDS.',
     collection: null,
   },

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -27,7 +27,7 @@ export default function About() {
 
   return (
     <PageShell
-      headTitle="About — Dame is…"
+      headTitle="Themself — Dame is…"
       atUri={`at://${ME_DID}/is.dame.profile/self`}
     >
       <section className="about-card">

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -200,7 +200,7 @@ const PICKER_GROUPS = [
       { to: '/admin?view=pages', label: 'Site pages', nsid: COLLECTIONS.page,
         summary: 'Titles, intros, and page bodies — see which serve from the PDS vs local defaults, and edit the raw records.' },
       { collection: COLLECTIONS.profile, label: 'About',
-        summary: 'The extended profile (rkey "self") that backs /about.' },
+        summary: 'The extended profile (rkey "self") that backs /themself.' },
       { collection: COLLECTIONS.heroPhrase, label: 'Hero phrases',
         summary: 'Rotating phrases for the home hero sentence.' },
     ],

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -52,7 +52,7 @@ export default function Resume() {
 
   if (status === 'loading') {
     return (
-      <PageShell headTitle="Resume — Dame is…" atUri={`at://${ME_DID}/is.dame.page/resume`}>
+      <PageShell headTitle="For hire — Dame is…" atUri={`at://${ME_DID}/is.dame.page/resume`}>
         <p className="placeholder-card">Loading resume…</p>
       </PageShell>
     );
@@ -62,14 +62,14 @@ export default function Resume() {
     return (
       <PageShell
         title={pageTitle}
-        headTitle="Resume — Dame is…"
+        headTitle="For hire — Dame is…"
         atUri={`at://${ME_DID}/is.dame.page/resume`}
       >
         <p className="feed-empty">
           {slug ? (
             <>
               No resume version <code>{slug}</code>.{' '}
-              <Link to="/resume">See the default resume.</Link>
+              <Link to="/for-hire">See the default resume.</Link>
             </>
           ) : (
             'No resume published yet.'
@@ -84,7 +84,7 @@ export default function Resume() {
 
   return (
     <PageShell
-      headTitle={`${v.headline || pageTitle || 'Resume'} — Dame is…`}
+      headTitle={`${v.headline || pageTitle || 'For hire'} — Dame is…`}
       atUri={resolved.uri}
       cid={resolved.cid}
     >
@@ -92,7 +92,7 @@ export default function Resume() {
         <header className="resume-header">
           <div className="resume-headline-row">
             <div>
-              <h1 className="resume-title">{pageTitle || 'Resume'}</h1>
+              <h1 className="resume-title">{pageTitle || 'For hire'}</h1>
               {v.headline && <p className="resume-headline">{v.headline}</p>}
             </div>
             <button
@@ -134,7 +134,7 @@ export default function Resume() {
                 return (
                   <Link
                     key={r.uri}
-                    to={`/resume/${s}`}
+                    to={`/for-hire/${s}`}
                     className={`resume-version-chip ${active ? 'is-active' : ''}`}
                     aria-current={active ? 'page' : undefined}
                   >

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
   "redirects": [
     { "source": "/index", "destination": "/", "permanent": true },
     { "source": "/home", "destination": "/", "permanent": true },
+    { "source": "/about", "destination": "/themself", "permanent": true },
+    { "source": "/resume", "destination": "/for-hire", "permanent": true },
+    { "source": "/resume/:path*", "destination": "/for-hire/:path*", "permanent": true },
+    { "source": "/work", "destination": "/for-hire", "permanent": true },
     { "source": "/blog", "destination": "/blogging", "permanent": true },
     { "source": "/blog/:path*", "destination": "/blogging/:path*", "permanent": true },
     { "source": "/writing/blogs", "destination": "/blogging", "permanent": true },


### PR DESCRIPTION
Renames the site-menu pages so the nav reads as the sentence **"Dame is…"** and adds redirects so old URLs keep working.

## Nav menu

| Label | Path | Notes |
|-------|------|-------|
| home | `/` | unchanged |
| **themself** | `/themself` | was About |
| **for hire** | `/for-hire` | was Resume; now sits directly under *themself* |
| blogging | `/blogging` | |
| creating | `/creating` | |
| curating | `/curating` | |
| mothing | `/mothing` | |

- Menu heading `Pages` → `Dame is…`
- All nav labels lowercased so the menu reads as one continuous sentence
- Redirects added: `/about → /themself`; `/resume`, `/resume/:path*`, `/work → /for-hire`

## Scope notes

- Backend record keys are unchanged — the resume page is still backed by `is.dame.page/resume` and the `is.dame.resume.*` collections. Only the URL routes and display labels changed.
- Updated head titles, internal links, and admin hint strings to match the new paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiwhZ6tey8qXtXsbikpmw2)_