### PR TITLE
Auto-refresh the app when a new build is deployed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ const OauthCallback = lazy(() => import('./pages/OauthCallback.jsx'));
 // Lazy: the explorer transitively imports RecordEditor + @atproto/api.
 const Exploring = lazy(() => import('./pages/Exploring.jsx'));
 import ChromeBar from './components/ChromeBar.jsx';
+import AutoUpdater from './components/AutoUpdater.jsx';
 import ActionDock from './components/ActionDock.jsx';
 import EditModeBar from './components/EditModeBar.jsx';
 import EditSheet from './components/EditSheet.jsx';
@@ -151,6 +152,7 @@ export default function App() {
             <EditModeBar />
             <EditSheet />
             <WindowScrollbar />
+            <AutoUpdater />
             <Analytics />
           </div>
       </FeedFooterProvider>

--- a/src/components/AutoUpdater.jsx
+++ b/src/components/AutoUpdater.jsx
@@ -1,0 +1,9 @@
+import useAutoUpdate from '../hooks/useAutoUpdate.js';
+
+// Headless: runs the deploy-detection loop for as long as the app is
+// mounted. Rendered inside the provider tree so the loop can read edit-mode
+// state and defer reloads that would interrupt work in progress.
+export default function AutoUpdater() {
+  useAutoUpdate();
+  return null;
+}

--- a/src/components/DebugPane.jsx
+++ b/src/components/DebugPane.jsx
@@ -5,6 +5,7 @@ import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import RecordEditor from './RecordEditor.jsx';
 import { ME_DID } from '../config.js';
 import { explorerPathFromAtUri } from '../lib/atproto.js';
+import { BUILD_ID } from '../lib/appVersion.js';
 import './DebugOverlay.css';
 
 /**
@@ -65,6 +66,7 @@ export default function DebugPane({ onClose }) {
         <Row label="lexicon" value={lexicon} copyValue={lexicon} mono copied={copied} onCopy={copy} />
         <Row label="pds" value={pds} copyValue={pds} placeholder="resolving…" mono copied={copied} onCopy={copy} />
         <Row label="appview" value="public.api.bsky.app" copyValue="public.api.bsky.app" mono copied={copied} onCopy={copy} />
+        <Row label="build" value={BUILD_ID} copyValue={BUILD_ID} mono copied={copied} onCopy={copy} />
       </dl>
 
       <div className="debug-overlay-actions">

--- a/src/hooks/useAutoUpdate.js
+++ b/src/hooks/useAutoUpdate.js
@@ -1,0 +1,168 @@
+// Auto-refresh on deploy.
+//
+// dame.is rebuilds often — on every push and on a 6-hour PDS-refresh cron —
+// so a tab left open drifts onto stale code. This watcher closes that gap:
+// the running app polls a tiny `/version.json` (emitted at build time with
+// the same build id baked into this bundle) and, when the deployed id no
+// longer matches ours, reloads to pick up the new build.
+//
+// It's the lightweight, service-worker-free cousin of Anisota's PWA
+// auto-update: no Workbox, no cached shell to invalidate — just a build-id
+// comparison and a guarded `location.reload()`.
+//
+// Guards:
+//   - Production only. Dev hot-reloads itself and ships no version.json.
+//   - Never interrupts work in progress — defers while the owner is in edit
+//     mode, has a quick-edit sheet open, or is focused in a text field —
+//     then applies the update on the next safe moment (a navigation, edit
+//     mode closing, or the next poll).
+//   - Reloads at most once per distinct deployed id, so a misconfigured
+//     build (baked id vs. version.json disagreeing) can never loop.
+
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useEditMode } from './useEditMode.jsx';
+import { BUILD_ID } from '../lib/appVersion.js';
+
+// How often to ask the server whether a newer build has shipped. Cheap:
+// version.json is a few bytes, usually answered with a 304, and only polled
+// while the tab is visible. We also check on focus / reconnect, so an idle
+// tab catches up the instant the reader returns.
+const CHECK_INTERVAL_MS = 60_000;
+
+// Let first paint settle before the first look.
+const KICKOFF_DELAY_MS = 3_000;
+
+// Remembers which build we last reloaded *to*. If a deploy's baked id and
+// its version.json ever disagree we'd otherwise reload forever; keying on
+// the target id means we reload at most once per distinct id.
+const RELOAD_TARGET_KEY = 'dame.update.reloadedTo';
+
+function readReloadTarget() {
+  try {
+    return sessionStorage.getItem(RELOAD_TARGET_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeReloadTarget(id) {
+  try {
+    sessionStorage.setItem(RELOAD_TARGET_KEY, id);
+  } catch {
+    /* sessionStorage may be unavailable (private mode, etc.) */
+  }
+}
+
+async function fetchDeployedBuildId() {
+  // Cache-bust hard — query param + no-store — so neither the browser nor
+  // Vercel's edge can hand us a stale version.json.
+  const res = await fetch(`/version.json?_=${Date.now()}`, {
+    cache: 'no-store',
+    headers: { 'Cache-Control': 'no-cache' },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data && typeof data.id === 'string' ? data.id : null;
+}
+
+// Reload to apply `served` if it's safe and we haven't already tried it.
+// Returns true if a reload was triggered.
+function attemptReload(served, isSafe) {
+  if (!served) return false;
+  if (!isSafe()) return false; // defer: user is mid-edit
+  if (readReloadTarget() === served) return false; // loop guard
+  writeReloadTarget(served);
+  window.location.reload();
+  return true;
+}
+
+export default function useAutoUpdate() {
+  const location = useLocation();
+  const editMode = useEditMode();
+
+  // The deployed build id we've detected as newer than ours and are waiting
+  // to apply. Null when we're up to date.
+  const pendingRef = useRef(null);
+
+  // Latest "safe to reload?" test, kept in a ref so the polling loop reads
+  // current edit state without re-arming its interval on every keystroke.
+  const isSafeRef = useRef(() => true);
+  isSafeRef.current = () => {
+    if (editMode.active) return false; // owner is bulk-editing the feed
+    if (editMode.editSheet) return false; // a quick-edit sheet is open
+    const el = typeof document !== 'undefined' ? document.activeElement : null;
+    if (el) {
+      const tag = el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
+      if (el.isContentEditable) return false;
+    }
+    return true;
+  };
+
+  // The poll loop + listeners. Armed once; reads live state through refs.
+  useEffect(() => {
+    if (!import.meta.env.PROD) return; // dev hot-reloads itself
+    if (typeof window === 'undefined') return;
+
+    let cancelled = false;
+
+    // If we reloaded to reach this build and we're now running it, clear the
+    // loop-guard marker so a *future* deploy can reload again.
+    if (readReloadTarget() === BUILD_ID) {
+      try {
+        sessionStorage.removeItem(RELOAD_TARGET_KEY);
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const check = async () => {
+      if (cancelled || document.hidden) return;
+      let served;
+      try {
+        served = await fetchDeployedBuildId();
+      } catch {
+        return; // offline / transient — try again next tick
+      }
+      if (cancelled || !served) return;
+      if (served === BUILD_ID) {
+        pendingRef.current = null; // up to date (e.g. a rollback)
+        return;
+      }
+      pendingRef.current = served;
+      attemptReload(served, isSafeRef.current);
+    };
+
+    const onWake = () => {
+      if (!document.hidden) check();
+    };
+
+    const intervalId = setInterval(check, CHECK_INTERVAL_MS);
+    const kickoffId = setTimeout(check, KICKOFF_DELAY_MS);
+    document.addEventListener('visibilitychange', onWake);
+    window.addEventListener('focus', onWake);
+    window.addEventListener('online', check);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+      clearTimeout(kickoffId);
+      document.removeEventListener('visibilitychange', onWake);
+      window.removeEventListener('focus', onWake);
+      window.removeEventListener('online', check);
+    };
+  }, []);
+
+  // Retry a deferred reload the moment it becomes safe: the reader navigates
+  // (edit mode + selection clear on route change) or closes edit mode / the
+  // quick-edit sheet. A short delay lets focus settle after the state change.
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+    if (!pendingRef.current) return;
+    const t = setTimeout(() => {
+      attemptReload(pendingRef.current, isSafeRef.current);
+    }, 400);
+    return () => clearTimeout(t);
+  }, [location.pathname, editMode.active, editMode.editSheet]);
+}

--- a/src/lib/appVersion.js
+++ b/src/lib/appVersion.js
@@ -1,0 +1,13 @@
+// Build identity, injected at build time by vite.config.js via `define`.
+//
+// These resolve in dev too (the config computes them on every start), but
+// nothing polls locally — the auto-update watcher is production-only. The
+// build id is keyed on the git commit, so a content-only rebuild (the
+// 6-hour PDS refresh cron) keeps the same id and never reloads anyone;
+// only an actual code change ships a new id.
+
+/* global __BUILD_ID__, __COMMIT_SHA__, __BUILD_TIME__ */
+
+export const BUILD_ID = typeof __BUILD_ID__ !== 'undefined' ? __BUILD_ID__ : 'dev';
+export const COMMIT_SHA = typeof __COMMIT_SHA__ !== 'undefined' ? __COMMIT_SHA__ : 'dev';
+export const BUILD_TIME = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : null;

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,15 @@
     { "source": "/site.standard.document/:rkey", "destination": "/index.html" },
     { "source": "/pub.leaflet.document/:rkey", "destination": "/index.html" },
     { "source": "/is.dame.creating.work/:rkey", "destination": "/index.html" },
-    { "source": "/((?!api/|assets/).*)", "destination": "/index.html" }
+    { "source": "/((?!api/|assets/|version.json).*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/version.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    }
   ],
   "redirects": [
     { "source": "/index", "destination": "/", "permanent": true },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,70 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Build identity for the auto-update watcher (see src/hooks/useAutoUpdate.js).
+//
+// Keyed on the git commit so a content-only rebuild — the 6-hour PDS-refresh
+// cron fires the deploy hook without a code change — keeps the same id and
+// never reloads anyone. Only an actual code change ships a new id. Falls back
+// to build time when git isn't available (e.g. a source tarball) so the id is
+// still unique.
+function getBuildInfo() {
+  const commit =
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    (() => {
+      try {
+        return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+      } catch {
+        return '';
+      }
+    })();
+  return {
+    id: commit ? commit.slice(0, 12) : `t${Date.now()}`,
+    commit: commit || 'unknown',
+    builtAt: new Date().toISOString(),
+  };
+}
+
+const BUILD = getBuildInfo();
+
+// Emit dist/version.json (matching the baked-in build id) so the running app
+// can poll it and detect when a newer build has been deployed. Written in
+// closeBundle — after Vite copies public/ into the output — so nothing
+// clobbers it.
+function emitVersionJson() {
+  let outDir = 'dist';
+  return {
+    name: 'dame-emit-version-json',
+    apply: 'build',
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    closeBundle() {
+      const body = JSON.stringify(
+        { id: BUILD.id, commit: BUILD.commit, builtAt: BUILD.builtAt },
+        null,
+        2,
+      );
+      writeFileSync(resolve(outDir, 'version.json'), body + '\n', 'utf8');
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), emitVersionJson()],
   server: {
     port: 5173,
   },
   build: {
     outDir: 'dist',
     sourcemap: true,
+  },
+  define: {
+    __BUILD_ID__: JSON.stringify(BUILD.id),
+    __COMMIT_SHA__: JSON.stringify(BUILD.commit),
+    __BUILD_TIME__: JSON.stringify(BUILD.builtAt),
   },
 });


### PR DESCRIPTION
A tab left open on dame.is drifts onto stale code: the site rebuilds on every push and on the 6-hour PDS-refresh cron, but the running bundle never notices. This adds a lightweight, service-worker-free deploy watcher — the same behavior as Anisota's PWA auto-update, without the Workbox machinery.

## How it works

- **`vite.config.js`** bakes a build id (the git commit) into the bundle and emits a matching **`dist/version.json`**. Keying on the commit means a content-only rebuild keeps the same id and never reloads anyone — only an actual code change ships a new id (fresh data still flows in live via `useLiveFeed`).
- **`vercel.json`** serves `version.json` uncached and keeps the SPA catch-all from rewriting it to `index.html`.
- **`src/hooks/useAutoUpdate.js`** polls `version.json` (every 60s while the tab is visible, plus on focus/reconnect) and reloads when the deployed id no longer matches ours. It **defers while the owner is mid-edit** (edit mode, a quick-edit sheet, or a focused text field) and applies on the next safe moment (navigation, edit mode closing, or the next poll), and reloads **at most once per distinct id** so a misconfigured build can never loop. Production only; dev hot-reloads itself.
- The **debug pane** shows the running build id.

## Verification

Driven in a real headless Chromium against a production preview build: the app boots with no JS errors, polls `version.json`, auto-reloads once when a new build id appears, and the anti-loop guard holds (no second reload).

## Notes

- Rides on Vercel's automatic Git deployments — no new env vars or Vercel settings needed. Sits alongside the existing `/api/rebuild` deploy-hook cron, whose content-only rebuilds intentionally do **not** force a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHCXQs1mRTBvQCwFjuZZJz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCXQs1mRTBvQCwFjuZZJz)_