### PR TITLE
Lay out the creating grid as a masonry

### DIFF
--- a/src/pages/Creating.css
+++ b/src/pages/Creating.css
@@ -5,13 +5,22 @@
   margin-bottom: var(--space-5);
 }
 
+/* Masonry via CSS multi-columns: cards flow down each column and pack
+   tightly against their neighbours, so the varying cover heights read as an
+   irregular mosaic rather than rows aligned to the tallest card. */
 .creating-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-  gap: var(--space-5);
+  columns: 16rem;
+  column-gap: var(--space-5);
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.creating-grid-cell {
+  break-inside: avoid;
+  /* Column layout has no row gap, so the inter-card rhythm lives on the cell.
+     A card must not straddle a column break. */
+  margin-bottom: var(--space-5);
 }
 
 .creating-grid-link {


### PR DESCRIPTION
## Summary

Now that creating covers render at their own aspect ratio, the fixed CSS grid left ragged whitespace — every row grew to the tallest card. Switch `.creating-grid` to a CSS multi-column (masonry) layout so cards flow down each column and pack against their neighbours, reading as an irregular mosaic rather than aligned rows.

- `.creating-grid` uses `columns: 16rem` + `column-gap` (responsive column count).
- `.creating-grid-cell` gets `break-inside: avoid` (no card splits across a column) and a bottom margin (columns have no row gap).

## Testing
- `vite build` passes.
- Verified with a rendered mock (sandbox can't reach the live PDS): varying cover heights produced tightly-packed columns with no card straddling a break and no whitespace-padded rows.

Note: CSS-columns masonry fills top-to-bottom per column (standard behavior); strict left-to-right reading order would require a JS masonry lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_