### PR TITLE
Turn the "Open in…" picker into a bottom sheet

### DIFF
--- a/src/components/WaypointsSheet.css
+++ b/src/components/WaypointsSheet.css
@@ -1,41 +1,39 @@
-/* Interior of the "Open in…" picker. The <Modal> shell owns positioning,
-   surface, scrim, and motion — only the layout of the picker lives here.
-   Styling follows the same language as InfoModal: small-caps header, hairline
-   rules, accent-on-hover. */
+/* Interior of the "Open in…" picker. The <BottomSheet> shell owns
+   positioning, the surface, and the expand-up animation; only the layout of
+   the picker lives here. Structure + spacing follow the sibling InfoSheet so
+   every bottom sheet reads as one family. */
 
-.waypoints-modal-panel {
-  width: min(440px, 100%);
+.waypoints-sheet {
+  /* Match InfoSheet's inset so the picker's content column lines up with the
+     other bottom sheets (and the bottom bar's buttons that trigger them). */
+  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
   display: flex;
   flex-direction: column;
+  gap: var(--space-4);
 }
 
-.waypoints-modal {
-  display: flex;
-  flex-direction: column;
-}
-
-.waypoints-modal-header {
+.waypoints-sheet-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-5) var(--space-5) var(--space-4);
-  border-bottom: 1px solid var(--rule-soft);
 }
 
-.waypoints-modal-heading {
+.waypoints-sheet-heading {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
   min-width: 0;
 }
 
-.waypoints-modal-heading .small-caps {
+.waypoints-sheet-heading .small-caps {
+  font-family: var(--sans);
   font-size: var(--text-xs);
   letter-spacing: 0.16em;
+  color: var(--ink-faint);
 }
 
-.waypoints-modal-subtitle {
+.waypoints-sheet-subtitle {
   font-family: var(--sans);
   font-size: var(--text-xs);
   color: var(--ink-faint);
@@ -44,7 +42,7 @@
   white-space: nowrap;
 }
 
-.waypoints-modal-close {
+.waypoints-sheet-close {
   flex: none;
   display: inline-flex;
   align-items: center;
@@ -54,28 +52,27 @@
   padding: 0;
   border: 1px solid var(--rule);
   border-radius: 0;
-  background: transparent;
+  background: var(--page);
   color: var(--ink-soft);
   cursor: pointer;
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
-.waypoints-modal-close:hover,
-.waypoints-modal-close:focus-visible {
+.waypoints-sheet-close:hover,
+.waypoints-sheet-close:focus-visible {
   color: var(--accent);
   border-color: var(--accent-soft);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
   outline: none;
 }
 
-.waypoints-modal-body {
+.waypoints-sheet-body {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  padding: var(--space-4) var(--space-5);
 }
 
-.waypoints-modal-note {
+.waypoints-sheet-note {
   margin: 0;
   font-family: var(--sans);
   font-size: var(--text-sm);
@@ -125,7 +122,7 @@
   gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--rule);
-  background: transparent;
+  background: var(--page);
   color: var(--ink);
   font-family: var(--sans);
   font-size: var(--text-sm);
@@ -142,7 +139,7 @@
 .waypoints-row-open:focus-visible {
   color: var(--accent);
   border-color: var(--accent-soft);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
   outline: none;
 }
 
@@ -172,7 +169,7 @@
   padding: 0;
   border: 1px solid var(--rule);
   border-radius: 0;
-  background: transparent;
+  background: var(--page);
   color: var(--ink-soft);
   cursor: pointer;
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
@@ -182,17 +179,16 @@
 .waypoints-row-copy:focus-visible {
   color: var(--accent);
   border-color: var(--accent-soft);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
   outline: none;
 }
 
 /* --- original-link fallback ---------------------------------------------- */
 
-.waypoints-modal-original {
+.waypoints-sheet-original {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  padding: var(--space-3) var(--space-5) var(--space-5);
   font-family: var(--sans);
   font-size: var(--text-xs);
   letter-spacing: 0.04em;
@@ -201,8 +197,8 @@
   transition: color 120ms ease;
 }
 
-.waypoints-modal-original:hover,
-.waypoints-modal-original:focus-visible {
+.waypoints-sheet-original:hover,
+.waypoints-sheet-original:focus-visible {
   color: var(--accent);
   outline: none;
 }

--- a/src/components/WaypointsSheet.jsx
+++ b/src/components/WaypointsSheet.jsx
@@ -1,20 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
 import { X, Copy, Check, ArrowUpRight } from 'lucide-react';
-import Modal from './Modal.jsx';
+import BottomSheet from './BottomSheet.jsx';
 import { resolveWaypoints, groupWaypoints, describeResolved } from '../lib/waypoints.js';
-import './WaypointsModal.css';
+import './WaypointsSheet.css';
 
 /**
  * The "Open in…" picker. Given an outbound Atmosphere link (or `at://` URI),
  * it resolves the record to the set of clients that can open it and lets the
  * visitor choose one — powered by @aturi.to/waypoints.
  *
+ * Expands up out of the bottom chrome bar as a <BottomSheet>, the same surface
+ * behind the search / info / filter panels and the nav dock — rather than a
+ * centered modal, so every dismissable surface reads as one system.
+ *
  * Rendered once at the app root by <WaypointsModalProvider>; `href` is set by
  * the global link interceptor (or an imperative `openWaypoints()` call). The
  * whole subtree carries `data-no-waypoints` so its own links don't re-trigger
  * the interceptor.
  */
-export default function WaypointsModal({ open, href, onClose }) {
+export default function WaypointsSheet({ open, href, onClose }) {
   const [status, setStatus] = useState('idle'); // idle | loading | ready | empty | error
   const [sections, setSections] = useState({ recommended: [], groups: [] });
   const [subtitle, setSubtitle] = useState('');
@@ -52,7 +56,7 @@ export default function WaypointsModal({ open, href, onClose }) {
     };
   }, [open, href]);
 
-  // Reset the transient "copied" checkmark whenever the modal closes.
+  // Reset the transient "copied" checkmark whenever the sheet closes.
   useEffect(() => {
     if (!open) {
       setCopiedUrl(null);
@@ -74,16 +78,16 @@ export default function WaypointsModal({ open, href, onClose }) {
   }
 
   return (
-    <Modal open={open} onClose={onClose} label="Open in…" className="waypoints-modal-panel">
-      <div className="waypoints-modal" data-no-waypoints>
-        <div className="waypoints-modal-header">
-          <div className="waypoints-modal-heading">
+    <BottomSheet open={open} onClose={onClose} label="Open in…" id="waypoints-sheet">
+      <div className="waypoints-sheet" data-no-waypoints>
+        <div className="waypoints-sheet-header">
+          <div className="waypoints-sheet-heading">
             <span className="small-caps">open in…</span>
-            {subtitle && <span className="waypoints-modal-subtitle">{subtitle}</span>}
+            {subtitle && <span className="waypoints-sheet-subtitle">{subtitle}</span>}
           </div>
           <button
             type="button"
-            className="waypoints-modal-close"
+            className="waypoints-sheet-close"
             onClick={onClose}
             aria-label="Close"
           >
@@ -91,19 +95,19 @@ export default function WaypointsModal({ open, href, onClose }) {
           </button>
         </div>
 
-        <div className="waypoints-modal-body">
+        <div className="waypoints-sheet-body">
           {status === 'loading' && (
-            <p className="waypoints-modal-note">Resolving destinations…</p>
+            <p className="waypoints-sheet-note">Resolving destinations…</p>
           )}
 
           {status === 'error' && (
-            <p className="waypoints-modal-note">
+            <p className="waypoints-sheet-note">
               Couldn't resolve this link into Atmosphere clients.
             </p>
           )}
 
           {status === 'empty' && (
-            <p className="waypoints-modal-note">
+            <p className="waypoints-sheet-note">
               No other clients can open this link.
             </p>
           )}
@@ -136,7 +140,7 @@ export default function WaypointsModal({ open, href, onClose }) {
 
         {isHttp && status !== 'loading' && (
           <a
-            className="waypoints-modal-original"
+            className="waypoints-sheet-original"
             href={href}
             target="_blank"
             rel="noreferrer noopener"
@@ -147,7 +151,7 @@ export default function WaypointsModal({ open, href, onClose }) {
           </a>
         )}
       </div>
-    </Modal>
+    </BottomSheet>
   );
 }
 

--- a/src/hooks/useWaypointsModal.jsx
+++ b/src/hooks/useWaypointsModal.jsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import WaypointsModal from '../components/WaypointsModal.jsx';
+import WaypointsSheet from '../components/WaypointsSheet.jsx';
 import { isWaypointHref } from '../lib/waypoints.js';
 
 const WaypointsModalContext = createContext(null);
@@ -66,7 +66,7 @@ export function WaypointsModalProvider({ children }) {
   return (
     <WaypointsModalContext.Provider value={value}>
       {children}
-      <WaypointsModal open={href != null} href={href} onClose={close} />
+      <WaypointsSheet open={href != null} href={href} onClose={close} />
     </WaypointsModalContext.Provider>
   );
 }


### PR DESCRIPTION
Convert the "Open in…" picker from a centered `<Modal>` overlay into a `<BottomSheet>` that expands up out of the bottom chrome bar — the same surface behind the search / info / filter panels and the nav dock — so every dismissable surface reads as one system. Mirrors the earlier InfoModal → InfoSheet move.

## Changes

- **Rename `WaypointsModal` → `WaypointsSheet`** (component + CSS) for honest naming. The `useWaypointsModal` provider API is unchanged, so `AturiActions` and the global link interceptor are untouched.
- **Rebuild the interior on the sheet surface** following `InfoSheet`'s structure: chrome-aligned padding, small-caps header + close button, grouped destination rows on the `--page` chip fill.
- **Preserve behavior**: the `data-no-waypoints` re-trigger guard, offline `at://` resolution, copy buttons, and the original-link fallback.

The image lightbox and first-visit welcome intro intentionally stay immersive overlays — a bottom sheet would confine the image / break the intro.

## Verification

Driven with a headless browser at 1000px and 560px widths by injecting an `at://` link (resolves offline) and clicking it:

- The picker expands as a `role="dialog"` sheet labelled "Open in…", resolving 4 destinations.
- The panel sits directly on top of the bottom bar (expands out of the bottom chrome).
- Content stays inside `[data-no-waypoints]`; closes on outside click and Escape.

`vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg477iojmbXEfoseuJGKgT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg477iojmbXEfoseuJGKgT)_