### PR TITLE
Align sheet content with the chrome column; drop nav menu to the bottom

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -57,6 +57,12 @@
      the page body; vertical padding stays a flat --space-4. */
   padding: var(--space-4) var(--chrome-pad-x);
   height: calc(100dvh - var(--chrome-top-h, var(--chrome-h)) - var(--chrome-h) - var(--edit-bar-h, 0px) - env(safe-area-inset-bottom, 0px));
+  /* The panel fills the whole gap up to the top chrome, but the menu is
+     short — sit its content at the BOTTOM of that space so the routes land
+     near the bottom bar (and the thumb) instead of floating up by the top
+     chrome. Block-level align-content; when a view overflows (debug dump),
+     the scroll container keeps the top reachable. */
+  align-content: end;
   overflow-y: auto;
   overscroll-behavior: contain;
 }

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -139,13 +139,9 @@
   /* Promote to its own compositor layer so the slide is a pure transform —
      no layout, no repaint of the page, nothing that can stall scrolling. */
   will-change: transform;
-}
-
-@media (min-width: 65rem) {
-  .chrome-bar-tertiary {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
+  /* Side hairlines (≥65rem) come from the shared `.chrome-bar-row` rule near
+     the bottom of this file, so they land at the exact same x as the header's
+     own side hairlines rather than inset by the bar's border. */
 }
 
 .chrome-breadcrumb {
@@ -444,12 +440,18 @@
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-/* On wide screens the chrome bars float as a 65rem-wide card with
-   the page background showing on either side; add left/right hairlines
-   to close the box visually. */
+/* On wide screens the chrome bars float as a 65rem-wide card with the page
+   background showing on either side; left/right hairlines close the box
+   visually. They live on the INNER rows (`.chrome-bar-row` for the top,
+   `.chrome-bottom-row` for the bottom) — not the outer bar — so they sit at
+   the true 65rem edge and line up with the scroll-revealed strips
+   (`.chrome-bar-tertiary` breadcrumb, `.chrome-bar-footer`), which carry
+   their own side hairlines one layer in. Putting them on the outer bar would
+   inset those strips' borders by the bar's own 1px border and leave a
+   hairline jog. The bars still own the top/bottom hairlines. */
 @media (min-width: 65rem) {
-  .chrome-bar-top,
-  .chrome-bar-bottom {
+  .chrome-bar-row,
+  .chrome-bottom-row {
     border-left: 1px solid var(--rule);
     border-right: 1px solid var(--rule);
   }

--- a/src/components/EditSheet.css
+++ b/src/components/EditSheet.css
@@ -61,7 +61,10 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x)
+     so the sheet's header/body/footer line up with the nav dock, breadcrumb,
+     and bottom-bar buttons — same as the other bottom sheets. */
+  padding: var(--space-3) var(--chrome-pad-x);
   background: var(--surface-deep);
   border-bottom: 1px solid var(--rule-soft);
 }
@@ -118,12 +121,12 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: var(--space-4);
+  padding: var(--space-4) var(--chrome-pad-x);
 }
 
 .edit-sheet-foot {
   flex: 0 0 auto;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--chrome-pad-x);
   background: var(--surface-deep);
   border-top: 1px solid var(--rule-soft);
 }

--- a/src/components/FeedFilters.css
+++ b/src/components/FeedFilters.css
@@ -108,7 +108,10 @@
    65rem chrome card rather than sitting as a narrow centered modal. */
 .feed-filter-sheet-panel {
   width: 100%;
-  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x)
+     so the filter grid lines up with the nav dock, breadcrumb, and the
+     bottom-bar buttons at every breakpoint. */
+  padding: var(--space-4) var(--chrome-pad-x);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);

--- a/src/components/InfoSheet.css
+++ b/src/components/InfoSheet.css
@@ -1,7 +1,10 @@
 /* Interior of the info bottom sheet. BottomSheet owns positioning, the
    surface, and the expand animation; only the prose layout lives here. */
 .info-sheet-panel {
-  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x,
+     kept on :root for exactly this) so the prose lines up with the nav dock,
+     the breadcrumb, and the bottom-bar buttons at every breakpoint. */
+  padding: var(--space-4) var(--chrome-pad-x);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);

--- a/src/components/SearchSheet.css
+++ b/src/components/SearchSheet.css
@@ -1,7 +1,10 @@
 /* Interior of the search bottom sheet. BottomSheet owns positioning, the
    surface, and the expand animation; only the field layout lives here. */
 .search-sheet-panel {
-  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x)
+     so the field lines up with the nav dock, breadcrumb, and bottom-bar
+     buttons at every breakpoint. */
+  padding: var(--space-4) var(--chrome-pad-x);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);

--- a/src/components/WaypointsSheet.css
+++ b/src/components/WaypointsSheet.css
@@ -4,9 +4,10 @@
    every bottom sheet reads as one family. */
 
 .waypoints-sheet {
-  /* Match InfoSheet's inset so the picker's content column lines up with the
-     other bottom sheets (and the bottom bar's buttons that trigger them). */
-  padding: var(--space-4) clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem);
+  /* Track the chrome bars' shared column (--chrome-pad-x), like the other
+     bottom sheets, so the picker's content lines up with the nav dock,
+     breadcrumb, and the bottom-bar buttons that trigger them. */
+  padding: var(--space-4) var(--chrome-pad-x);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);


### PR DESCRIPTION
Two chrome-alignment tweaks.

## Sheet content aligned with the chrome column

The nav dock and chrome bars share the responsive `--chrome-pad-x` inset, but the bottom sheets (search, info, filter, waypoints) and the owner edit sheet hardcoded `clamp(var(--space-4), calc(6vw - 3.5rem), 2.5rem)`, which doesn't track `--chrome-pad-x`'s `≤65rem` / `≤700px` steps. Below 65rem that left their content ~40px to the left of the nav/breadcrumb column — the bars jump to `clamp(space-5, 6vw, space-9)` there while the sheets stayed at `space-4`.

Point all of them at `--chrome-pad-x` (kept on `:root` precisely so these portalled surfaces can share it) so every chrome-attached surface lines up with the breadcrumb, the nav dock, and the bottom-bar buttons at every breakpoint.

## Nav menu drops to the bottom of its panel

Give `.dock-panel` `align-content: end` so the short menu sits at the bottom of the tall panel — near the bottom bar and the thumb — instead of floating up against the top chrome.

## Verification

Rendered at 950px (≤65rem, where the mismatch showed):

| surface | before | after |
|---|---|---|
| chrome column (buttons / breadcrumb) | 57px | 57px |
| info / search / nav dock content | **16px** | **57px** |

Nav dock `align-content: end` confirmed computed — the menu sits with ~268px of space above it and only its 16px bottom padding below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7)_