### PR TITLE
Pause the paper-texture feature (blank page for now)

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -16,6 +16,7 @@ import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
 import DensityToggle from './DensityToggle.jsx';
 import PaperToggle from './PaperToggle.jsx';
+import { PAPER_ENABLED } from '../hooks/usePaper.jsx';
 import SearchSheet from './SearchSheet.jsx';
 import InfoSheet from './InfoSheet.jsx';
 import './ChromeBar.css';
@@ -345,7 +346,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
               >
                 <DensityToggle />
-                <PaperToggle />
+                {PAPER_ENABLED && <PaperToggle />}
                 <button
                   type="button"
                   className={`chrome-nav chrome-tool-debug ${view === 'debug' ? 'is-open' : ''}`}

--- a/src/hooks/usePaper.jsx
+++ b/src/hooks/usePaper.jsx
@@ -3,6 +3,14 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 const PaperContext = createContext(null);
 const STORAGE_KEY = 'dame.paper';
 
+// Feature flag. The paper-texture feature (ruled lines / dot grid) is
+// paused for now — every page renders blank, the way it used to. Flip
+// this to `true` to bring the whole thing back: the chrome toggle
+// reappears (see ChromeBar), the stored preference is honoured again
+// (it's never overwritten while disabled, so returning users keep their
+// old choice), and the textures paint. Keep in sync with main.jsx.
+export const PAPER_ENABLED = false;
+
 // Three paper textures painted faintly behind long-form text content
 // (multiline feed posts, blog/document prose):
 //   - blank : no texture, a clean page (the default)
@@ -22,9 +30,15 @@ function readInitial() {
 }
 
 export function PaperProvider({ children }) {
-  const [paper, setPaperState] = useState(readInitial);
+  const [paper, setPaperState] = useState(() => (PAPER_ENABLED ? readInitial() : 'blank'));
 
   useEffect(() => {
+    // While disabled, always render blank and leave the stored preference
+    // untouched so it comes back if the feature is re-enabled later.
+    if (!PAPER_ENABLED) {
+      applyPaper('blank');
+      return;
+    }
     applyPaper(paper);
     try {
       localStorage.setItem(STORAGE_KEY, paper);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import { PAPER_ENABLED } from './hooks/usePaper.jsx';
 import './styles/reset.css';
 import './styles/theme.css';
 import './styles/typography.css';
@@ -43,11 +44,16 @@ if (!VALID_DENSITY.includes(storedDensity)) {
 document.documentElement.setAttribute('data-density', storedDensity);
 
 // Paper texture behind long-form text (blank / ruled / dots). Set before
-// the first paint so ruled/dots users don't flash a blank page. Keep in
-// sync with usePaper.jsx.
+// the first paint so ruled/dots users don't flash a blank page. The
+// feature is currently paused (PAPER_ENABLED = false), so this always
+// resolves to blank; the stored preference is left in place for when it
+// returns. Keep in sync with usePaper.jsx.
 const VALID_PAPER = ['blank', 'ruled', 'dots'];
 const storedPaper = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.paper') : null;
-document.documentElement.setAttribute('data-paper', VALID_PAPER.includes(storedPaper) ? storedPaper : 'blank');
+document.documentElement.setAttribute(
+  'data-paper',
+  PAPER_ENABLED && VALID_PAPER.includes(storedPaper) ? storedPaper : 'blank',
+);
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
Turns the ruled-lines / dot-grid feature off for now — every page renders blank the way it used to — while keeping all the code in place to bring back later.

A single `PAPER_ENABLED` flag in `usePaper.jsx` drives it:

- When `false`, the provider always applies `data-paper="blank"` and **leaves the stored `dame.paper` preference untouched**, so a returning visitor who had chosen ruled/dots sees blank now but keeps their choice for when the feature returns.
- `main.jsx`'s pre-paint block honours the same flag.
- `ChromeBar` hides the paper toggle while disabled.

Flip `PAPER_ENABLED` to `true` to restore the toggle, the honoured preference, and the textures. `paper.css`, `PaperToggle`, and the multiline detection all stay put — nothing is deleted.

## Verification

Simulated a returning user with `dame.paper=ruled` in localStorage: `data-paper` resolves to `blank`, nothing paints, the stored preference is preserved, and the toggle is absent from the nav dock (only the density buttons, debug, and account remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSfSsPjea5LRCyikjK26sv)_