### PR TITLE
Add listening stats dashboard and restore nav link

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -14,6 +14,7 @@ const ROUTES = [
   { to: '/for-hire', label: 'for hire' },
   { to: '/blogging', label: 'blogging' },
   { to: '/creating', label: 'creating' },
+  { to: '/listening', label: 'listening' },
   { to: '/curating', label: 'curating' },
   { to: '/mothing', label: 'mothing' },
 ];

--- a/src/components/ListeningStats.css
+++ b/src/components/ListeningStats.css
@@ -1,0 +1,258 @@
+/* Listening stats dashboard — the rich header on /listening.
+   Flat, ruled, serif; leans on the same tan rules + mossy accent as the
+   rest of the site. No border-radius (the theme pins --radius-* to 0). */
+
+.listen-stats {
+  margin-bottom: var(--space-7);
+  padding-bottom: var(--space-5);
+  border-bottom: 1px solid var(--rule);
+}
+
+.listen-stats-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-5);
+}
+
+.listen-stats-title {
+  font-family: var(--serif);
+  font-size: var(--text-xl);
+  margin: 0;
+  color: var(--ink);
+}
+
+/* Segmented 7 / 30 toggle. */
+.listen-stats-toggle {
+  display: inline-flex;
+  border: 1px solid var(--rule);
+}
+
+.listen-stats-tab {
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.1em;
+  font-size: var(--text-xs);
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  border: 0;
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.listen-stats-tab + .listen-stats-tab {
+  border-left: 1px solid var(--rule);
+}
+
+.listen-stats-tab:hover {
+  color: var(--ink);
+}
+
+.listen-stats-tab.is-active {
+  background: var(--accent);
+  color: var(--page);
+}
+
+.listen-stats-empty {
+  color: var(--ink-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ---- Headline tiles ---------------------------------------------- */
+
+.listen-stats-tiles {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  margin-bottom: var(--space-6);
+}
+
+.listen-stat-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.15rem;
+  padding: var(--space-4) var(--space-2);
+  background: var(--bg);
+  text-align: center;
+  min-width: 0;
+}
+
+.listen-stat-value {
+  font-family: var(--serif);
+  font-size: var(--text-2xl);
+  line-height: 1;
+  font-weight: 600;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.listen-stat-label {
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.12em;
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+}
+
+.listen-stat-sub {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+}
+
+/* ---- Ranked lists ------------------------------------------------ */
+
+.listen-stats-cols {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-5);
+}
+
+.listen-rank {
+  min-width: 0;
+}
+
+.listen-rank-title {
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.listen-rank-empty {
+  color: var(--ink-faint);
+  margin: 0;
+}
+
+.listen-rank-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.listen-rank-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.listen-rank-num {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  width: 1.1rem;
+  flex: 0 0 auto;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.listen-rank-cover {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  object-fit: cover;
+  background: var(--rule-soft);
+  border: 1px solid var(--rule-soft);
+}
+
+.listen-rank-cover-empty {
+  background: linear-gradient(135deg, var(--rule-soft), var(--surface-raised));
+}
+
+.listen-rank-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+  line-height: var(--leading-tight);
+}
+
+.listen-rank-primary {
+  display: block;
+  max-width: 100%;
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* When the label is a link (tracks / artists / albums), the anchor is the
+   flex item — give it min-width:0 so the primary span can ellipsis-clip
+   instead of shoving the play count off the row. */
+.listen-rank-text a {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+}
+
+.listen-rank-text a:hover .listen-rank-primary,
+.listen-rank-text a:focus-visible .listen-rank-primary {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: var(--accent-soft);
+}
+
+.listen-rank-secondary {
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.listen-rank-count {
+  flex: 0 0 auto;
+  font-family: var(--mono-ui);
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.listen-rank-count-unit {
+  color: var(--ink-faint);
+  margin-left: 0.05rem;
+}
+
+/* ---- Responsive -------------------------------------------------- */
+
+@media (max-width: 720px) {
+  .listen-stats-cols {
+    grid-template-columns: 1fr;
+    gap: var(--space-5);
+  }
+}
+
+@media (max-width: 560px) {
+  /* Tiles reflow to a tidy 2-across (last one spans the row) so the big
+     numbers stay legible on phones instead of shrinking to nothing. */
+  .listen-stats-tiles {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .listen-stat-tile:last-child {
+    grid-column: 1 / -1;
+  }
+  .listen-stat-value {
+    font-size: var(--text-xl);
+  }
+}

--- a/src/components/ListeningStats.jsx
+++ b/src/components/ListeningStats.jsx
@@ -1,0 +1,293 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useReducedMotion } from 'motion/react';
+import { useAlbumArt } from '../hooks/useAlbumArt.js';
+import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import './ListeningStats.css';
+
+/**
+ * Rich stats header for the /listening page. Rolls the recently-played
+ * feed into a dashboard: headline counts (plays, minutes, unique tracks /
+ * artists / albums) plus ranked "top" lists over a selectable 7- or 30-day
+ * window. Everything is derived on the client from the same play records
+ * the feed below already loads — no extra fetch.
+ */
+
+const WINDOWS = [
+  { days: 7, label: '7 days' },
+  { days: 30, label: '30 days' },
+];
+
+const TOP_N = 6;
+
+export default function ListeningStats({ items }) {
+  const [days, setDays] = useState(7);
+  const stats = useMemo(() => computeStats(items, days), [items, days]);
+
+  // Nothing loaded yet — let the page's own skeleton carry the wait.
+  if (!items || items.length === 0) return null;
+
+  return (
+    <section className="listen-stats" aria-label="Listening statistics">
+      <div className="listen-stats-head">
+        <h2 className="listen-stats-title">Recent listening</h2>
+        <div className="listen-stats-toggle" role="tablist" aria-label="Time window">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.days}
+              type="button"
+              role="tab"
+              aria-selected={days === w.days}
+              className={`listen-stats-tab ${days === w.days ? 'is-active' : ''}`}
+              onClick={() => setDays(w.days)}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {stats.totalPlays === 0 ? (
+        <p className="listen-stats-empty">No plays in the last {days} days.</p>
+      ) : (
+        <>
+          <div className="listen-stats-tiles">
+            <Tile value={stats.totalPlays} label={stats.totalPlays === 1 ? 'play' : 'plays'} />
+            <Tile value={stats.minutes} label="minutes" sub={stats.hoursSub} />
+            <Tile value={stats.uniqueTracks} label={stats.uniqueTracks === 1 ? 'track' : 'tracks'} />
+            <Tile value={stats.uniqueArtists} label={stats.uniqueArtists === 1 ? 'artist' : 'artists'} />
+            <Tile value={stats.uniqueAlbums} label={stats.uniqueAlbums === 1 ? 'album' : 'albums'} />
+          </div>
+
+          <div className="listen-stats-cols">
+            <RankList title="Top tracks" rows={stats.topTracks} kind="track" />
+            <RankList title="Top artists" rows={stats.topArtists} kind="artist" />
+            <RankList title="Top albums" rows={stats.topAlbums} kind="album" />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Tiles                                                               */
+/* ------------------------------------------------------------------ */
+
+function Tile({ value, label, sub }) {
+  const n = useCountUp(value);
+  return (
+    <div className="listen-stat-tile">
+      <span className="listen-stat-value">{n.toLocaleString()}</span>
+      <span className="listen-stat-label">{label}</span>
+      {sub && <span className="listen-stat-sub">{sub}</span>}
+    </div>
+  );
+}
+
+/**
+ * Short eased count-up whenever the target changes (e.g. toggling the
+ * window). Mirrors ProfileStats' animation; respects reduced-motion by
+ * snapping straight to the value.
+ */
+function useCountUp(target, ms = 650) {
+  const reduce = useReducedMotion();
+  const [n, setN] = useState(typeof target === 'number' ? target : 0);
+  const fromRef = useRef(0);
+  const startRef = useRef(0);
+  const rafRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof target !== 'number') return undefined;
+    if (reduce) {
+      setN(target);
+      return undefined;
+    }
+    cancelAnimationFrame(rafRef.current);
+    fromRef.current = n;
+    startRef.current = performance.now();
+    function tick(t) {
+      const p = Math.min(1, (t - startRef.current) / ms);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setN(Math.round(fromRef.current + (target - fromRef.current) * eased));
+      if (p < 1) rafRef.current = requestAnimationFrame(tick);
+    }
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target, ms, reduce]);
+
+  return reduce && typeof target === 'number' ? target : n;
+}
+
+/* ------------------------------------------------------------------ */
+/* Ranked lists                                                        */
+/* ------------------------------------------------------------------ */
+
+function RankList({ title, rows, kind }) {
+  return (
+    <div className="listen-rank">
+      <h3 className="listen-rank-title">{title}</h3>
+      {rows.length === 0 ? (
+        <p className="listen-rank-empty">—</p>
+      ) : (
+        <ol className="listen-rank-list">
+          {rows.map((row, i) => (
+            <li key={row.key} className="listen-rank-row">
+              <span className="listen-rank-num" aria-hidden="true">
+                {i + 1}
+              </span>
+              {kind !== 'artist' && <Cover payload={row.sample} />}
+              <span className="listen-rank-text">
+                <RankLabel row={row} kind={kind} />
+                {row.secondary && <span className="listen-rank-secondary">{row.secondary}</span>}
+              </span>
+              <span className="listen-rank-count" title={`${row.count} plays`}>
+                {row.count}
+                <span className="listen-rank-count-unit">×</span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function RankLabel({ row, kind }) {
+  const inner = <span className="listen-rank-primary">{row.primary}</span>;
+  if (kind === 'track' && row.href) {
+    return <Link to={row.href}>{inner}</Link>;
+  }
+  if ((kind === 'artist' || kind === 'album') && row.query) {
+    return <Link to={`/listening?q=${encodeURIComponent(row.query)}`}>{inner}</Link>;
+  }
+  return inner;
+}
+
+/** Small album-art thumbnail, resolved lazily from the sample play. */
+function Cover({ payload }) {
+  const state = useAlbumArt(payload, { size: 100 });
+  const url = state.status === 'hit' ? state.art?.thumbUrl : null;
+  if (url) {
+    return <img className="listen-rank-cover" src={url} alt="" loading="lazy" decoding="async" />;
+  }
+  return <span className="listen-rank-cover listen-rank-cover-empty" aria-hidden="true" />;
+}
+
+/* ------------------------------------------------------------------ */
+/* Aggregation                                                         */
+/* ------------------------------------------------------------------ */
+
+function computeStats(items, days) {
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+  const tracks = new Map();
+  const artists = new Map();
+  const albums = new Map();
+  let totalPlays = 0;
+  let totalSeconds = 0;
+
+  for (const it of items || []) {
+    const p = it?.payload;
+    if (!p) continue;
+    const t = Date.parse(it.createdAt || p.playedTime || '');
+    if (!Number.isFinite(t) || t < cutoff) continue;
+
+    totalPlays += 1;
+    const dur = Number(p.duration);
+    if (Number.isFinite(dur) && dur > 0) totalSeconds += dur;
+
+    // Everything is keyed by the *displayed* text identity, not the
+    // MusicBrainz IDs: those come and go play-to-play (the same track can
+    // carry a recordingMbId on one scrobble and none on the next), which
+    // would split one song/artist/album into two identical-looking rows.
+    // Grouping on what the reader sees also matches how listeners count
+    // ("I played this song N times" regardless of which release it was).
+    const artistLine = artistNames(p);
+
+    // Track — title + primary artist.
+    if (p.trackName || p.track) {
+      const tKey = `${lower(p.trackName || p.track)}|${lower(firstArtistName(p))}`;
+      bump(tracks, tKey, () => ({
+        primary: p.trackName || p.track || '—',
+        secondary: artistLine,
+        sample: p,
+        href: recordPathFromAtUri(it.atUri),
+        query: p.trackName || p.track || '',
+      }));
+    }
+
+    // Artists — credit every credited artist on the play.
+    for (const a of artistList(p)) {
+      if (!a?.artistName) continue;
+      bump(artists, lower(a.artistName), () => ({ primary: a.artistName, query: a.artistName }));
+    }
+
+    // Album / release — title + primary artist (same-named albums by
+    // different artists stay distinct).
+    if (p.releaseName) {
+      const alKey = `${lower(p.releaseName)}|${lower(firstArtistName(p))}`;
+      bump(albums, alKey, () => ({
+        primary: p.releaseName,
+        secondary: firstArtistName(p),
+        sample: p,
+        query: p.releaseName,
+      }));
+    }
+  }
+
+  const minutes = Math.round(totalSeconds / 60);
+  const hours = totalSeconds / 3600;
+
+  return {
+    totalPlays,
+    minutes,
+    hoursSub: hours >= 1 ? `≈ ${hours.toFixed(hours >= 10 ? 0 : 1)} hrs` : null,
+    uniqueTracks: tracks.size,
+    uniqueArtists: artists.size,
+    uniqueAlbums: albums.size,
+    topTracks: topN(tracks),
+    topArtists: topN(artists),
+    topAlbums: topN(albums),
+  };
+}
+
+/** Increment a keyed counter, capturing display metadata on first sight. */
+function bump(map, key, makeMeta) {
+  const existing = map.get(key);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    map.set(key, { key, count: 1, ...makeMeta() });
+  }
+}
+
+/** Sort a counter map by play count (ties broken alphabetically) and cap. */
+function topN(map, n = TOP_N) {
+  return Array.from(map.values())
+    .sort((a, b) => b.count - a.count || String(a.primary).localeCompare(String(b.primary)))
+    .slice(0, n);
+}
+
+function artistList(payload) {
+  if (Array.isArray(payload?.artists)) return payload.artists;
+  if (payload?.artist) return [{ artistName: payload.artist }];
+  return [];
+}
+
+function firstArtistName(payload) {
+  const list = artistList(payload);
+  return list[0]?.artistName || '';
+}
+
+function artistNames(payload) {
+  return artistList(payload)
+    .map((a) => a?.artistName)
+    .filter(Boolean)
+    .join(', ');
+}
+
+function lower(s) {
+  return String(s || '').toLowerCase();
+}

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
+import ListeningStats from '../components/ListeningStats.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
@@ -24,7 +25,7 @@ export default function Listening() {
     strategy: 'live-first',
     fetchLive: async () => {
       const pds = await resolvePds(ME_DID);
-      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.listen, max: 500 });
+      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.listen, max: 1000 });
     },
     mapItems: toListeningItems,
   });
@@ -32,6 +33,12 @@ export default function Listening() {
   const { removedUris } = useEditMode();
   const loading = status === 'loading';
   const safeItems = items || [];
+  // Stats reflect all listening (minus any owner-removed plays), independent
+  // of the feed's text search below.
+  const statsItems = useMemo(
+    () => safeItems.filter((i) => !removedUris.has(i.atUri)),
+    [safeItems, removedUris],
+  );
   const filtered = useMemo(
     () =>
       safeItems.filter((i) => {
@@ -61,6 +68,7 @@ export default function Listening() {
       atUri={`at://${ME_DID}/is.dame.page/listening`}
       headTitle="Listening — Dame is&hellip;"
     >
+      {!loading && statsItems.length > 0 && <ListeningStats items={statsItems} />}
       {loading ? (
         <FeedSkeleton rows={6} label="Loading plays" />
       ) : status === 'error' ? (


### PR DESCRIPTION
Adds a rich stats header to the `/listening` page and restores the `listening` link to the site nav menu.

## Stats dashboard
A new `ListeningStats` component rolls the play feed into a dashboard over a selectable **7- or 30-day** window:

- **Headline tiles**: total plays, minutes listened (with an `≈ X hrs` readout), and unique tracks / artists / albums — each with a short count-up animation.
- **Ranked lists**: Top tracks, Top artists, Top albums, with play counts and lazy-loaded album-art thumbnails. Track titles link to their record page; artists and albums link into the feed's text search so a click filters the plays below.

It's derived entirely on the client from the play records the feed already loads (no extra fetch), and dedupes on **displayed text identity** rather than MusicBrainz IDs — those are inconsistently present across scrobbles, which otherwise splits one track/artist/album into two identical-looking rows.

## Other changes
- Restore `listening` to the nav menu (`ActionDock`).
- Bump the listening fetch 500 → 1000 records so the 30-day window is complete.

## Verification
Rendered against 100 real play records in light, dark, and mobile layouts. Aggregation verified (e.g. 79 plays / 253 min / 60 tracks over 7 days); ellipsis truncation and mobile reflow confirmed; the MusicBrainz-ID dedup split was caught and fixed during this pass. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT51QQYZwBKXwzU54zYMhS)_