### PR TITLE
Horizontal masonry order + resolve relative og:image URLs

### DIFF
--- a/api/unfurl.js
+++ b/api/unfurl.js
@@ -70,6 +70,16 @@ export default async function handler(req, res) {
       description: metaContent(html, ['og:description', 'twitter:description', 'description']),
       image: metaContent(html, ['og:image', 'twitter:image']),
     };
+    // og:image is often a relative path ("/cover.png") or protocol-relative
+    // ("//host/cover.png"); resolve it against the final (post-redirect) page
+    // URL so callers always get an absolute http(s) URL they can fetch.
+    if (out.image) {
+      try {
+        out.image = new URL(out.image, upstream.url || url).href;
+      } catch {
+        out.image = '';
+      }
+    }
     res.setHeader('cache-control', 'public, max-age=3600');
     return res.status(200).json(out);
   } catch (err) {

--- a/src/components/blocks/WebsiteBlockEditor.jsx
+++ b/src/components/blocks/WebsiteBlockEditor.jsx
@@ -108,11 +108,22 @@ export default function WebsiteBlockEditor({ block, agent, onChange, onSetCover 
         title: block.title || data?.title || '',
         description: block.description || data?.description || '',
       };
-      if (data?.image) setDetected(data.image);
-      if (data?.image && !block.previewImage) {
+      // Resolve a relative og:image ("/cover.png") against the page URL — the
+      // proxy needs an absolute http(s) URL. (The unfurl endpoint already does
+      // this; this is a belt-and-braces fallback for cached/older responses.)
+      let image = data?.image || '';
+      if (image) {
+        try {
+          image = new URL(image, src).href;
+        } catch {
+          image = '';
+        }
+      }
+      if (image) setDetected(image);
+      if (image && !block.previewImage) {
         try {
           setStatus('Fetching preview image…');
-          next.previewImage = await fetchAndUploadImage(data.image);
+          next.previewImage = await fetchAndUploadImage(image);
           setStatus(null);
         } catch {
           setStatus('Metadata loaded, but the preview image could not be fetched.');

--- a/src/pages/Creating.css
+++ b/src/pages/Creating.css
@@ -5,22 +5,25 @@
   margin-bottom: var(--space-5);
 }
 
-/* Masonry via CSS multi-columns: cards flow down each column and pack
-   tightly against their neighbours, so the varying cover heights read as an
-   irregular mosaic rather than rows aligned to the tallest card. */
+/* Masonry as side-by-side flex columns. Works are dealt round-robin into the
+   columns (see Creating.jsx) so they read left-to-right — newest along the top
+   row — while each column still packs tightly to its own varying heights,
+   giving the irregular mosaic instead of rows aligned to the tallest card. */
 .creating-grid {
-  columns: 16rem;
-  column-gap: var(--space-5);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-5);
+}
+
+.creating-grid-col {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.creating-grid-cell {
-  break-inside: avoid;
-  /* Column layout has no row gap, so the inter-card rhythm lives on the cell.
-     A card must not straddle a column break. */
-  margin-bottom: var(--space-5);
 }
 
 .creating-grid-link {

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import CreatingFilters, { filterCreatingItems } from '../components/CreatingFilters.jsx';
@@ -17,6 +17,60 @@ import '../components/FeedFilters.css';
 import './Creating.css';
 
 const STANDARD_DOC = 'site.standard.document';
+
+// Masonry column sizing — keep in step with `.creating-grid` in Creating.css.
+const MASONRY_MIN_COL_REM = 16;
+const MASONRY_GAP_REM = 1.5; // --space-5
+
+/**
+ * Responsive masonry column count from the container's own width. Distributing
+ * items round-robin across this many columns (item i → column i % n) keeps the
+ * tight, non-aligned masonry look while preserving left-to-right reading order
+ * — newest across the top row rather than straight down the first column.
+ */
+function useMasonryColumns() {
+  const ref = useRef(null);
+  const [cols, setCols] = useState(1);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    const rem = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    const minCol = MASONRY_MIN_COL_REM * rem;
+    const gap = MASONRY_GAP_REM * rem;
+    const measure = () => {
+      const w = el.clientWidth;
+      if (w > 0) setCols(Math.max(1, Math.floor((w + gap) / (minCol + gap))));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, cols];
+}
+
+function WorkCard({ record }) {
+  const v = record.value || {};
+  const slug = workSlug(v);
+  const thumb = coverThumb(v);
+  const category = workCategory(v);
+  return (
+    <li className="creating-grid-cell">
+      <Link to={`/creating/${slug}`} className="creating-grid-link">
+        {thumb ? (
+          <img src={thumb.url} alt={thumb.alt || ''} loading="lazy" />
+        ) : (
+          <div className="creating-grid-placeholder" aria-hidden="true">&#x2767;</div>
+        )}
+        <div className="creating-grid-meta">
+          {category && <span className="small-caps creating-grid-kind">{category}</span>}
+          <h3 className="creating-grid-title">{v.title || slug}</h3>
+          {v.createdAt && <span className="gutter">{relativeTime(v.createdAt)}</span>}
+        </div>
+      </Link>
+    </li>
+  );
+}
 
 // How many leading covers to preload before revealing the grid — roughly
 // the first couple of rows, enough for a clean first paint. The rest keep
@@ -100,6 +154,15 @@ export default function Creating() {
   }, [loading, coversReady]);
   const showSkeleton = loading || (filtered.length > 0 && !revealed);
 
+  // Deal the (newest-first) works round-robin into responsive columns so the
+  // masonry reads left-to-right, newest along the top.
+  const [gridRef, columnCount] = useMasonryColumns();
+  const columns = useMemo(() => {
+    const buckets = Array.from({ length: columnCount }, () => []);
+    filtered.forEach((r, i) => buckets[i % columnCount].push(r));
+    return buckets;
+  }, [filtered, columnCount]);
+
   return (
     <PageShell
       title={title}
@@ -115,30 +178,15 @@ export default function Creating() {
           {q ? 'No works match that search.' : 'No works yet.'}
         </p>
       ) : (
-        <ul className="creating-grid reveal-stagger">
-          {filtered.map((r, i) => {
-            const v = r.value || {};
-            const slug = workSlug(v);
-            const thumb = coverThumb(v);
-            const category = workCategory(v);
-            return (
-              <li key={r.uri || i} className="creating-grid-cell">
-                <Link to={`/creating/${slug}`} className="creating-grid-link">
-                  {thumb ? (
-                    <img src={thumb.url} alt={thumb.alt || ''} loading="lazy" />
-                  ) : (
-                    <div className="creating-grid-placeholder" aria-hidden="true">&#x2767;</div>
-                  )}
-                  <div className="creating-grid-meta">
-                    {category && <span className="small-caps creating-grid-kind">{category}</span>}
-                    <h3 className="creating-grid-title">{v.title || slug}</h3>
-                    {v.createdAt && <span className="gutter">{relativeTime(v.createdAt)}</span>}
-                  </div>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="creating-grid" ref={gridRef}>
+          {columns.map((col, ci) => (
+            <ul className="creating-grid-col reveal-stagger" key={ci}>
+              {col.map((r, i) => (
+                <WorkCard key={r.uri || `${ci}-${i}`} record={r} />
+              ))}
+            </ul>
+          ))}
+        </div>
       )}
     </PageShell>
   );


### PR DESCRIPTION
## Summary

Two changes stacked on this branch:

### Creating masonry reads left-to-right
CSS multi-columns filled top-to-bottom, so the newest works ran straight down the first column. Deal the (newest-first) works round-robin into responsive flex columns (item `i` → column `i % n`) so they read left-to-right — newest along the top row — while each column still packs to its own varying heights, keeping the irregular mosaic. Column count derives from the container width via a `ResizeObserver` (stays responsive down to one column on mobile).

### Resolve relative og:image URLs for link-card previews
`og:image` is frequently a relative (`/cover.png`) or protocol-relative (`//host/cover.png`) path. Passed through verbatim it failed the image proxy's `^https?://` check (`Pass a valid http(s) url`), so preview images never came through. Resolve the image against the final page URL in `api/unfurl.js`, with a belt-and-braces fallback in the block editor for cached/older responses.

## Testing
- `vite build` passes.
- Masonry ordering + packing verified with a rendered mock: top row = works 1-2-3-4 (newest), columns pack to ragged heights, no aligned rows.
- og:image resolution verified for relative, protocol-relative, and absolute URLs.

Note: the serverless endpoints (`/api/unfurl`, `/api/image-proxy`) only run on a real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_