### PR TITLE
Fix album-art cache reading every hit back as a miss

### DIFF
--- a/src/lib/albumArt.js
+++ b/src/lib/albumArt.js
@@ -22,7 +22,10 @@
 // 1 day so a freshly released track can recover once its art is indexed.
 
 const ALBUM_ART_ENDPOINT = '/api/albumart';
-const CACHE_KEY = 'dame:albumArtCache:v1';
+// v2: v1 read/wrote the cache on mismatched fields (stored `artworkUrl100`,
+// checked `url`), so every hit was read back as a miss and covers vanished
+// on reload. Bumping the key discards those poisoned entries.
+const CACHE_KEY = 'dame:albumArtCache:v2';
 const HIT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MISS_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -58,7 +61,7 @@ function cacheGet(key) {
   const cache = readCache();
   const entry = cache[key];
   if (!entry) return undefined;
-  const ttl = entry.url ? HIT_TTL_MS : MISS_TTL_MS;
+  const ttl = entry.artworkUrl100 ? HIT_TTL_MS : MISS_TTL_MS;
   if (Date.now() - (entry.t || 0) > ttl) return undefined;
   return entry;
 }
@@ -178,7 +181,7 @@ export async function albumArtFor(payload, { size = 600 } = {}) {
 
   const cached = cacheGet(key);
   if (cached) {
-    if (!cached.url) return null;
+    if (!cached.artworkUrl100) return null;
     return {
       ...cached,
       url: upscaleArtwork(cached.artworkUrl100, size),
@@ -192,7 +195,7 @@ export async function albumArtFor(payload, { size = 600 } = {}) {
     try {
       const hit = await resolveResult(payload);
       if (!hit?.artworkUrl100) {
-        cacheSet(key, { url: null });
+        cacheSet(key, { artworkUrl100: null });
         return null;
       }
       const entry = {


### PR DESCRIPTION
## What & why

Album covers showed on first fetch and then vanished on reload. The localStorage cache stored hits under `artworkUrl100` but the read path and TTL check both looked at a `url` field that was never written — so every cached hit was treated as a miss: `albumArtFor` returned `null` on the cache branch (blank placeholder), and hits expired on the 1-day miss TTL instead of 30 days.

This is the real reason a play's art appeared once and then disappeared, independent of the earlier `/api/albumart` proxy work (which correctly addresses the stats page's rate-limiting via CDN caching).

## Changes

- `src/lib/albumArt.js`: key the cache read and TTL on `artworkUrl100` (the field actually stored), store misses as `{ artworkUrl100: null }`, and bump the cache key to `v2` so poisoned `v1` entries are discarded and users repopulate from the working proxy.

## Verification

- Build compiles.
- Cache round-trip test (mocked `localStorage` + proxy fetch): first call fetches and returns the URL; second call serves from cache and returns the URL (previously returned `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtDrcXoikiF9Gav8ArCCY)_