### PR TITLE
Stack display name and handle on post reply bylines

### DIFF
--- a/src/components/Comments.css
+++ b/src/components/Comments.css
@@ -83,9 +83,9 @@
 
 .comment-author {
   display: inline-flex;
-  align-items: baseline;
-  gap: 0.4rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
   min-width: 0;
 }
 


### PR DESCRIPTION
On post pages, each reply's byline now stacks the author's display name above their handle instead of laying them out inline side-by-side.

## Changes
- In `src/components/Comments.css`, the `.comment-author` container (wrapping the display name and `@handle`) switches from a baseline-aligned horizontal row to a vertical column (`flex-direction: column` + `align-items: flex-start`).
- Tightened the `gap` from `0.4rem` to `0.1rem` for natural stacked spacing and removed the now-unneeded `flex-wrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKzr82UjwSvsTinwv6gMcU)_