### PR TITLE
Lock paper textures to the line box to fix drift and doubling

### DIFF
--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -2,17 +2,24 @@
    Driven by the `data-paper` attribute on <html> (see usePaper.jsx):
    blank (default, nothing), ruled (horizontal rules), dots (dot grid).
 
-   The rhythm is tied to each target's own line-height so the rules/dots
-   line up with the text baselines: one horizontal band per text line.
-   `--paper-lh` carries that line-height (unitless), and the band period
-   is `calc(1em * var(--paper-lh))` — 1em resolves against the target's
-   own font-size, so the period always equals one rendered line box
-   regardless of font-size or density.
+   The rhythm is one band per text line, and it MUST stay locked to the
+   text for the full height of a post — otherwise the rules drift line by
+   line and eventually collide into "doubled" rules on long posts. So the
+   band period is the CSS `lh` unit: the element's own *rendered* line
+   box, including whatever device-pixel rounding the browser applies.
+   `1lh` == one line of this text exactly, so N bands cover N lines with
+   no accumulating error, at any font size, density, or device pixel
+   ratio. (`em`-based periods can't guarantee this — an exact 1.6em is not
+   the same as the rounded line box the browser actually lays out.)
 
-   `--paper-baseline` phases the pattern down so a rule falls just below
-   each line — in the leading gap under the descenders, so the rule reads
-   as clearly beneath the type (not cutting through it) and stays legible
-   against the text. */
+   Vertical placement is baked into the gradient stops (and the dot's own
+   center), not into `background-position`: each rule is anchored to the
+   BOTTOM of its line box (`1lh - drop`), a deterministic multiple of the
+   line height. That guarantees exactly one rule under every line — the
+   first and the last included — with none floating above the first line,
+   independent of the font's baseline metrics. `--paper-drop` is how far
+   the rule sits above each line-box bottom, tuned to land just under the
+   descenders. */
 
 :root,
 [data-theme='light'] {
@@ -26,29 +33,28 @@
   --paper-dot:  rgba(236, 228, 203, 0.08);
 }
 
-/* Targets. Default line-height rhythm is the body leading; the tight
-   density re-tunes feed post text to the tighter leading so its rules
-   still track each (shorter) line. Documents/blog prose use their own
-   fixed 1.6 leading (see LeafletDocument.css). */
+/* `--paper-drop`: distance the rule/dot row sits above each line-box
+   bottom, landing it just below the descenders. The tight density packs
+   a shorter line box, so it uses a smaller drop. Both feed post text and
+   document/blog prose share the default. */
 [data-paper='ruled'] .post-card-text,
 [data-paper='dots'] .post-card-text,
 [data-paper='ruled'] .leaflet-paragraph,
 [data-paper='dots'] .leaflet-paragraph {
-  --paper-lh: var(--leading);
-  --paper-baseline: 1.4em; /* just below the baseline of a 1.6 line box, in the leading gap */
+  --paper-drop: 0.2em;
 }
 
 /* `data-paper` and `data-density` both live on <html>, so this must be a
    compound (same-element) selector, not a descendant combinator. */
 [data-paper='ruled'][data-density='tight'] .post-card-text,
 [data-paper='dots'][data-density='tight'] .post-card-text {
-  --paper-lh: var(--leading-tight);
-  --paper-baseline: 1.15em; /* just below the baseline of the tighter 1.3 line box */
+  --paper-drop: 0.16em;
 }
 
 /* ── Ruled ─────────────────────────────────────────────────────────
-   A 1px rule at the top of each period, phased down by --paper-baseline
-   so it lands under the text baseline. Only painted on multiline feed
+   A 1px rule anchored to the bottom of each line box (1lh − drop), with
+   the repeat period equal to one rendered line (1lh) so exactly one rule
+   lands under each line with no drift. Only painted on multiline feed
    posts (see PostCard's data-multiline gate) so short single-line
    statuses don't pick up a lone underline. Document/blog paragraphs are
    always eligible. */
@@ -56,25 +62,31 @@
 [data-paper='ruled'] .leaflet-paragraph {
   background-image: repeating-linear-gradient(
     to bottom,
-    var(--paper-rule) 0,
-    var(--paper-rule) 1px,
-    transparent 1px,
-    transparent calc(1em * var(--paper-lh))
+    transparent 0,
+    transparent calc(1lh - var(--paper-drop) - 1px),
+    var(--paper-rule) calc(1lh - var(--paper-drop) - 1px),
+    var(--paper-rule) calc(1lh - var(--paper-drop)),
+    transparent calc(1lh - var(--paper-drop)),
+    transparent 1lh
   );
-  background-position: 0 var(--paper-baseline);
+  background-position: 0 0;
   background-origin: content-box;
 }
 
 /* ── Dots ──────────────────────────────────────────────────────────
-   Same row rhythm as the rules, with a matching column pitch so the
-   grid reads as square-ish. Dots sit on the baseline rows. */
+   One dot row per line, on the same rhythm as the rules: the dot's
+   center is placed at (1lh − drop) within a 1lh-tall tile, so rows sit
+   just under each line and never drift. Columns form a square grid
+   matched to the line height. Placement lives in the radial's own `at`
+   position (no background-position phase), so it stays locked. */
 [data-paper='dots'] .post-card-text[data-multiline],
 [data-paper='dots'] .leaflet-paragraph {
   background-image: radial-gradient(
-    var(--paper-dot) 0.85px,
-    transparent 1.4px
+    circle at 0.5em calc(1lh - var(--paper-drop)),
+    var(--paper-dot) 0.9px,
+    transparent 1.5px
   );
-  background-size: calc(1em * var(--paper-lh)) calc(1em * var(--paper-lh));
-  background-position: 0.2em var(--paper-baseline);
+  background-size: 1lh 1lh;
+  background-position: 0 0;
   background-origin: content-box;
 }


### PR DESCRIPTION
Fixes the inconsistent ruled/dot rendering reported on longer feed posts and blog prose — misalignment, "doubled" rules where a line drifted into the next, a rule appearing above the first line, and none under the last.

## Root cause

The band period was an exact `1.6em`, phased with `background-position`. That's *not* the same as the line box the browser actually lays out once device-pixel rounding is applied, so the tiny per-line error accumulated down a post: short posts looked fine, long posts drifted until a rule collided with the next line ("doubled"). The `background-position` phase also meant that if the offset was ever reset, rules snapped to the top of each line box (rule above the first line, none under the last).

## Fix

- **Period is now the CSS `lh` unit** — the element's actual rendered line box — so N bands cover N lines with zero accumulating error, at any font size, density, or device pixel ratio.
- **Vertical placement is baked into the gradient stops and the dot's own center** (anchored to `1lh - drop`, the bottom of each line box) instead of `background-position`, guaranteeing exactly one rule/row under every line — first and last included, none above the first.
- Realigns the **dot grid** to the line height (square grid, one row per line).

## Verification

Pixel-measured the actual rule positions on an 8-line post at 1×/2×/3× device pixel ratio: 8 rules for 8 lines every time, with a constant ~17.7px rule-to-line offset (no accumulation). Visually confirmed ruled + dots in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv)_