### PR TITLE
Use dynamic colors for reliable dark/light, add theme override

### DIFF
--- a/scripts/scriptable/README.md
+++ b/scripts/scriptable/README.md
@@ -39,6 +39,7 @@ In **Edit Widget → Parameter**, pass `key=value` pairs separated by `;`:
 | `did` | `did:plc:gq4fo3u6tqzzdkjlwzpb23tj` | The repo (DID) whose `now` records to read. |
 | `count` | `4` | How many updates to show (medium/large). |
 | `site` | `https://dame.is` | Home page a tap opens. |
+| `theme` | `auto` | `auto` tracks system light/dark; force with `light` or `dark`. |
 | `shortcut` | *(none)* | Name of an Apple Shortcut to run on tap instead of opening `site`. |
 | `post` | *(off)* | Set `post=1` to show a "＋ new" button that posts a new status. |
 

--- a/scripts/scriptable/dame-now-widget.js
+++ b/scripts/scriptable/dame-now-widget.js
@@ -40,6 +40,9 @@ const DEFAULTS = {
   collection: 'is.dame.now',
   count: 4, // how many recent updates to show in medium/large widgets
   site: 'https://dame.is', // tapping opens here (record page when possible)
+  // 'auto' (default) tracks the system light/dark appearance; force it with
+  // theme=light or theme=dark.
+  theme: '',
   // Optional: name of an Apple Shortcut to run on tap instead of opening the
   // site. When set, the latest status text is passed as the shortcut's input.
   shortcut: '',
@@ -130,7 +133,24 @@ function parseParams(raw) {
 }
 
 const cfg = parseParams(args.widgetParameter);
-const theme = Device.isUsingDarkAppearance() ? THEMES.dark : THEMES.light;
+
+// Build the active palette. `Device.isUsingDarkAppearance()` is unreliable in
+// the widget process (it's read once and cached, so the home-screen widget
+// won't re-theme when the system flips), so for 'auto' we hand each color to
+// `Color.dynamic(light, dark)` and let iOS pick per appearance at render time.
+// theme=light / theme=dark force a fixed palette.
+function buildTheme() {
+  const { light, dark } = THEMES;
+  if (cfg.theme === 'light') return light;
+  if (cfg.theme === 'dark') return dark;
+  const out = {};
+  for (const key of Object.keys(light)) {
+    out[key] = Color.dynamic(light[key], dark[key]);
+  }
+  return out;
+}
+
+const theme = buildTheme();
 const postEnabled = cfg.post && cfg.post !== '0' && cfg.post !== 'false';
 
 // URL that re-runs this script inside the Scriptable app in "post" mode. Uses


### PR DESCRIPTION
Follow-up to #105.

- **Auto dark/light fix:** `Device.isUsingDarkAppearance()` is read once and cached in the widget process, so the home-screen widget didn't re-theme when the system appearance flipped. Each color is now built with `Color.dynamic(light, dark)` so iOS picks the right one per appearance at render time.
- **Manual override:** new `theme` parameter — `auto` (default) tracks the system, `light` / `dark` force a fixed palette.

## Files

- `scripts/scriptable/dame-now-widget.js`
- `scripts/scriptable/README.md` — documents the `theme` option.

## Verification

`node --check` passes. Rendering is iOS-only; verify by toggling system appearance with the widget on the home screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPdiU3WhjZfTVVGAtpFim)_