### PR TITLE
Lift the author's linear self-reply thread into the main post area

### DIFF
--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -296,3 +296,62 @@
   font-style: italic;
   padding: var(--space-2) 0;
 }
+
+/* Author's own self-reply continuation, lifted into the main post area and
+   stacked below the focused post as one linear thread. Full-size posts (not
+   nested replies); each is tied to the one above by a dotted rule and a
+   quiet "↳ continued" marker. */
+.record-self-thread {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--space-5);
+}
+
+.record-thread-post {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  margin-top: var(--space-4);
+  border-top: 1px dotted var(--rule);
+}
+
+.record-thread-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.record-thread-cont {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+}
+
+.record-thread-time {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.record-thread-time a {
+  color: var(--ink-faint);
+  text-decoration: none;
+  border-bottom: 1px dotted transparent;
+}
+
+.record-thread-time a:hover,
+.record-thread-time a:focus-visible {
+  border-bottom-color: var(--ink-faint);
+}
+
+.record-thread-text {
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  white-space: pre-wrap;
+  margin: 0;
+  color: var(--ink);
+  max-width: var(--measure);
+  overflow-wrap: anywhere;
+}

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { CornerDownRight } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
 import PostCard from '../components/PostCard.jsx';
 import StatusEntry from '../components/StatusEntry.jsx';
@@ -61,6 +62,9 @@ export default function Record({ verb, nsid, source }) {
   // own nested `replies`). Drives the comments tree below the record.
   const [replies, setReplies] = useState([]);
   const [repliesStatus, setRepliesStatus] = useState('idle'); // idle | loading | ready | error
+  // The author's own linear self-reply continuation of this post, lifted out
+  // of `replies` and stacked in the main post area (oldest → newest).
+  const [selfThread, setSelfThread] = useState([]);
 
   useEffect(() => {
     if (!collection || !rkey) return;
@@ -69,6 +73,7 @@ export default function Record({ verb, nsid, source }) {
     setMissing(false);
     setParents([]);
     setReplies([]);
+    setSelfThread([]);
     setRepliesStatus(verb === 'posting' || verb === 'reposting' ? 'loading' : 'idle');
 
     async function load() {
@@ -141,8 +146,12 @@ export default function Record({ verb, nsid, source }) {
         if (cancelled || !threadNode) return;
         const chain = collectParents(threadNode);
         if (chain.length) setParents(chain);
-        const childReplies = Array.isArray(threadNode.replies) ? threadNode.replies : [];
-        setReplies(childReplies);
+        // Lift the author's own linear self-reply chain into the main post
+        // area; everything else stays in the replies tree.
+        const authorDid = threadNode.post?.author?.did || ME_DID;
+        const { thread, leftover } = splitSelfThread(threadNode, authorDid);
+        setSelfThread(thread.map((node) => postViewToFeedItem('posting', node.post)));
+        setReplies(leftover);
         setRepliesStatus('ready');
       }
     }
@@ -202,6 +211,14 @@ export default function Record({ verb, nsid, source }) {
           </div>
         ) : (
           <RecordSkeleton />
+        )}
+
+        {item && selfThread.length > 0 && (
+          <div className="record-self-thread" aria-label="Thread continues">
+            {selfThread.map((post) => (
+              <SelfThreadPost key={post.atUri} item={post} />
+            ))}
+          </div>
         )}
 
         {item && <RecordMeta collection={collection} createdAt={createdAt} />}
@@ -457,6 +474,103 @@ function ParentPostCard({ parent, isRoot }) {
         {text ? renderPostText(text, facets) : <em>—</em>}
       </p>
       {embed && <PostEmbed embed={embed} did={did} />}
+    </article>
+  );
+}
+
+function isRenderableReplyNode(node) {
+  if (!node) return false;
+  if (node.$type === 'app.bsky.feed.defs#notFoundPost') return true;
+  if (node.$type === 'app.bsky.feed.defs#blockedPost') return true;
+  return Boolean(node.post);
+}
+
+/**
+ * A post record page for one of the author's own posts often sits at the head
+ * of a self-reply thread — the author replied to their own post to keep a
+ * thought going. Those continuation posts read as one linear piece, so we
+ * lift them out of the replies tree and stack them in the main post area.
+ *
+ * Walks down from the focused post following a *single* self-reply at each
+ * level. It stops as soon as a level has zero self-replies (the thread ended)
+ * or more than one (the author branched — no longer a linear thread, so which
+ * branch "continues" is ambiguous and we leave everything in replies).
+ *
+ * Returns:
+ *   thread   — continuation `threadViewPost` nodes, oldest → newest
+ *   leftover — every reply node NOT on the lifted chain, ready to feed the
+ *              Comments tree: other people's replies to any post in the
+ *              thread, plus all replies hanging off the thread's tail.
+ */
+function splitSelfThread(rootNode, authorDid) {
+  const thread = [];
+  const leftover = [];
+  if (!rootNode || !authorDid) return { thread, leftover };
+  let cursor = rootNode;
+  const seen = new Set(); // guard against a malformed cyclic thread view
+  while (cursor && cursor.post?.uri && !seen.has(cursor.post.uri)) {
+    seen.add(cursor.post.uri);
+    const replies = (cursor.replies || []).filter(isRenderableReplyNode);
+    const selfReplies = replies.filter((r) => r.post?.author?.did === authorDid);
+    if (selfReplies.length === 1) {
+      const next = selfReplies[0];
+      // Siblings of the continuation (replies by others at this level) stay
+      // in the replies section.
+      for (const r of replies) if (r !== next) leftover.push(r);
+      thread.push(next);
+      cursor = next;
+    } else {
+      // 0 → thread ended here; 2+ → branched, not linear. Either way, every
+      // reply hanging off this node belongs in the replies section.
+      leftover.push(...replies);
+      break;
+    }
+  }
+  return { thread, leftover };
+}
+
+/**
+ * One continuation post in the author's self-reply thread, rendered as a
+ * full-size post in the main area (not a nested reply). A dotted rule and a
+ * "↳ continued" marker tie it to the post above; the timestamp links to the
+ * post's own record page.
+ */
+function SelfThreadPost({ item }) {
+  const text = item.payload?.text || '';
+  const facets = item.payload?.facets || null;
+  const embed = item.payload?.embed || item.payload?.embedRecord || null;
+  const author = item.payload?.author || null;
+  const authorDid = author?.did;
+  const ts = item.createdAt || item.payload?.indexedAt;
+  // Local permalink only for the author's own posts (the only records this
+  // site hosts); a reposted foreign thread links its continuations out to
+  // bsky.app instead, matching the parent-chain treatment above.
+  const isMine = authorDid === ME_DID;
+  const localHref = isMine ? recordPathFromAtUri(item.atUri) : null;
+  const externalHref = !isMine && author?.handle && item.atUri
+    ? `https://bsky.app/profile/${author.handle}/post/${item.atUri.split('/').pop()}`
+    : null;
+  return (
+    <article className="record-thread-post" data-at-uri={item.atUri}>
+      <header className="record-thread-head">
+        <span className="record-thread-cont small-caps">
+          <CornerDownRight size={12} strokeWidth={1.75} aria-hidden="true" />
+          continued
+        </span>
+        {ts && (
+          <span className="gutter record-thread-time">
+            {localHref ? (
+              <Link to={localHref}>{relativeTime(ts)}</Link>
+            ) : externalHref ? (
+              <a href={externalHref} target="_blank" rel="noreferrer noopener">{relativeTime(ts)}</a>
+            ) : (
+              relativeTime(ts)
+            )}
+          </span>
+        )}
+      </header>
+      {text && <p className="record-thread-text">{renderPostText(text, facets)}</p>}
+      {embed && <PostEmbed embed={embed} did={authorDid} collapsible />}
     </article>
   );
 }


### PR DESCRIPTION
On a post record page, a chain of the author's own self-replies now reads as one continuous thread stacked below the focused post, instead of being buried in the replies section.

## Detection
Walks the fetched thread view downward from the focused post, following a *single* self-reply at each level. It stops as soon as a level has zero self-replies (thread ended) or two or more (the author branched — no longer linear, so which branch "continues" is ambiguous and everything is left in replies).

## Main-area rendering
Lifted self-replies stack directly below the focused post as full-size posts, each with a quiet `↳ continued` marker, a dotted separator, and its own timestamp permalink (local for the author's own posts; bsky.app for a reposted foreign thread).

## Replies section
Everything not on the lifted chain stays there: other people's replies to any post in the thread, plus all replies hanging off the thread's tail. With no self-thread present, behavior is unchanged.

## Verification
- 7 unit tests over the split logic (linear chain, self + others at a level, branching, empty, foreign `notFoundPost` nodes, mid-chain branch).
- Clean `vite build`.
- Rendered screenshot of the record-page layout confirming continuations land in the main area and only foreign replies remain under Replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKzr82UjwSvsTinwv6gMcU)_