### PR TITLE
Lower ruled/dot paper lines into the inter-line gap

### DIFF
--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -9,8 +9,10 @@
    own font-size, so the period always equals one rendered line box
    regardless of font-size or density.
 
-   `--paper-baseline` phases the pattern down so a rule falls just under
-   each line's baseline (text sits *on* the line, like ruled paper). */
+   `--paper-baseline` phases the pattern down so a rule falls just below
+   each line — in the leading gap under the descenders, so the rule reads
+   as clearly beneath the type (not cutting through it) and stays legible
+   against the text. */
 
 :root,
 [data-theme='light'] {
@@ -33,7 +35,7 @@
 [data-paper='ruled'] .leaflet-paragraph,
 [data-paper='dots'] .leaflet-paragraph {
   --paper-lh: var(--leading);
-  --paper-baseline: 1.12em; /* ~baseline within a 1.6 line box */
+  --paper-baseline: 1.4em; /* just below the baseline of a 1.6 line box, in the leading gap */
 }
 
 /* `data-paper` and `data-density` both live on <html>, so this must be a
@@ -41,7 +43,7 @@
 [data-paper='ruled'][data-density='tight'] .post-card-text,
 [data-paper='dots'][data-density='tight'] .post-card-text {
   --paper-lh: var(--leading-tight);
-  --paper-baseline: 0.98em; /* baseline within the tighter 1.3 line box */
+  --paper-baseline: 1.15em; /* just below the baseline of the tighter 1.3 line box */
 }
 
 /* ── Ruled ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up tuning for the paper-texture feature (#125).

The rules previously sat right on the text baseline (offset `1.12em`), which cut through the descenders — hard to see, and reading as if a faint line hugged the top and bottom of each post. This moves the offset down into the leading gap just below the descenders (`1.4em` normal, `1.15em` tight) so each rule sits clearly beneath its line of type and stays legible.

## Verification

Reproduced the exact rendering in a harness loading the real `Feed.css` **and Crimson Pro** (font metrics matter here), compared candidate offsets side by side, and confirmed the result in light, dark, and dot-grid modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv)_