### PR TITLE
Add ruled/dot-grid paper textures behind long-form text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import { ActionDockProvider } from './hooks/useActionDock.jsx';
 import { ChromePanelProvider } from './hooks/useChromePanel.jsx';
 import { ThemeProvider } from './hooks/useTheme.jsx';
 import { DensityProvider } from './hooks/useDensity.jsx';
+import { PaperProvider } from './hooks/usePaper.jsx';
 import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
 import { FeedFilterProvider } from './hooks/useFeedFilter.jsx';
 import { AtprotoSessionProvider } from './hooks/useAtprotoSession.jsx';
@@ -84,6 +85,7 @@ export default function App() {
   return (
     <ThemeProvider>
       <DensityProvider>
+      <PaperProvider>
       <ChromeBarProvider>
       <AtprotoSessionProvider>
       <FeedFilterProvider>
@@ -161,6 +163,7 @@ export default function App() {
       </FeedFilterProvider>
       </AtprotoSessionProvider>
       </ChromeBarProvider>
+      </PaperProvider>
       </DensityProvider>
     </ThemeProvider>
   );

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -15,6 +15,7 @@ import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
 import DensityToggle from './DensityToggle.jsx';
+import PaperToggle from './PaperToggle.jsx';
 import SearchSheet from './SearchSheet.jsx';
 import InfoSheet from './InfoSheet.jsx';
 import './ChromeBar.css';
@@ -344,6 +345,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
               >
                 <DensityToggle />
+                <PaperToggle />
                 <button
                   type="button"
                   className={`chrome-nav chrome-tool-debug ${view === 'debug' ? 'is-open' : ''}`}

--- a/src/components/PaperToggle.jsx
+++ b/src/components/PaperToggle.jsx
@@ -1,0 +1,32 @@
+import { AlignJustify, Grip, Square } from 'lucide-react';
+import { usePaper } from '../hooks/usePaper.jsx';
+
+// Per-mode glyph + label for the cycling paper-texture button.
+//   blank → empty square, ruled → horizontal lines, dots → dot grid.
+const PAPER = {
+  blank: { Icon: Square, label: 'blank page' },
+  ruled: { Icon: AlignJustify, label: 'ruled lines' },
+  dots: { Icon: Grip, label: 'dot grid' },
+};
+
+const NEXT_LABEL = {
+  blank: 'ruled lines',
+  ruled: 'dot grid',
+  dots: 'blank page',
+};
+
+export default function PaperToggle() {
+  const { paper, cycle } = usePaper();
+  const { Icon, label } = PAPER[paper] || PAPER.blank;
+  return (
+    <button
+      type="button"
+      className="chrome-nav chrome-paper-toggle"
+      onClick={cycle}
+      aria-label={`Paper: ${label} — tap for ${NEXT_LABEL[paper] || 'blank page'}`}
+      title={`Paper: ${label} — tap to switch`}
+    >
+      <Icon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+    </button>
+  );
+}

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Repeat2 } from 'lucide-react';
 import { relativeTime } from '../lib/time.js';
@@ -5,8 +6,40 @@ import { rkeyFromAtUri } from '../lib/atproto.js';
 import { ME_DID } from '../config.js';
 import { renderPostText } from '../lib/postRichText.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
+import { usePaper } from '../hooks/usePaper.jsx';
 import PostEmbed from './PostEmbed.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
+
+/**
+ * Flags a text element with `data-multiline` when it wraps to more than one
+ * line, so the ruled/dot paper texture only paints behind posts long enough
+ * to read as lined paper (a lone rule under a one-line status looks like a
+ * stray underline). Inert while paper is 'blank' — no observers, no attr.
+ */
+function useMultilineFlag(enabled, text) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    if (!enabled) {
+      el.removeAttribute('data-multiline');
+      return undefined;
+    }
+    const measure = () => {
+      const lh = parseFloat(getComputedStyle(el).lineHeight);
+      const multiline = Number.isFinite(lh)
+        ? el.offsetHeight > lh * 1.5
+        : el.getClientRects().length > 1;
+      if (multiline) el.setAttribute('data-multiline', 'true');
+      else el.removeAttribute('data-multiline');
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [enabled, text]);
+  return ref;
+}
 
 /**
  * True when a post has no text body and no foreign-author header, so its
@@ -63,6 +96,9 @@ export default function PostCard({
   // is stripped — this row is what stays visible.
   const showStandaloneTime = !text && !showOriginalAuthor && ts && variant !== 'record';
 
+  const { paper } = usePaper();
+  const textRef = useMultilineFlag(paper !== 'blank' && Boolean(text), text);
+
   return (
     <article
       className={`post-card feed-card post-card-${variant}`}
@@ -98,7 +134,7 @@ export default function PostCard({
       )}
       {text && (
         <div className="post-card-row">
-          <p className="post-card-text">{renderPostText(text, facets)}</p>
+          <p className="post-card-text" ref={textRef}>{renderPostText(text, facets)}</p>
           {ts && variant !== 'record' && (
             recordHref ? (
               <Link className="gutter post-card-time" to={recordHref}>

--- a/src/hooks/usePaper.jsx
+++ b/src/hooks/usePaper.jsx
@@ -1,0 +1,57 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const PaperContext = createContext(null);
+const STORAGE_KEY = 'dame.paper';
+
+// Three paper textures painted faintly behind long-form text content
+// (multiline feed posts, blog/document prose):
+//   - blank : no texture, a clean page (the default)
+//   - ruled : very faint horizontal rules, like ruled-lined paper
+//   - dots  : a very faint dot grid
+const VALID = ['blank', 'ruled', 'dots'];
+const DEFAULT = 'blank';
+
+function applyPaper(paper) {
+  document.documentElement.setAttribute('data-paper', paper);
+}
+
+function readInitial() {
+  if (typeof localStorage === 'undefined') return DEFAULT;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return VALID.includes(stored) ? stored : DEFAULT;
+}
+
+export function PaperProvider({ children }) {
+  const [paper, setPaperState] = useState(readInitial);
+
+  useEffect(() => {
+    applyPaper(paper);
+    try {
+      localStorage.setItem(STORAGE_KEY, paper);
+    } catch {}
+  }, [paper]);
+
+  const setPaper = useCallback((next) => {
+    if (!VALID.includes(next)) return;
+    setPaperState(next);
+  }, []);
+
+  const cycle = useCallback(() => {
+    setPaperState((prev) => {
+      const idx = VALID.indexOf(prev);
+      return VALID[(idx + 1) % VALID.length];
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ paper, setPaper, cycle, options: VALID }),
+    [paper, setPaper, cycle],
+  );
+  return <PaperContext.Provider value={value}>{children}</PaperContext.Provider>;
+}
+
+export function usePaper() {
+  const ctx = useContext(PaperContext);
+  if (!ctx) throw new Error('usePaper must be used inside <PaperProvider>');
+  return ctx;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import './styles/reset.css';
 import './styles/theme.css';
 import './styles/typography.css';
 import './styles/app.css';
+import './styles/paper.css';
 
 // Theme selection happens here (before React mounts) so the first
 // paint is in the correct palette. Two themes; retired monochrome
@@ -40,6 +41,13 @@ if (!VALID_DENSITY.includes(storedDensity)) {
   storedDensity = legacyCompact === 'true' ? 'compact' : 'normal';
 }
 document.documentElement.setAttribute('data-density', storedDensity);
+
+// Paper texture behind long-form text (blank / ruled / dots). Set before
+// the first paint so ruled/dots users don't flash a blank page. Keep in
+// sync with usePaper.jsx.
+const VALID_PAPER = ['blank', 'ruled', 'dots'];
+const storedPaper = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.paper') : null;
+document.documentElement.setAttribute('data-paper', VALID_PAPER.includes(storedPaper) ? storedPaper : 'blank');
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -1,0 +1,78 @@
+/* Faint "paper" textures painted behind long-form text content.
+   Driven by the `data-paper` attribute on <html> (see usePaper.jsx):
+   blank (default, nothing), ruled (horizontal rules), dots (dot grid).
+
+   The rhythm is tied to each target's own line-height so the rules/dots
+   line up with the text baselines: one horizontal band per text line.
+   `--paper-lh` carries that line-height (unitless), and the band period
+   is `calc(1em * var(--paper-lh))` — 1em resolves against the target's
+   own font-size, so the period always equals one rendered line box
+   regardless of font-size or density.
+
+   `--paper-baseline` phases the pattern down so a rule falls just under
+   each line's baseline (text sits *on* the line, like ruled paper). */
+
+:root,
+[data-theme='light'] {
+  /* Kept intentionally near-invisible — a texture you feel more than see. */
+  --paper-rule: rgba(29, 36, 25, 0.07);
+  --paper-dot:  rgba(29, 36, 25, 0.10);
+}
+
+[data-theme='dark'] {
+  --paper-rule: rgba(236, 228, 203, 0.055);
+  --paper-dot:  rgba(236, 228, 203, 0.08);
+}
+
+/* Targets. Default line-height rhythm is the body leading; the tight
+   density re-tunes feed post text to the tighter leading so its rules
+   still track each (shorter) line. Documents/blog prose use their own
+   fixed 1.6 leading (see LeafletDocument.css). */
+[data-paper='ruled'] .post-card-text,
+[data-paper='dots'] .post-card-text,
+[data-paper='ruled'] .leaflet-paragraph,
+[data-paper='dots'] .leaflet-paragraph {
+  --paper-lh: var(--leading);
+  --paper-baseline: 1.12em; /* ~baseline within a 1.6 line box */
+}
+
+/* `data-paper` and `data-density` both live on <html>, so this must be a
+   compound (same-element) selector, not a descendant combinator. */
+[data-paper='ruled'][data-density='tight'] .post-card-text,
+[data-paper='dots'][data-density='tight'] .post-card-text {
+  --paper-lh: var(--leading-tight);
+  --paper-baseline: 0.98em; /* baseline within the tighter 1.3 line box */
+}
+
+/* ── Ruled ─────────────────────────────────────────────────────────
+   A 1px rule at the top of each period, phased down by --paper-baseline
+   so it lands under the text baseline. Only painted on multiline feed
+   posts (see PostCard's data-multiline gate) so short single-line
+   statuses don't pick up a lone underline. Document/blog paragraphs are
+   always eligible. */
+[data-paper='ruled'] .post-card-text[data-multiline],
+[data-paper='ruled'] .leaflet-paragraph {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    var(--paper-rule) 0,
+    var(--paper-rule) 1px,
+    transparent 1px,
+    transparent calc(1em * var(--paper-lh))
+  );
+  background-position: 0 var(--paper-baseline);
+  background-origin: content-box;
+}
+
+/* ── Dots ──────────────────────────────────────────────────────────
+   Same row rhythm as the rules, with a matching column pitch so the
+   grid reads as square-ish. Dots sit on the baseline rows. */
+[data-paper='dots'] .post-card-text[data-multiline],
+[data-paper='dots'] .leaflet-paragraph {
+  background-image: radial-gradient(
+    var(--paper-dot) 0.85px,
+    transparent 1.4px
+  );
+  background-size: calc(1em * var(--paper-lh)) calc(1em * var(--paper-lh));
+  background-position: 0.2em var(--paper-baseline);
+  background-origin: content-box;
+}


### PR DESCRIPTION
Introduce a **paper** setting (blank / ruled / dots) that paints an incredibly faint background texture behind long-form text content so it reads like ruled-lined or dot-grid paper.

## What changed

- **`usePaper` hook + `PaperProvider`** persist the choice to `localStorage` (`dame.paper`) and drive a `data-paper` attribute on `<html>`, mirroring the existing theme/density pattern. `main.jsx` sets it before first paint so ruled/dots users don't flash a blank page.
- **A cycling `PaperToggle` button** in the bottom nav dock, next to the density toggles (blank → ruled → dots).
- **`src/styles/paper.css`** draws the texture with an `em`-based repeating gradient whose rhythm is tied to each target's own `line-height`, so rules/dots line up with the text baselines across font sizes and densities. Faint, theme-aware colors keep it a texture you feel more than see.
- Applied to **multiline home-feed posts** (gated by a `data-multiline` flag so one-line statuses don't pick up a stray underline) and to **document / blog prose** paragraphs.

## Verification

Rendered across all four theme × mode combinations with headless Chromium using the real CSS: rules sit under each baseline, single-line posts stay clean, documents read as ruled paper, and both light/dark stay subtle. Drove the real app to confirm the dock toggle appears next to the density controls and cycles/persists correctly.

The About page is left for a future pass (as discussed) — extending it is a one-line selector addition to `paper.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv)_