### PR TITLE
Share the overlay scroll-chain guard across all sheets and modals

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ChevronLeft } from 'lucide-react';
 import { useActionDock } from '../hooks/useActionDock.jsx';
+import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
@@ -28,46 +29,9 @@ export default function ActionDock() {
   const { open, view, setView, openDock, closeDock } = useActionDock();
   const reduce = useReducedMotion();
   const panelRef = useRef(null);
-
-  // Keep a touch-drag on the open sheet from scrolling the page behind it.
-  // The panel fully conceals the page, but it's a `position: fixed` scroll
-  // container whose content often fits without overflowing (e.g. the short
-  // route list). When there's nothing to scroll, `overscroll-behavior:
-  // contain` has nothing to contain, so iOS treats a tap-drag as a page
-  // scroll — the concealed window slides underneath and the sheet visibly
-  // jitters. Swallow any touchmove that would chain to the window: the whole
-  // gesture when the panel can't scroll, and the boundary-overscroll frames
-  // (drag down at the top / up at the bottom) when it can. Attached
-  // non-passively so preventDefault actually takes — React's synthetic
-  // touchmove is passive and can't cancel the scroll.
-  useEffect(() => {
-    if (!open) return undefined;
-    const el = panelRef.current;
-    if (!el) return undefined;
-    let startY = 0;
-    const onTouchStart = (e) => {
-      startY = e.touches[0]?.clientY ?? 0;
-    };
-    const onTouchMove = (e) => {
-      // Leave pinch-zoom and other multi-touch gestures alone.
-      if (e.touches.length > 1) return;
-      const dy = (e.touches[0]?.clientY ?? 0) - startY;
-      const { scrollTop, scrollHeight, clientHeight } = el;
-      if (scrollHeight <= clientHeight) {
-        e.preventDefault();
-        return;
-      }
-      const atTop = scrollTop <= 0;
-      const atBottom = scrollTop + clientHeight >= scrollHeight;
-      if ((atTop && dy > 0) || (atBottom && dy < 0)) e.preventDefault();
-    };
-    el.addEventListener('touchstart', onTouchStart, { passive: true });
-    el.addEventListener('touchmove', onTouchMove, { passive: false });
-    return () => {
-      el.removeEventListener('touchstart', onTouchStart);
-      el.removeEventListener('touchmove', onTouchMove);
-    };
-  }, [open]);
+  // Keep a touch-drag on the open sheet from scrolling the concealed page
+  // behind it (the route list often fits without overflowing).
+  usePreventScrollChain(panelRef, open);
 
   // Esc pops the sub-view first; only closes the dock once we're back
   // at the root menu. The Modal's built-in Esc handler is disabled

--- a/src/components/BottomSheet.jsx
+++ b/src/components/BottomSheet.jsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import './BottomSheet.css';
 
 /**
@@ -35,6 +36,10 @@ export default function BottomSheet({
   children,
 }) {
   const reduce = useReducedMotion();
+  const panelRef = useRef(null);
+  // Keep a touch-drag on the open sheet from scrolling the page behind it
+  // when the panel's content fits without overflowing.
+  usePreventScrollChain(panelRef, open);
 
   useEffect(() => {
     if (!open || !closeOnEscape) return undefined;
@@ -74,6 +79,7 @@ export default function BottomSheet({
             transition={{ duration: reduce ? 0 : 0.34, ease: [0.32, 0.72, 0, 1] }}
           >
             <div
+              ref={panelRef}
               id={id}
               className={`bottom-sheet-panel bottom-sheet-panel-${size} ${className}`.trim()}
               role="dialog"

--- a/src/components/EditSheet.jsx
+++ b/src/components/EditSheet.jsx
@@ -6,6 +6,7 @@ import { ExternalLink, X } from 'lucide-react';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { useActionDock } from '../hooks/useActionDock.jsx';
+import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import RecordEditor from './RecordEditor.jsx';
 import { lexiconFor } from '../lib/lexicons.js';
 import { ME_DID } from '../config.js';
@@ -33,6 +34,10 @@ export default function EditSheet() {
   // Imperative handle into the editor + its live status, so the edit action
   // bar can host the Save / Delete controls instead of the sheet itself.
   const editorRef = useRef(null);
+  // Keep a touch-drag inside the sheet body from scrolling the page behind
+  // it when the form fits without overflowing.
+  const bodyRef = useRef(null);
+  usePreventScrollChain(bodyRef, !!editSheet);
   const [editorStatus, setEditorStatus] = useState({
     saving: false,
     deleting: false,
@@ -126,7 +131,7 @@ export default function EditSheet() {
                 </button>
               </div>
 
-              <div className="edit-sheet-body">
+              <div ref={bodyRef} className="edit-sheet-body">
                 {editable ? (
                   <RecordEditor
                     key={editSheet.atUri}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import './Modal.css';
 
 const PRESETS = {
@@ -58,6 +59,10 @@ export default function Modal({
   closeOnEscape = true,
 }) {
   const reduce = useReducedMotion();
+  const panelRef = useRef(null);
+  // Keep a touch-drag on the panel from scrolling the page behind it when
+  // its content fits without overflowing.
+  usePreventScrollChain(panelRef, open);
 
   useEffect(() => {
     if (!open || !closeOnEscape) return;
@@ -134,6 +139,7 @@ export default function Modal({
         {open && (
           <motion.div
             key="panel"
+            ref={panelRef}
             id={id}
             className={`modal-panel ${className}`}
             role="dialog"

--- a/src/hooks/usePreventScrollChain.js
+++ b/src/hooks/usePreventScrollChain.js
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+
+/** Can `node` actually scroll in the gesture's direction right now? A node
+ *  qualifies only if it truly overflows AND its overflow style allows
+ *  scrolling (scrollHeight > clientHeight alone is true for `overflow:
+ *  hidden` boxes too), and it isn't already pinned against the edge the
+ *  drag is pulling toward. `dy > 0` is a downward drag → content moves up →
+ *  scrollTop decreases, so it only has room when not already at the top;
+ *  `dy < 0` is the mirror at the bottom. */
+function scrollsInDirection(node, dy) {
+  if (!(node instanceof HTMLElement)) return false;
+  if (node.scrollHeight <= node.clientHeight) return false;
+  const overflowY = getComputedStyle(node).overflowY;
+  if (overflowY !== 'auto' && overflowY !== 'scroll') return false;
+  const atTop = node.scrollTop <= 0;
+  const atBottom = node.scrollTop + node.clientHeight >= node.scrollHeight;
+  if (dy > 0 && atTop) return false;
+  if (dy < 0 && atBottom) return false;
+  return true;
+}
+
+/**
+ * Keep a touch-drag inside an open overlay from scrolling the page behind it.
+ *
+ * Our overlays (the nav dock, the search/filter/info sheets, modals, the
+ * edit sheet) are `position: fixed` scroll containers that fully conceal the
+ * page. They already carry `overscroll-behavior: contain`, but that only
+ * stops scroll *chaining* once the container is actually scrollable and hits
+ * a boundary. When the content fits without overflowing — a short route
+ * list, a two-field form — there's nothing to scroll, so iOS treats a
+ * tap-drag as a page scroll and the concealed window slides underneath,
+ * making the overlay visibly jitter.
+ *
+ * On each move we walk from the touched node up to (and including) the
+ * container: if anything along the way can still scroll in the drag's
+ * direction — the container itself, or a nested scroller like a textarea —
+ * we let the browser handle it. Only when nothing can absorb the gesture do
+ * we cancel it, so it can never chain out to the window. Attached
+ * non-passively so `preventDefault()` actually takes — React's synthetic
+ * touchmove is passive and can't cancel the scroll.
+ *
+ * @param {import('react').RefObject<HTMLElement>} ref  the scroll container
+ * @param {boolean} active  guard only while the overlay is open
+ */
+export function usePreventScrollChain(ref, active) {
+  useEffect(() => {
+    if (!active) return undefined;
+    const el = ref.current;
+    if (!el) return undefined;
+    let startY = 0;
+    const onTouchStart = (e) => {
+      startY = e.touches[0]?.clientY ?? 0;
+    };
+    const onTouchMove = (e) => {
+      // Leave pinch-zoom and other multi-touch gestures alone.
+      if (e.touches.length > 1) return;
+      const dy = (e.touches[0]?.clientY ?? 0) - startY;
+      // Walk the ancestor chain from the touch target up through the
+      // container; bail the moment something can take the scroll.
+      let node = e.target;
+      while (node) {
+        if (scrollsInDirection(node, dy)) return;
+        if (node === el) break;
+        node = node.parentNode;
+      }
+      e.preventDefault();
+    };
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+    };
+  }, [ref, active]);
+}


### PR DESCRIPTION
## Summary

Follow-up to #134. Extracts the nav-menu touch-scroll guard into a reusable `usePreventScrollChain` hook and applies it to the other fixed overlays that fully conceal the page and can chain a tap-drag out to the window when their content fits without overflowing.

## Overlays covered

| Overlay | Scroll container | Reaches |
|---|---|---|
| `ActionDock` | `.dock-panel` | nav menu (refactored onto the hook) |
| `BottomSheet` | `.bottom-sheet-panel` | search / filter / info sheets |
| `Modal` | `.modal-panel` | lightbox + waypoints ("open in…") |
| `EditSheet` | `.edit-sheet-body` | owner edit mode |

## Behavior

The hook walks from the touched node up to the container and only cancels the gesture when nothing along the way can absorb it — the container itself or a nested scroller like a textarea. So in-panel scrolling and nested scrolling keep working, while a drag that would otherwise chain to the concealed page is blocked. Attached non-passively so `preventDefault()` takes (React's synthetic touchmove is passive).

Verified with `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiZ3ypj38Enah1Vz6kJo1Y)_