### PR TITLE
Don't bold the artist list on multi-artist listening sessions

### DIFF
--- a/src/components/ListenRow.jsx
+++ b/src/components/ListenRow.jsx
@@ -157,7 +157,11 @@ function TrackLabel({ payload, href, plays }) {
     const extra = artists.length > ARTIST_DISPLAY_MAX
       ? ` + ${artists.length - ARTIST_DISPLAY_MAX} more`
       : '';
-    const inner = <strong>{shown + extra}</strong>;
+    // No single track leads a multi-artist session, so the artist pool
+    // carries the line on its own — in regular weight, matching how the
+    // artist reads in a normal "<track> · <artist>" row (bold is reserved
+    // for the track title, which isn't shown here).
+    const inner = shown + extra;
     return href ? <Link to={href}>{inner}</Link> : <span>{inner}</span>;
   }
   const artistLine = isBatch ? (artists[0] || '') : formatArtist(payload);


### PR DESCRIPTION
## What & why

On a multi-artist listening-session row, no single track leads the line, so the deduped artist pool carries it. That list was rendered entirely in `<strong>`, which read as heavy and inconsistent with normal rows — where bold is reserved for the track title and the artist name stays regular weight.

## Change

- `src/components/ListenRow.jsx`: render the multi-artist session's artist list in regular weight (drop the `<strong>` wrapper). Single-artist sessions and normal rows are unchanged (`**Track** · Artist`).

Shared `ListenRow` component, so this applies to both the Listening page and the home feed.

## Verification

- Build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY)_