### PR TITLE
Align chrome, dock, and page-body margins on desktop

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -52,7 +52,10 @@
      Lives on the sheet's bottom edge (the sheet paints above the bar,
      z 31 > 30, so it wins over the bar's own hidden top border). */
   border-bottom: 1px solid var(--rule);
-  padding: var(--space-4);
+  /* Horizontal padding tracks the chrome bars' shared inset (--chrome-pad-x)
+     so the nav menu items land on the same column as the chrome content and
+     the page body; vertical padding stays a flat --space-4. */
+  padding: var(--space-4) var(--chrome-pad-x);
   height: calc(100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -213,10 +216,12 @@
 }
 
 @media (max-width: 540px) {
-  /* Tighten the sheet's padding on phones and give routes a slightly
-     taller tap target. */
+  /* Tighten the sheet's top padding on phones and give routes a slightly
+     taller tap target. Horizontal padding stays locked to --chrome-pad-x
+     (which is --space-4 at this width) so the menu items keep aligning
+     with the chrome content column. */
   .dock-panel {
-    padding: var(--space-3) var(--space-4) var(--space-4);
+    padding: var(--space-3) var(--chrome-pad-x) var(--space-4);
   }
 
   .dock-rule {

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -1,3 +1,30 @@
+/* Horizontal inset shared by every chrome surface — the top/bottom bars,
+   the atmosphere & breadcrumb rows, and the nav dock sheet — so their
+   content columns line up with each other AND with the page body (`.main`)
+   and its nav menu items. The bars/sheet cap at 65rem while `.main` caps at
+   72rem, so each side of the bar sits 3.5rem inside the main column;
+   subtracting 3.5rem from `.main`'s own `6vw` padding lands chrome content
+   on the same column (`6vw - 3.5rem`, clamped with a small floor + 2.5rem
+   cap for the narrow + max-width extremes). Below the 65rem cap the bars are
+   full-bleed exactly like `.main`, so the inset tracks `.main`'s padding
+   directly at each of its breakpoints. Kept on :root — not the chrome
+   scope — because the dock sheet is portalled to <body>, outside .chrome-bar. */
+:root {
+  --chrome-pad-x: clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
+}
+
+@media (max-width: 65rem) {
+  :root {
+    --chrome-pad-x: clamp(var(--space-5), 6vw, var(--space-9));
+  }
+}
+
+@media (max-width: 700px) {
+  :root {
+    --chrome-pad-x: var(--space-4);
+  }
+}
+
 .chrome-bar {
   /* Background lives on the inner top/bottom containers below, not
      here — the wide-screen treatment caps them at 72rem so the page
@@ -37,17 +64,12 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  /* Bar is 65rem (7rem narrower than `.main`'s 72rem). When both
-     reach their max-widths, the bar sits 3.5rem inside the main
-     column on each side — so the chrome's own padding can be
-     `main_padding - 3.5rem` and chrome elements still land on the
-     main content's margin column. `6vw - 3.5rem` tracks `.main`'s
-     `6vw` padding scale; clamped with a small floor + 2.5rem cap
-     for the narrow + max-width extremes. */
   width: 100%;
   max-width: 65rem;
   margin: 0 auto;
-  padding: 0 clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
+  /* Shared inset that keeps chrome content on the same column as `.main`
+     and the nav dock — see `--chrome-pad-x` at the top of this file. */
+  padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
 }
 
@@ -341,10 +363,6 @@
   background: var(--page);
 }
 
-.chrome-expand {
-  margin-right: calc(-1 * var(--space-2));
-}
-
 .chrome-nav:hover,
 .chrome-nav:focus-visible,
 .chrome-expand:hover,
@@ -444,7 +462,7 @@
   width: 100%;
   max-width: 65rem;
   margin: 0 auto;
-  padding: 0 clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
+  padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
 }
 
@@ -519,24 +537,6 @@
   will-change: transform;
 }
 
-/* Below the 65rem cap the chrome bars are full-bleed, exactly like `.main`.
-   Match `.main`'s own horizontal padding so the header/dock content lines
-   up with the page's content column. (The base `6vw - 3.5rem` padding only
-   makes sense once the bar is actually capped at 65rem and sits inset from
-   the wider 72rem main column above this width.) */
-@media (max-width: 65rem) {
-  .chrome-bar-row,
-  .chrome-bottom-row {
-    padding-left: clamp(var(--space-5), 6vw, var(--space-9));
-    padding-right: clamp(var(--space-5), 6vw, var(--space-9));
-  }
-  /* Drop the top-right chevron's outdent here so the right margin stays
-     symmetric with the left and matches the page's content edge. */
-  .chrome-expand {
-    margin-right: 0;
-  }
-}
-
 @media (max-width: 700px) {
   .chrome-bar-row {
     gap: var(--space-2);
@@ -546,13 +546,6 @@
   }
   .chrome-bottom-cluster {
     gap: var(--space-2);
-  }
-  /* `.main` tightens to `var(--space-4)` at this width — track it so the
-     chrome margins stay locked to the content column. */
-  .chrome-bar-row,
-  .chrome-bottom-row {
-    padding-left: var(--space-4);
-    padding-right: var(--space-4);
   }
   .chrome-signals-secondary {
     flex-direction: column;


### PR DESCRIPTION
## Summary

On desktop, the horizontal margins inside the top/bottom chrome bars didn't match the page body and nav menu items, and the atmosphere-bar expand chevron poked out past the right content edge into the margin.

Measured geometry (dock open) showed:
- The chrome bars already aligned with the page body (`.main`) by design, but the **nav dock panel** used a flat `1rem` padding, so its menu items sat **~15–45px further toward the edges** than the chrome/body column (they only coincided near ~1200px).
- The **chevron** carried a `-0.5rem` outdent that was only cancelled below 65rem, so on desktop it overflowed the right content edge by 8px.

## Changes

- Consolidated the three independently-maintained horizontal-inset formulas into a single `:root` token, `--chrome-pad-x` (with its 65rem / 700px responsive tiers), now consumed by both the chrome rows and the dock panel. All chrome surfaces — top bar, bottom bar, atmosphere/breadcrumb rows, and the nav dock — now land on the same column as `.main` at every width.
- Removed the chevron's outdent so its right edge sits on the content edge instead of in the margin.

## Verification

Re-measured with the app running at 1440 / 1200 / 1024px (dock open): top chrome, bottom chrome, page body, and nav menu now share the same left/right edges, margins are symmetric (e.g. 231px both sides at 1440px), and the chevron reports `margin-right: 0`. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dewk7sYgY2sKv1xPW6Pzv)_