### PR TITLE
Fix album art via same-origin proxy (CORS was blocking every lookup)

### DIFF
--- a/api/albumart.js
+++ b/api/albumart.js
@@ -1,0 +1,89 @@
+// Vercel serverless function: resolve album art for a play via Apple's
+// open iTunes Search/Lookup API.
+//
+// This exists because iTunes' API does NOT send an `Access-Control-Allow-
+// Origin` header, so a browser fetch straight from dame.is is blocked by
+// CORS and every lookup fails (blank cover placeholders). Proxying through
+// our own origin sidesteps CORS entirely, and — because the response is
+// CDN-cached (`s-maxage`) — the first viewer of a track warms the cache for
+// everyone else, which also keeps us clear of iTunes' per-IP rate limit.
+//
+// Identifier ladder, most reliable first (mirrors the client's old logic):
+//   1. ISRC        — recording id, universal across services.
+//   2. Apple song id — exact match when the play came from Apple Music.
+//   3. track + artist — last-resort fuzzy text search.
+
+const ITUNES_LOOKUP = 'https://itunes.apple.com/lookup';
+const ITUNES_SEARCH = 'https://itunes.apple.com/search';
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!res.ok) throw new Error(`iTunes ${res.status}`);
+  return res.json();
+}
+
+async function resolve({ isrc, appleId, track, artist }) {
+  if (isrc) {
+    const data = await fetchJson(
+      `${ITUNES_LOOKUP}?isrc=${encodeURIComponent(isrc)}&entity=song&limit=1`,
+    );
+    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
+    if (hit) return hit;
+  }
+
+  if (appleId) {
+    const data = await fetchJson(
+      `${ITUNES_LOOKUP}?id=${encodeURIComponent(appleId)}&entity=song&limit=1`,
+    );
+    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
+    if (hit) return hit;
+  }
+
+  if (track) {
+    const term = [track, artist].filter(Boolean).join(' ');
+    const data = await fetchJson(
+      `${ITUNES_SEARCH}?term=${encodeURIComponent(term)}&entity=song&limit=1`,
+    );
+    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
+    if (hit) return hit;
+  }
+
+  return null;
+}
+
+export default async function handler(req, res) {
+  const q = req.query || {};
+  const isrc = typeof q.isrc === 'string' ? q.isrc : '';
+  const appleId = typeof q.appleId === 'string' && /^\d+$/.test(q.appleId) ? q.appleId : '';
+  const track = typeof q.track === 'string' ? q.track.trim() : '';
+  const artist = typeof q.artist === 'string' ? q.artist.trim() : '';
+
+  if (!isrc && !appleId && !track) {
+    return res.status(400).json({ error: 'Pass isrc, appleId, or track.' });
+  }
+
+  try {
+    const hit = await resolve({ isrc, appleId, track, artist });
+    // Cache hits hard and misses briefly: a freshly released track can gain
+    // art later, so we don't want to pin an empty result for long.
+    if (!hit?.artworkUrl100) {
+      res.setHeader('cache-control', 'public, s-maxage=86400, max-age=3600');
+      return res.status(200).json({ found: false });
+    }
+    res.setHeader(
+      'cache-control',
+      'public, s-maxage=2592000, max-age=86400, stale-while-revalidate=86400',
+    );
+    return res.status(200).json({
+      found: true,
+      artworkUrl100: hit.artworkUrl100,
+      track: hit.trackName || null,
+      artist: hit.artistName || null,
+      album: hit.collectionName || null,
+    });
+  } catch (err) {
+    // Don't let the client cache a transient upstream failure.
+    res.setHeader('cache-control', 'no-store');
+    return res.status(502).json({ error: err?.message || 'album art lookup failed' });
+  }
+}

--- a/src/lib/albumArt.js
+++ b/src/lib/albumArt.js
@@ -9,17 +9,19 @@
 //      play came from Apple). Exact match when present.
 //   3. trackName + first artistName. Last-resort fuzzy text search.
 //
-// We hit Apple's open iTunes Search/Lookup API for all three. It's free,
-// requires no auth, is CORS-friendly, and returns an `artworkUrl100` that
-// can be upscaled by swapping the `100x100bb.jpg` segment for a larger
-// size — Apple actually serves whatever resolution you ask for.
+// The lookup goes through our own `/api/albumart` serverless proxy rather
+// than hitting iTunes from the browser directly: Apple's API sends no CORS
+// header, so a direct fetch is blocked and every cover falls back to a
+// blank placeholder. The proxy also CDN-caches results, so the first viewer
+// of a track warms the art for everyone. Apple returns an `artworkUrl100`
+// that can be upscaled by swapping the `100x100bb.jpg` segment for a larger
+// size — Apple serves whatever resolution the URL asks for.
 //
-// Results are cached in localStorage so we don't re-hit Apple on every
-// re-render or page navigation. Hits are kept for 30 days, misses for 1
-// day so a freshly released track can recover once its art is indexed.
+// Results are also cached in localStorage so we don't re-hit the proxy on
+// every re-render or page navigation. Hits are kept for 30 days, misses for
+// 1 day so a freshly released track can recover once its art is indexed.
 
-const ITUNES_LOOKUP = 'https://itunes.apple.com/lookup';
-const ITUNES_SEARCH = 'https://itunes.apple.com/search';
+const ALBUM_ART_ENDPOINT = '/api/albumart';
 const CACHE_KEY = 'dame:albumArtCache:v1';
 const HIT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MISS_TTL_MS = 24 * 60 * 60 * 1000;
@@ -125,45 +127,28 @@ function cacheKeyFor(payload) {
 
 async function fetchJson(url) {
   const res = await fetch(url, { headers: { Accept: 'application/json' } });
-  if (!res.ok) throw new Error(`iTunes ${res.status}`);
+  if (!res.ok) throw new Error(`album art ${res.status}`);
   return res.json();
 }
 
 /**
- * Resolve a payload to a result row from iTunes Search/Lookup. Walks the
- * identifier ladder: ISRC → Apple song id → free-text search.
+ * Resolve a payload to an artwork row via our `/api/albumart` proxy, which
+ * walks the identifier ladder (ISRC → Apple song id → free-text search)
+ * server-side. Returns a row with `artworkUrl100`, or null on a miss.
  */
 async function resolveResult(payload) {
-  const isrc = payload?.isrc;
-  if (isrc) {
-    const data = await fetchJson(
-      `${ITUNES_LOOKUP}?isrc=${encodeURIComponent(isrc)}&entity=song&limit=1`,
-    );
-    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
-    if (hit) return hit;
-  }
-
+  const params = new URLSearchParams();
+  if (payload?.isrc) params.set('isrc', String(payload.isrc));
   const songId = appleSongIdFrom(payload);
-  if (songId) {
-    const data = await fetchJson(
-      `${ITUNES_LOOKUP}?id=${encodeURIComponent(songId)}&entity=song&limit=1`,
-    );
-    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
-    if (hit) return hit;
-  }
-
+  if (songId) params.set('appleId', songId);
   const track = trackTitle(payload);
+  if (track) params.set('track', track);
   const artist = firstArtist(payload);
-  if (track) {
-    const term = [track, artist].filter(Boolean).join(' ');
-    const data = await fetchJson(
-      `${ITUNES_SEARCH}?term=${encodeURIComponent(term)}&entity=song&limit=1`,
-    );
-    const hit = (data?.results || []).find((r) => r?.artworkUrl100);
-    if (hit) return hit;
-  }
+  if (artist) params.set('artist', artist);
+  if (![...params.keys()].length) return null;
 
-  return null;
+  const data = await fetchJson(`${ALBUM_ART_ENDPOINT}?${params}`);
+  return data?.found && data.artworkUrl100 ? data : null;
 }
 
 /**
@@ -212,9 +197,9 @@ export async function albumArtFor(payload, { size = 600 } = {}) {
       }
       const entry = {
         artworkUrl100: hit.artworkUrl100,
-        track: hit.trackName || null,
-        artist: hit.artistName || null,
-        album: hit.collectionName || null,
+        track: hit.track || null,
+        artist: hit.artist || null,
+        album: hit.album || null,
         source: 'itunes',
       };
       cacheSet(key, entry);


### PR DESCRIPTION
## What & why

The listening stats covers (Top Tracks / Albums) were all blank placeholders. The browser resolved album art by fetching Apple's iTunes Search/Lookup API directly, but that API sends **no `Access-Control-Allow-Origin` header** — so every request was blocked by CORS and fell back to the empty placeholder. (The artwork images on `mzstatic.com` load fine; the code just never got their URLs.)

## Changes

- **New `api/albumart.js` serverless proxy** — resolves art through our own origin (no CORS), walking the identifier ladder server-side: ISRC → Apple song id → track+artist text search.
- **CDN-cached responses** (`s-maxage=30d` on hits, plus `stale-while-revalidate`; short cache on misses so newly-released tracks recover). The first viewer of a track warms the artwork for everyone and keeps us clear of iTunes' per-IP rate limit — which also speeds up cover loading generally.
- **`src/lib/albumArt.js`** now calls `/api/albumart` instead of iTunes directly; the localStorage cache and upscaling logic are unchanged.

## Verification

- Build compiles.
- Smoke-tested the function against real iTunes: `CPR · Wet Leg` and `Heat Wave · Ella Fitzgerald` resolve to real artwork URLs, unresolved lookups return `found: false`, and empty queries 400.
- Note: `/api/*` runs on Vercel (or `vercel dev`), not plain `vite dev`, so covers still appear blank in a plain local dev server but work in preview/production — consistent with the repo's other API routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY)_