### PR TITLE
Refine reply bylines and thread nesting on post pages

### DIFF
--- a/src/components/Comments.css
+++ b/src/components/Comments.css
@@ -18,12 +18,19 @@
   margin: 0;
   display: flex;
   flex-direction: column;
+  /* Avatar edge length; also drives the hanging indent of text/embeds so
+     they line up under the byline. Nested replies shrink it below. */
+  --comment-avatar: 2.5rem;
 }
 
 .comments-tree-nested {
+  --comment-avatar: 2rem;
   margin-top: var(--space-3);
-  padding-left: var(--space-4);
-  border-left: 1px solid var(--rule-soft);
+  margin-left: var(--space-2);
+  padding-left: var(--space-5);
+  /* A soft green rail reads as a thread spine, distinct from the tan
+     hairline rules that separate sibling replies. */
+  border-left: 2px solid color-mix(in srgb, var(--accent-soft) 55%, transparent);
 }
 
 .comment {
@@ -52,13 +59,13 @@
 
 .comment-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-3);
 }
 
 .comment-avatar {
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--comment-avatar);
+  height: var(--comment-avatar);
   border-radius: 0;
   border: 1px solid var(--rule);
   object-fit: cover;
@@ -75,7 +82,7 @@
 .comment-byline {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: flex-start;
   gap: var(--space-2) var(--space-3);
   min-width: 0;
   flex: 1 1 auto;
@@ -85,13 +92,14 @@
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.1rem;
+  gap: 0;
   min-width: 0;
 }
 
 .comment-author-name {
   color: var(--ink);
   font-weight: 500;
+  line-height: 1.25;
   text-decoration: none;
   border-bottom: 1px dotted transparent;
 }
@@ -104,6 +112,7 @@ a.comment-author-name:focus-visible {
 .comment-author-handle {
   color: var(--ink-muted);
   font-size: var(--text-sm);
+  line-height: 1.2;
   letter-spacing: 0.04em;
 }
 
@@ -131,7 +140,7 @@ a.comment-author-name:focus-visible {
   white-space: pre-wrap;
   color: var(--ink-soft);
   max-width: var(--measure);
-  padding-left: calc(1.75rem + var(--space-3));
+  padding-left: calc(var(--comment-avatar) + var(--space-3));
   overflow-wrap: anywhere;
 }
 
@@ -142,7 +151,7 @@ a.comment-author-name:focus-visible {
 }
 
 .comment-embed {
-  padding-left: calc(1.75rem + var(--space-3));
+  padding-left: calc(var(--comment-avatar) + var(--space-3));
 }
 
 .comment-embed > * {

--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -85,8 +85,8 @@ function ReplyNode({ node, depth }) {
               className="comment-avatar"
               src={author.avatar}
               alt=""
-              width={28}
-              height={28}
+              width={40}
+              height={40}
               loading="lazy"
             />
           ) : (


### PR DESCRIPTION
Follow-up to #140. Tightens the reply byline and makes nested replies read more like a conversation thread.

## Changes
- **Byline fits the avatar** — introduced a `--comment-avatar` size variable (top-level `2.5rem`, up from `1.75rem`) so the avatar height matches the stacked display name + handle. Collapsed the gap between name and handle to `0` with tight line-heights so the two lines read as one block, and vertically centered the byline against the avatar. Bumped the `<img>` intrinsic dimensions to `40` to match.
- **Thread rail for nesting** — nested reply trees now use a 2px sage-green rail (`--accent-soft` via `color-mix`) with a small indent instead of the tan hairline, so the reply hierarchy reads as a thread spine. Nested avatars shrink one step (`2rem`).
- The avatar variable also drives the text/embed hanging indent, so alignment stays correct at any avatar size and across nesting levels.

Verified with a rendered screenshot of the exact markup + CSS and a clean `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKzr82UjwSvsTinwv6gMcU)_