### PR TITLE
Group listening into sessions; drop redundant verb headers on single-verb feeds

### DIFF
--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -85,7 +85,7 @@ function hrefFor(item) {
  * registry. The verb badge doubles as the link to the underlying record
  * page (or generic JSON fallback for verbs without a specialized one).
  */
-export default function FeedItem({ item }) {
+export default function FeedItem({ item, showVerb = true }) {
   const navigate = useNavigate();
   const edit = useEditMode();
   const cfg = verbConfig(item.verb);
@@ -175,7 +175,7 @@ export default function FeedItem({ item }) {
   // time is shown and the card's own row is hidden; in compact/tight —
   // where the verb column is stripped — this hoisted copy is hidden and
   // the card's in-place timestamp is what remains (see Feed.css).
-  const hoistTime = cfg.renderer === 'PostCard' && postCardShowsStandaloneTime(item);
+  const hoistTime = showVerb && cfg.renderer === 'PostCard' && postCardShowsStandaloneTime(item);
   const hoistTs = hoistTime ? item.createdAt || item.payload?.indexedAt : null;
   const liClassName = [
     'feed-item',
@@ -208,7 +208,7 @@ export default function FeedItem({ item }) {
           {selected && <Check size={12} strokeWidth={2.5} />}
         </span>
       )}
-      {(() => {
+      {showVerb && (() => {
         const verbEl = href && !listeningEdit ? (
           <Link className={verbClassName} to={href}>
             {verbInner}
@@ -238,7 +238,7 @@ export default function FeedItem({ item }) {
       <Component
         {...item}
         verb={item.verb}
-        suppressReplyBadge={isReplyVerb || threadContinuation}
+        suppressReplyBadge={showVerb ? isReplyVerb || threadContinuation : threadContinuation}
       />
     </li>
   );

--- a/src/lib/listenSessions.js
+++ b/src/lib/listenSessions.js
@@ -1,0 +1,42 @@
+/**
+ * Collapse consecutive `listening` items into session batches.
+ *
+ * Listens merge into one session when they fall within
+ * `LISTEN_BATCH_GAP_MS` of each other — the gap is measured
+ * listen-to-listen, so non-listening items interleaved in a mixed feed
+ * (a post mid-session, etc.) don't fragment the batch, and they pass
+ * through to the output untouched. Day boundaries don't matter; a
+ * session that crosses midnight still groups into one row.
+ *
+ * A batch keeps the first-seen play's fields (in a newest-first feed
+ * that's the most recent play, so the batch sorts and dates like its
+ * newest song) plus a `count` and a `plays` array of the underlying
+ * records for expand/collapse.
+ */
+export const LISTEN_BATCH_GAP_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+export function collapseListens(items) {
+  const out = [];
+  let openBatch = null;
+  let lastListenTime = 0;
+  for (const item of items) {
+    if (item.verb === 'listening') {
+      const t = Date.parse(item.createdAt) || 0;
+      if (openBatch && Math.abs(lastListenTime - t) <= LISTEN_BATCH_GAP_MS) {
+        openBatch.count = (openBatch.count || 1) + 1;
+        openBatch.plays.push(item);
+        lastListenTime = t;
+        continue;
+      }
+      const batch = { ...item, count: 1, plays: [item] };
+      openBatch = batch;
+      lastListenTime = t;
+      out.push(batch);
+    } else {
+      // Non-listening items pass through but DON'T close the batch — the
+      // next listen within the gap window still merges into the session.
+      out.push(item);
+    }
+  }
+  return out;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,6 +20,7 @@ import {
   endRefresh,
 } from '../lib/feedCache.js';
 import { groupByDay } from '../lib/time.js';
+import { collapseListens } from '../lib/listenSessions.js';
 import { resolvePds } from '../lib/atproto.js';
 import { buildUnifiedFeed } from '../lib/feedBuilder.js';
 import { groupSelfReplyThreads, threadAwareDateKey } from '../lib/threadGrouping.js';
@@ -45,16 +46,6 @@ const LOAD_MORE_STEP = 100;
 // the page when the network is flaky.
 const SNAPSHOT_FALLBACK_MAX = 60;
 
-
-/**
- * Collapse `listening` items into session batches. Listens are merged
- * when they fall within `LISTEN_BATCH_GAP_MS` of each other — the gap
- * is measured listen-to-listen, so non-listening items interleaved in
- * the feed (a post mid-session, etc.) don't fragment the batch. Day
- * boundary doesn't matter; a session that crosses midnight still
- * groups into one row.
- */
-const LISTEN_BATCH_GAP_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 /**
  * True when every verb in `need` was part of the `have` fetch set — i.e.
@@ -150,32 +141,6 @@ function DayActivityMeta({ checking, stats, reduce }) {
   );
 }
 
-function collapseListens(items) {
-  const out = [];
-  let openBatch = null;
-  let lastListenTime = 0;
-  for (const item of items) {
-    if (item.verb === 'listening') {
-      const t = Date.parse(item.createdAt) || 0;
-      if (openBatch && Math.abs(lastListenTime - t) <= LISTEN_BATCH_GAP_MS) {
-        openBatch.count = (openBatch.count || 1) + 1;
-        openBatch.plays.push(item);
-        lastListenTime = t;
-        continue;
-      }
-      const batch = { ...item, count: 1, plays: [item] };
-      openBatch = batch;
-      lastListenTime = t;
-      out.push(batch);
-    } else {
-      // Non-listening items pass through to the output but DON'T
-      // close the batch — the next listen within the gap window
-      // still merges into the same session.
-      out.push(item);
-    }
-  }
-  return out;
-}
 
 export default function Home() {
   const [params] = useSearchParams();

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -11,6 +11,7 @@ import { usePageContent } from '../hooks/usePageContent.js';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
+import { collapseListens } from '../lib/listenSessions.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
@@ -56,7 +57,18 @@ export default function Listening() {
       }),
     [safeItems, q, removedUris],
   );
-  const groups = groupByDay(filtered, (i) => i.createdAt);
+  // Merge consecutive plays into "listening sessions" (same batching the
+  // home feed uses) so a run of songs reads as one compact, expandable row
+  // instead of one row per track. Plays are newest-first from the PDS, but
+  // sort defensively so a play whose recorded time drifts from its rkey
+  // doesn't split a session.
+  const sessions = useMemo(() => {
+    const sorted = [...filtered].sort(
+      (a, b) => (Date.parse(b.createdAt) || 0) - (Date.parse(a.createdAt) || 0),
+    );
+    return collapseListens(sorted);
+  }, [filtered]);
+  const groups = groupByDay(sessions, (i) => i.createdAt);
 
   // Feed page: report the newest visible record's time in the global footer.
   usePublishLatestRecord(useMemo(() => newestInstant(filtered), [filtered]));
@@ -84,7 +96,7 @@ export default function Listening() {
               <DayOfLifeHeader date={group.date} />
               <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
                 {group.items.map((item) => (
-                  <FeedItem key={item.atUri} item={item} />
+                  <FeedItem key={item.atUri} item={item} showVerb={false} />
                 ))}
               </ul>
             </li>

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -71,7 +71,7 @@ export default function Posting() {
               <DayOfLifeHeader date={group.date} />
               <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
                 {group.items.map((item) => (
-                  <FeedItem key={item.atUri} item={item} />
+                  <FeedItem key={item.atUri} item={item} showVerb={false} />
                 ))}
               </ul>
             </li>


### PR DESCRIPTION
## What & why

On the dedicated **Listening** and **Posting** pages, the per-item gerund header ("LISTENING TO", "POSTING") is redundant — the page already names the verb. This PR removes it and makes the Listening feed more compact by grouping plays into sessions.

## Changes

- **`showVerb` prop on `FeedItem`** — the Listening and Posting pages render with `showVerb={false}`, dropping the verb column. Reply context isn't lost: `PostCard`'s own inline reply badge takes over when the verb column is hidden (it was previously suppressed *because* the column showed it), and self-reply thread continuations stay quiet. Timestamps continue to render in-card.
- **Listening sessions** — consecutive plays within a 2h gap now collapse into one compact, expandable "N songs" row instead of one row per track — the same batching the home feed already used.
- **Shared batching logic** — extracted `collapseListens` (and the gap constant) out of `Home.jsx` into `src/lib/listenSessions.js` so Home and Listening share one implementation.

## Verification

- Production build compiles.
- Unit-checked the session grouping (runs of close plays merge; a gap over the threshold starts a new session).
- Live screenshots weren't possible in the sandbox (outbound fetch to the PDS is blocked and the Listening page has no offline snapshot), so a look at the Vercel preview is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY)_