### PR TITLE
Link card editor fixes + preserve/annotate record images + natural-ratio covers

### DIFF
--- a/api/image-proxy.js
+++ b/api/image-proxy.js
@@ -1,0 +1,41 @@
+// Vercel serverless function: stream a remote image through our own origin so
+// the block editor can pull a link's preview image (og:image) and re-upload it
+// to the author's PDS as a blob. A straight browser fetch of the remote image
+// is blocked by CORS on most hosts; proxying through dame.is sidesteps that and
+// hands the client clean bytes + content-type it can wrap in a File.
+//
+// Read-only, owner-facing (used only inside the admin editor), but still guard
+// the obvious feet: http(s) only, image content-types only, and a size cap.
+
+const MAX_BYTES = 8 * 1024 * 1024; // og images are small; refuse anything huge.
+
+export default async function handler(req, res) {
+  const url = req.query?.url;
+  if (!url || !/^https?:\/\//i.test(url)) {
+    return res.status(400).json({ error: 'Pass a valid http(s) `url` query param.' });
+  }
+  try {
+    const upstream = await fetch(url, {
+      headers: { 'user-agent': 'Mozilla/5.0 (dame.is link unfurl)' },
+      redirect: 'follow',
+    });
+    if (!upstream.ok) {
+      return res.status(502).json({ error: `Upstream ${upstream.status}` });
+    }
+    const type = upstream.headers.get('content-type') || '';
+    if (!/^image\//i.test(type)) {
+      return res.status(415).json({ error: `Not an image (${type || 'unknown type'}).` });
+    }
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    if (buf.length > MAX_BYTES) {
+      return res.status(413).json({ error: 'Image too large.' });
+    }
+    res.setHeader('content-type', type);
+    res.setHeader('content-length', String(buf.length));
+    res.setHeader('cache-control', 'public, max-age=3600, s-maxage=86400');
+    return res.status(200).end(buf);
+  } catch (err) {
+    res.setHeader('cache-control', 'no-store');
+    return res.status(502).json({ error: err?.message || 'image proxy failed' });
+  }
+}

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -701,6 +701,9 @@ a.post-card-author-link:focus-visible {
 }
 
 .creating-card-thumb img {
+  /* Full cover at its natural aspect ratio (no crop); width fills the column. */
+  width: 100%;
+  height: auto;
   border-radius: var(--radius-2);
   border: 1px solid var(--rule-soft);
 }

--- a/src/components/LeafletDocument.jsx
+++ b/src/components/LeafletDocument.jsx
@@ -247,8 +247,11 @@ export function videoEmbedSrc(url) {
 }
 
 function WebsiteBlock({ block }) {
-  const href = block.src;
-  if (!href) return null;
+  const raw = block.src;
+  if (!raw) return null;
+  // Authors can enter a bare host ("anisota.net"); make the link (and the
+  // hostname parse below) work by assuming https when no scheme is present.
+  const href = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
 
   // Known video hosts render as an inline player instead of a link card.
   const embed = videoEmbedSrc(href);

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -1,10 +1,51 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
 import { renderMarkdown } from '../lib/markdown.js';
+import { resolvePds } from '../lib/atproto.js';
+import { annotateBlobUrl, annotateLeafletBlobs } from '../lib/feedBuilder.js';
 import BlocksEditor from './blocks/BlocksEditor.jsx';
 import { uploadImageFile } from './blocks/ImageBlockEditor.jsx';
 import LeafletDocument from './LeafletDocument.jsx';
 import '../pages/Admin.css';
+
+/**
+ * `agent.com.atproto.repo.getRecord` returns blobs as `BlobRef` instances.
+ * `structuredClone` mangles those into invalid plain objects (losing `toJSON`
+ * and `ref.$link`), which then get re-put as garbage — silently stripping the
+ * image. A JSON round-trip instead runs each BlobRef's `toJSON`, yielding the
+ * plain `{$type:'blob', ref:{$link}, …}` wire form: safe to clone, and
+ * re-hydrated correctly by the client on save.
+ */
+function toPlainRecord(value) {
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+/** Deep-remove our `_url` display annotations so they never reach the PDS. */
+function stripUrlAnnotations(value) {
+  if (Array.isArray(value)) return value.map(stripUrlAnnotations);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === '_url') continue;
+      out[k] = stripUrlAnnotations(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Bake `_url` display URLs onto a record's blob refs (top-level image fields
+ * and any image/preview blobs inside `blocks` bodies) so existing images show
+ * in the editor. Mirrors the feed builder's read-path annotation.
+ */
+function annotateRecordBlobs(record, lex, pds, did) {
+  if (!record || !pds) return;
+  for (const f of lex?.fields || []) {
+    if (f.type === 'image') annotateBlobUrl(record[f.key], pds, did);
+    if (f.type === 'blocks') annotateLeafletBlobs(record[f.key], pds, did);
+  }
+}
 
 /**
  * Reusable record editor (form + raw JSON + save/delete) shared by the admin
@@ -99,10 +140,24 @@ const RecordEditor = forwardRef(function RecordEditor({
         });
         const fetched = (res?.data || res)?.value || {};
         if (cancelled) return;
-        const migrated = lex?.migrate ? lex.migrate(structuredClone(fetched)) : structuredClone(fetched);
+        // Normalize BlobRef instances to plain JSON *before* any clone/migrate
+        // (structuredClone would corrupt them and strip images on save).
+        const plain = toPlainRecord(fetched);
+        const migrated = lex?.migrate ? lex.migrate(plain) : plain;
+        // Bake display URLs onto blob refs so existing images render in the
+        // editor. Best-effort: a failed PDS resolve just leaves them blank.
+        let pds = null;
+        try {
+          pds = await resolvePds(did);
+        } catch {
+          /* display-only; the record still loads and saves fine */
+        }
+        if (cancelled) return;
+        if (pds) annotateRecordBlobs(migrated, lex, pds, did);
         setOriginal(fetched);
         setValue(migrated);
-        setRawText(JSON.stringify(migrated, null, 2));
+        // The raw-JSON view and payload must stay clean of `_url` annotations.
+        setRawText(JSON.stringify(stripUrlAnnotations(migrated), null, 2));
         if (!lex) setRawMode(true);
       } catch (err) {
         if (!cancelled) setError(err?.message || String(err));
@@ -149,7 +204,10 @@ const RecordEditor = forwardRef(function RecordEditor({
     if (Array.isArray(lex?.stripLegacyKeys)) {
       for (const k of lex.stripLegacyKeys) delete next[k];
     }
-    return next;
+    // Normalize first (runs BlobRef.toJSON on freshly uploaded blobs → clean
+    // wire form; a plain recursive walk would mangle those instances), then
+    // drop the `_url` display annotations so they never reach the PDS.
+    return stripUrlAnnotations(toPlainRecord(next));
   }, [value, lex, rawMode, rawText, isNew]);
 
   async function handleSave() {

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -66,6 +66,14 @@ const RecordEditor = forwardRef(function RecordEditor({
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState(null);
   const [savedFlash, setSavedFlash] = useState(false);
+  // A transient object URL so a cover image set from inside a link card shows
+  // in the cover field right away (a fresh blob has no `_url` until reload).
+  const [coverPreview, setCoverPreview] = useState(null);
+  const coverPreviewRef = useRef(null);
+  coverPreviewRef.current = coverPreview;
+  useEffect(() => () => {
+    if (coverPreviewRef.current) URL.revokeObjectURL(coverPreviewRef.current);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -315,6 +323,14 @@ const RecordEditor = forwardRef(function RecordEditor({
           onChange={updateField}
           agent={agent}
           did={did}
+          coverPreview={coverPreview}
+          onSetCover={(key, blob, previewUrl) => {
+            updateField(key, blob);
+            setCoverPreview((prev) => {
+              if (prev && prev !== previewUrl) URL.revokeObjectURL(prev);
+              return previewUrl || null;
+            });
+          }}
         />
       )}
 
@@ -353,7 +369,14 @@ export default RecordEditor;
 /* Field renderers                                                      */
 /* ------------------------------------------------------------------ */
 
-function FormEditor({ lex, value, onChange, agent, did }) {
+function FormEditor({ lex, value, onChange, agent, did, coverPreview, onSetCover }) {
+  // If this record type carries a top-level image field (e.g. a document's
+  // coverImage), link cards can offer to reuse their preview image as it.
+  const coverField = lex.fields.find((f) => f.type === 'image');
+  const setCover = coverField
+    ? (blob, previewUrl) => onSetCover(coverField.key, blob, previewUrl)
+    : null;
+
   return (
     <div className="admin-form">
       {lex.fields.map((f) => (
@@ -364,6 +387,8 @@ function FormEditor({ lex, value, onChange, agent, did }) {
           onChange={(v) => onChange(f.key, v)}
           agent={agent}
           did={did}
+          onSetCover={f.type === 'blocks' ? setCover : undefined}
+          externalPreview={coverField && f.key === coverField.key ? coverPreview : undefined}
         />
       ))}
     </div>
@@ -428,7 +453,7 @@ function RecordPreview({ lex, record }) {
   );
 }
 
-function Field({ field, value, onChange, agent, did }) {
+function Field({ field, value, onChange, agent, did, onSetCover, externalPreview }) {
   const id = `record-editor-field-${field.key}`;
   let control;
   switch (field.type) {
@@ -550,11 +575,25 @@ function Field({ field, value, onChange, agent, did }) {
       break;
     case 'blocks':
       control = (
-        <BlocksEditor agent={agent} did={did} value={value} onChange={onChange} />
+        <BlocksEditor
+          agent={agent}
+          did={did}
+          value={value}
+          onChange={onChange}
+          onSetCover={onSetCover}
+        />
       );
       break;
     case 'image':
-      control = <ImageField id={id} value={value} onChange={onChange} agent={agent} />;
+      control = (
+        <ImageField
+          id={id}
+          value={value}
+          onChange={onChange}
+          agent={agent}
+          externalPreview={externalPreview}
+        />
+      );
       break;
     case 'publicationPicker':
       control = (
@@ -746,7 +785,7 @@ function CategoryField({ id, value, onChange, placeholder, suggestions }) {
  * upload to the PDS; stores the returned BlobRef. Mirrors ImageBlockEditor's
  * upload flow but for one top-level field rather than a content block.
  */
-function ImageField({ id, value, onChange, agent }) {
+function ImageField({ id, value, onChange, agent, externalPreview }) {
   const [status, setStatus] = useState(null);
   const [previewUrl, setPreviewUrl] = useState(null);
   const fileRef = useRef(null);
@@ -772,7 +811,7 @@ function ImageField({ id, value, onChange, agent }) {
     }
   }
 
-  const displayUrl = previewUrl || value?._url || null;
+  const displayUrl = previewUrl || value?._url || externalPreview || null;
 
   return (
     <div className="image-block-editor">

--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -22,7 +22,7 @@ const CONTENT_TYPE = 'pub.leaflet.content';
  * at a time — clicking another block (or "Done", or away from the editor)
  * collapses the active block back to its preview.
  */
-export default function BlocksEditor({ agent, did, value, onChange }) {
+export default function BlocksEditor({ agent, did, value, onChange, onSetCover }) {
   const content = useMemo(() => ensureShape(value), [value]);
   const blocks = content.pages[0].blocks;
 
@@ -351,6 +351,7 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
                     agent={agent}
                     did={did}
                     onChange={(next) => updateBlock(i, next)}
+                    onSetCover={onSetCover}
                   />
                 </div>
               ) : (
@@ -393,7 +394,7 @@ export default function BlocksEditor({ agent, did, value, onChange }) {
   );
 }
 
-function BlockBody({ block, agent, did, onChange }) {
+function BlockBody({ block, agent, did, onChange, onSetCover }) {
   switch (block.$type) {
     case 'pub.leaflet.blocks.text':
       return <TextBlockEditor block={block} onChange={onChange} />;
@@ -402,7 +403,15 @@ function BlockBody({ block, agent, did, onChange }) {
     case 'pub.leaflet.blocks.image':
       return <ImageBlockEditor block={block} agent={agent} did={did} onChange={onChange} />;
     case 'pub.leaflet.blocks.website':
-      return <WebsiteBlockEditor block={block} agent={agent} did={did} onChange={onChange} />;
+      return (
+        <WebsiteBlockEditor
+          block={block}
+          agent={agent}
+          did={did}
+          onChange={onChange}
+          onSetCover={onSetCover}
+        />
+      );
     case 'pub.leaflet.blocks.code':
       return <CodeBlockEditor block={block} onChange={onChange} />;
     case 'pub.leaflet.blocks.unorderedList':

--- a/src/components/blocks/WebsiteBlockEditor.jsx
+++ b/src/components/blocks/WebsiteBlockEditor.jsx
@@ -1,38 +1,124 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { uploadImageFile } from './ImageBlockEditor.jsx';
 
-export default function WebsiteBlockEditor({ block, agent, onChange }) {
+/**
+ * Add `https://` to a bare URL so authors can type `anisota.net` and still
+ * get a working link (and a fetchable target for metadata). Leaves an
+ * existing scheme — or an empty string — untouched.
+ */
+export function normalizeUrl(raw) {
+  const s = (raw || '').trim();
+  if (!s) return '';
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(s)) return s; // already has a scheme
+  if (s.startsWith('//')) return `https:${s}`;
+  return `https://${s}`;
+}
+
+export default function WebsiteBlockEditor({ block, agent, onChange, onSetCover }) {
   const [status, setStatus] = useState(null);
   const [unfurling, setUnfurling] = useState(false);
+  // Object URL for a just-obtained image (upload or auto-detected preview).
+  // A fresh blob has no `_url` yet — that only lands when the record is read
+  // back — so we keep a local URL to show the thumbnail immediately.
+  const [localPreviewUrl, setLocalPreviewUrl] = useState(null);
+  const [coverDone, setCoverDone] = useState(false);
+  // The link's og:image URL, if metadata turned one up. Kept in local state
+  // (not on the block) so it never gets persisted into the record.
+  const [detected, setDetected] = useState(null);
   const fileRef = useRef(null);
+  // The raw bytes behind the current preview, kept so "Use as record cover"
+  // can mint a fresh, independently-owned object URL for the cover field
+  // (this editor's own preview URL is revoked when the card collapses).
+  const rawImageRef = useRef(null);
+
+  // Revoke the local object URL on unmount / when replaced.
+  useEffect(() => () => localPreviewUrl && URL.revokeObjectURL(localPreviewUrl), [localPreviewUrl]);
+
+  function setLocalPreview(url) {
+    setLocalPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return url;
+    });
+  }
 
   async function handlePreviewFile(file) {
     if (!file) return;
+    rawImageRef.current = file;
+    const local = URL.createObjectURL(file);
+    setLocalPreview(local);
     setStatus('Uploading…');
     try {
       const { blob } = await uploadImageFile(agent, file);
       onChange({ ...block, previewImage: blob });
+      setCoverDone(false);
       setStatus(null);
     } catch (err) {
       setStatus(`Upload failed: ${err?.message || err}`);
     }
   }
 
-  // Pull title/description from the linked page's Open Graph tags via the
-  // /api/unfurl serverless endpoint, so link cards aren't filled by hand.
+  // Pull a remote image (e.g. the link's og:image) through our same-origin
+  // proxy — a direct cross-origin fetch is CORS-blocked on most hosts — then
+  // upload it to the PDS. Returns the blob ref (and shows the thumbnail from a
+  // local object URL); the caller decides how to merge it into the block so
+  // this never clobbers concurrent field edits.
+  async function fetchAndUploadImage(imageUrl) {
+    const res = await fetch(`/api/image-proxy?url=${encodeURIComponent(imageUrl)}`);
+    if (!res.ok) throw new Error(`proxy ${res.status}`);
+    const raw = await res.blob();
+    const type = raw.type || 'image/jpeg';
+    const ext = (type.split('/')[1] || 'jpg').split(';')[0];
+    const file = new File([raw], `preview.${ext}`, { type });
+    rawImageRef.current = raw;
+    setLocalPreview(URL.createObjectURL(raw));
+    const { blob } = await uploadImageFile(agent, file);
+    return blob;
+  }
+
+  // "Use detected image" button — swap the current preview for the og:image.
+  async function useDetectedImage(imageUrl) {
+    if (!imageUrl) return;
+    setStatus('Fetching preview image…');
+    try {
+      const blob = await fetchAndUploadImage(imageUrl);
+      onChange({ ...block, previewImage: blob });
+      setCoverDone(false);
+      setStatus(null);
+    } catch {
+      setStatus('Could not load that image.');
+    }
+  }
+
+  // Pull title/description/image from the linked page's Open Graph tags via the
+  // /api/unfurl endpoint so link cards aren't filled by hand. A detected image
+  // auto-fills the preview when the card doesn't already have one.
   async function fetchMetadata() {
-    if (!block.src) return;
+    const src = normalizeUrl(block.src);
+    if (!src) return;
     setUnfurling(true);
     try {
-      const res = await fetch(`/api/unfurl?url=${encodeURIComponent(block.src)}`);
+      const res = await fetch(`/api/unfurl?url=${encodeURIComponent(src)}`);
       const data = await res.json();
-      if (data && (data.title || data.description)) {
-        onChange({
-          ...block,
-          title: block.title || data.title || '',
-          description: block.description || data.description || '',
-        });
+      // Merge everything into a single block so title/description and a
+      // freshly uploaded preview blob land together (avoids a stale-block race
+      // between two separate onChange calls).
+      const next = {
+        ...block,
+        src,
+        title: block.title || data?.title || '',
+        description: block.description || data?.description || '',
+      };
+      if (data?.image) setDetected(data.image);
+      if (data?.image && !block.previewImage) {
+        try {
+          setStatus('Fetching preview image…');
+          next.previewImage = await fetchAndUploadImage(data.image);
+          setStatus(null);
+        } catch {
+          setStatus('Metadata loaded, but the preview image could not be fetched.');
+        }
       }
+      onChange(next);
     } catch {
       /* leave fields as-is on failure */
     } finally {
@@ -40,7 +126,24 @@ export default function WebsiteBlockEditor({ block, agent, onChange }) {
     }
   }
 
-  const previewUrl = block?.previewImage?._url || null;
+  function clearPreview() {
+    setLocalPreview(null);
+    setCoverDone(false);
+    onChange({ ...block, previewImage: undefined });
+  }
+
+  function useAsCover() {
+    if (!onSetCover || !block.previewImage) return;
+    // Mint a URL the cover field can own (ours is revoked on collapse); fall
+    // back to the blob's read-back URL if the raw bytes aren't around.
+    const coverUrl = rawImageRef.current
+      ? URL.createObjectURL(rawImageRef.current)
+      : block.previewImage?._url || null;
+    onSetCover(block.previewImage, coverUrl);
+    setCoverDone(true);
+  }
+
+  const previewUrl = localPreviewUrl || block?.previewImage?._url || null;
 
   return (
     <div className="website-block-editor">
@@ -51,7 +154,11 @@ export default function WebsiteBlockEditor({ block, agent, onChange }) {
           type="url"
           value={block.src || ''}
           onChange={(e) => onChange({ ...block, src: e.target.value })}
-          placeholder="https://example.com"
+          onBlur={() => {
+            const src = normalizeUrl(block.src);
+            if (src !== block.src) onChange({ ...block, src });
+          }}
+          placeholder="example.com"
         />
       </label>
       <div className="website-block-actions">
@@ -63,7 +170,9 @@ export default function WebsiteBlockEditor({ block, agent, onChange }) {
         >
           {unfurling ? 'Fetching…' : 'Fetch metadata'}
         </button>
-        <span className="admin-field-hint">YouTube / Vimeo URLs render as an inline player.</span>
+        <span className="admin-field-hint">
+          No “https://” needed. YouTube / Vimeo URLs render as an inline player.
+        </span>
       </div>
       <label className="admin-field-label">
         Title
@@ -90,22 +199,43 @@ export default function WebsiteBlockEditor({ block, agent, onChange }) {
         {previewUrl && (
           <img className="website-block-preview-img" src={previewUrl} alt="" />
         )}
-        <button
-          type="button"
-          className="admin-link-subtle"
-          onClick={() => fileRef.current?.click()}
-        >
-          {previewUrl ? 'Replace preview' : 'Upload preview'}
-        </button>
-        {block.previewImage && (
+        {/* Offer the detected og:image when it isn't the one already in use. */}
+        {detected && !previewUrl && (
           <button
             type="button"
             className="admin-link-subtle"
-            onClick={() => onChange({ ...block, previewImage: undefined })}
+            onClick={() => useDetectedImage(detected)}
           >
-            Remove preview
+            Use detected image
           </button>
         )}
+        <div className="website-block-preview-actions">
+          <button
+            type="button"
+            className="admin-link-subtle"
+            onClick={() => fileRef.current?.click()}
+          >
+            {previewUrl ? 'Replace preview' : 'Upload preview'}
+          </button>
+          {previewUrl && onSetCover && (
+            <button
+              type="button"
+              className="admin-link-subtle"
+              onClick={useAsCover}
+            >
+              {coverDone ? 'Cover set ✓' : 'Use as record cover'}
+            </button>
+          )}
+          {block.previewImage && (
+            <button
+              type="button"
+              className="admin-link-subtle"
+              onClick={clearPreview}
+            >
+              Remove preview
+            </button>
+          )}
+        </div>
         <input
           ref={fileRef}
           type="file"

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -388,6 +388,13 @@
   align-items: flex-start;
 }
 
+.website-block-preview-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
 .website-block-preview-img {
   max-width: 12rem;
   max-height: 8rem;

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -16,6 +16,11 @@
   padding: var(--space-2) var(--space-3);
   font-family: var(--sans);
   font-size: var(--text-sm);
+  /* Some inputs sit *inside* their <label class="admin-field-label">, which
+     carries `font-variant: all-small-caps`; without this reset the typed
+     value renders as small caps (e.g. link-card URL/title/description). */
+  font-variant: normal;
+  text-transform: none;
   color: var(--ink);
   background: var(--page);
   border: 1px solid var(--rule);

--- a/src/pages/Creating.css
+++ b/src/pages/Creating.css
@@ -32,9 +32,10 @@
 }
 
 .creating-grid-link img {
-  aspect-ratio: 4/3;
+  /* Show the cover at its own aspect ratio rather than cropping it to a
+     fixed box. Width fills the card; height follows the image. */
   width: 100%;
-  object-fit: cover;
+  height: auto;
   background: var(--page);
 }
 


### PR DESCRIPTION
## Summary

Addresses link-card editor polish and a data-loss bug found in the record editor.

### Link card editor
- **Inputs no longer render in small-caps.** URL/title/description inputs sit inside their `.admin-field-label` (which sets `font-variant: all-small-caps`) and inherited it; reset `font-variant`/`text-transform` on `.admin-input`.
- **URLs work without `https://`.** A bare host (`anisota.net`) is normalized to https on blur and before an unfurl fetch, and the rendered card assumes https for scheme-less `src`.
- **Preview images come through.** Fresh uploads show immediately via a local object URL; "Fetch metadata" now auto-detects the page's og:image and fills the preview (pulled through a new same-origin `/api/image-proxy` so the cross-origin image can be re-uploaded as a blob), with a "Use detected image" fallback.
- **"Use as record cover"** action promotes a link card's preview image to the record's top-level cover in one click, when the record type has an image field.

### Record editor image bug (data loss)
`agent.getRecord` returns blobs as `BlobRef` instances; the editor cloned records with `structuredClone`, which mangles a `BlobRef` into an invalid object (no `toJSON`, no `ref.$link`). That corrupted blob was re-put on save — silently stripping cover/block images — and rendered blank with no `_url`.
- Load: normalize via a JSON round-trip (runs `BlobRef.toJSON` → clean wire form) instead of `structuredClone`.
- Display: bake `_url` onto blob refs on load so existing cover + block images show in the editor.
- Save: normalize the payload and strip `_url` annotations so they never reach the PDS.

### Creating covers
The `/creating` grid cropped covers to a fixed `4/3` box (`object-fit: cover`); grid and feed cards now render the cover at its natural aspect ratio.

## Testing
- `vite build` passes.
- Save-payload round-trip validated against `@atproto`'s `jsonToLex`: both loaded blobs and fresh uploads serialize to valid `{$type:"blob", ref:{$link}…}` with `_url` stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_