### PR TITLE
Footer + drop-cap polish: drop the fleuron, widen the cap gutter

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -21,11 +21,6 @@
   color: var(--ink-muted);
 }
 
-.page-footer-mark {
-  color: var(--accent-soft);
-  font-size: 1rem;
-}
-
 .page-footer-meta {
   font-size: var(--text-xs);
   color: var(--ink-faint);

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,6 @@ export default function Footer() {
   return (
     <footer className="page-footer" role="contentinfo">
       <div className="page-footer-inner">
-        <span className="page-footer-mark">&#x2767;</span>
         <RecordTimestamp />
         <span className="page-footer-meta">
           <span className="small-caps">Published on the AT Protocol</span>

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -131,7 +131,7 @@ blockquote {
   -webkit-initial-letter: 3;
   initial-letter: 3;
   /* Gap between the cap and the text that wraps around it. */
-  margin-right: 0.1em;
+  margin-right: 0.18em;
 }
 
 /* Firefox has no `initial-letter` support yet — approximate with the classic
@@ -146,7 +146,7 @@ blockquote {
     font-size: 3.3em;
     line-height: 0.82;
     padding-top: 0.02em;
-    padding-right: 0.08em;
+    padding-right: 0.12em;
     margin-right: 0;
   }
 }


### PR DESCRIPTION
Two small polish tweaks.

## Footer
Removed the ❧ fleuron glyph (and its `.page-footer-mark` style) to reclaim space in the footer. The record timestamp and "Published on the AT Protocol" meta still sit at each end of the `space-between` row.

## Drop cap
Bumped the initial-letter's right-hand gutter (`margin-right` 0.1em → 0.18em, and the Firefox float fallback's `padding-right` to match) so the wrapped lines clear the cap with a bit more breathing room. Verified in a headless browser.

Offline build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRV2d3n36yZsqjXGoK4UT5)_