### PR TITLE
Stack blog timestamps on wide screens; show back button on all non-home pages

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -332,12 +332,14 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
     };
   }, []);
 
-  // A "sub page" is anything nested one level deeper than a section index
-  // (e.g. /curating/:slug, /creating/:slug) — those get a back handle in
-  // the bottom bar that walks up to the section index (the breadcrumb parent).
+  // Every page except home gets a back handle in the bottom bar. It walks
+  // back through history (mirroring the browser's back button) so you can
+  // return to wherever you came from — including home → /blogging → back →
+  // home, not just deep sub-pages like /creating/:slug. On a fresh or
+  // deep-linked load with no in-app history, it falls back to the breadcrumb
+  // parent: the section index for a sub-page, else home.
   const crumbs = buildCrumbs(location.pathname);
-  const isSubPage = crumbs.length >= 2;
-  const parentPath = isSubPage ? crumbs[crumbs.length - 2].to : '/';
+  const parentPath = crumbs.length >= 2 ? crumbs[crumbs.length - 2].to : '/';
 
   function goBack() {
     // Prefer real history so the back button mirrors the browser's, but fall
@@ -483,7 +485,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           </AnimatePresence>
         </div>
         <div className="chrome-bottom-spacer" aria-hidden="true" />
-        {isSubPage && (
+        {!onHomePage && (
           <button
             type="button"
             className="chrome-nav chrome-back-btn"

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -71,6 +71,15 @@
   align-self: start;
   padding-top: 0.4em;
   white-space: nowrap;
+  /* On wide screens the two timestamps stack — the full date on top, the
+     relative "Xmo ago" beneath it — right-aligned in the meta gutter.
+     `column-reverse` keeps the source order (relative, date) so the mobile
+     inline fallback below reads "Xmo ago • date" without extra markup. */
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+  gap: 0.15em;
+  text-align: right;
 }
 
 .blog-article {
@@ -173,11 +182,21 @@
     display: none;
   }
   .blogging-toc-meta {
-    text-align: left;
     /* In the stacked single-column layout the meta is its own row, so the
        baseline nudge (meant for the desktop 3-column row) just piles space
-       above the timestamp. */
+       above the timestamp. The two timestamps collapse back onto one line,
+       separated by a bullet (see ::after below) rather than stacked. */
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-start;
+    gap: 0.4em;
+    text-align: left;
     padding-top: 0;
+  }
+  .blogging-toc-rel::after {
+    content: '•';
+    margin-left: 0.4em;
+    color: var(--ink-faint);
   }
 }
 

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -76,9 +76,12 @@ export default function Blogging() {
                   {e.summary && <p className="blogging-toc-summary">{e.summary}</p>}
                 </span>
                 <span className="blogging-toc-meta gutter">
-                  {e.createdAt
-                    ? `${relativeTime(e.createdAt)} • ${formatDateFull(e.createdAt)}`
-                    : ''}
+                  {e.createdAt && (
+                    <>
+                      <span className="blogging-toc-rel">{relativeTime(e.createdAt)}</span>
+                      <span className="blogging-toc-date">{formatDateFull(e.createdAt)}</span>
+                    </>
+                  )}
                 </span>
               </Link>
             </li>


### PR DESCRIPTION
Two small chrome/layout fixes.

## Blog index timestamps stack on wide screens

On desktop/wide viewports the blog table-of-contents timestamps now stack in the right-hand gutter — the full date on top, the relative "Xmo ago" beneath it — instead of sharing one line separated by a bullet. Narrow viewports (≤700px) keep the original single-line, bullet-separated layout.

The meta is a flex `column-reverse` so the source order (relative, date) is preserved for the mobile inline fallback, which reattaches the bullet with a `::after` rule (no markup duplication).

- `src/pages/Blogging.jsx` — split the combined timestamp string into `.blogging-toc-rel` / `.blogging-toc-date` spans
- `src/pages/Blogging.css` — stack on desktop, collapse back to one bulleted line on mobile

## Back button appears on every non-home page

The bottom-chrome back arrow previously only showed on deeply-nested sub-pages (`crumbs.length >= 2`, e.g. `/creating/:slug`). It now shows on section index pages too (`/blogging`, `/creating`, …) so that after navigating home → section you can step back. Home stays back-button-free. The `goBack` handler is unchanged — it walks real browser history first and falls back to the breadcrumb parent on a fresh/deep-linked load.

- `src/components/ChromeBar.jsx` — gate the back button on `!onHomePage` instead of `isSubPage`

## Verification

- Timestamp layout confirmed at desktop (stacked) and mobile (bulleted single line) widths via rendered screenshots.
- Back button confirmed live in the dev server: absent on `/`, present on `/blogging`, and clicking it from `/blogging` returns to `/`.
- `npm run build:offline` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrdhoSq41QSDQbDziZFc8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrdhoSq41QSDQbDziZFc8y)_