### PR TITLE
Rework page titles: brand-first surfaces, title-first record pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="dame.is" />
-    <title>Dame is…</title>
+    <title>dame.is</title>
     <meta name="description" content="An atmospheric website by dame, built atop the AT Protocol." />
 
     <!--
@@ -27,14 +27,14 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="dame.is" />
     <meta property="og:url" content="https://dame.is/" />
-    <meta property="og:title" content="Dame is…" />
+    <meta property="og:title" content="dame.is" />
     <meta property="og:description" content="An atmospheric website by dame, built atop the AT Protocol." />
     <meta property="og:image" content="https://dame.is/api/og" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Dame is… — an atmospheric website built atop the AT Protocol." />
+    <meta property="og:image:alt" content="dame.is — an atmospheric website built atop the AT Protocol." />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Dame is…" />
+    <meta name="twitter:title" content="dame.is" />
     <meta name="twitter:description" content="An atmospheric website by dame, built atop the AT Protocol." />
     <meta name="twitter:image" content="https://dame.is/api/og" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/middleware.js
+++ b/middleware.js
@@ -12,7 +12,8 @@
 // home route and all nested/dynamic routes stay fully static — no middleware
 // cost, no risk of breaking client-side navigation.
 
-import { pageMeta } from './og/pages.js';
+import { pageMeta, SITE, cleanPath, segsFor } from './og/pages.js';
+import { recordMeta } from './og/records.js';
 
 const ORIGIN = 'https://dame.is';
 
@@ -21,8 +22,11 @@ export const config = {
     '/themself',
     '/for-hire',
     '/blogging',
+    '/blogging/:slug',
     '/creating',
+    '/creating/:slug',
     '/curating',
+    '/curating/:slug',
     '/listening',
     '/posting',
     '/logging',
@@ -54,8 +58,31 @@ function setMeta(html, keyAttr, keyVal, content) {
 export default async function middleware(request) {
   try {
     const url = new URL(request.url);
-    const path = url.pathname.replace(/\/+$/, '') || '/';
-    const meta = pageMeta(path);
+    const path = cleanPath(url.pathname);
+    const segs = segsFor(path);
+
+    // Two title conventions:
+    //   • top-level surfaces → the page's own "dame.is {label}" (from pages.js)
+    //   • record/leaf pages   → "{record title} — dame.is", resolved live from
+    //     the PDS; the OG image falls back to the parent section's card.
+    // A record route whose record can't be fetched degrades to the section's
+    // own card + title, so crawlers never see the generic home card there.
+    let title;
+    let desc;
+    let ogImage;
+    if (segs.length === 2) {
+      const sectionPath = `/${segs[0]}`;
+      const section = pageMeta(sectionPath);
+      const rec = await recordMeta(path);
+      title = rec ? `${rec.title} — ${SITE.domain}` : section.title;
+      desc = (rec && rec.description) || section.desc;
+      ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(sectionPath)}`;
+    } else {
+      const meta = pageMeta(path);
+      title = meta.title;
+      desc = meta.desc;
+      ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(path)}`;
+    }
 
     // Pull the built SPA shell. The matcher never matches /index.html, so this
     // subrequest can't loop back through the middleware.
@@ -66,17 +93,16 @@ export default async function middleware(request) {
     let html = await shellRes.text();
 
     const canonical = `${ORIGIN}${path}`;
-    const ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(path)}`;
 
-    html = html.replace(/<title>[^<]*<\/title>/i, `<title>${escapeAttr(meta.title)}</title>`);
-    html = setMeta(html, 'name', 'description', meta.desc);
+    html = html.replace(/<title>[^<]*<\/title>/i, `<title>${escapeAttr(title)}</title>`);
+    html = setMeta(html, 'name', 'description', desc);
     html = setMeta(html, 'property', 'og:url', canonical);
-    html = setMeta(html, 'property', 'og:title', meta.title);
-    html = setMeta(html, 'property', 'og:description', meta.desc);
+    html = setMeta(html, 'property', 'og:title', title);
+    html = setMeta(html, 'property', 'og:description', desc);
     html = setMeta(html, 'property', 'og:image', ogImage);
-    html = setMeta(html, 'property', 'og:image:alt', `${meta.title} — dame.is`);
-    html = setMeta(html, 'name', 'twitter:title', meta.title);
-    html = setMeta(html, 'name', 'twitter:description', meta.desc);
+    html = setMeta(html, 'property', 'og:image:alt', title);
+    html = setMeta(html, 'name', 'twitter:title', title);
+    html = setMeta(html, 'name', 'twitter:description', desc);
     html = setMeta(html, 'name', 'twitter:image', ogImage);
 
     return new Response(html, {

--- a/og/pages.js
+++ b/og/pages.js
@@ -22,7 +22,7 @@ export const SITE = {
 
 export const DEFAULT = {
   label: '',
-  title: 'Dame is…',
+  title: 'dame.is',
   desc: 'An atmospheric website by dame, built atop the AT Protocol.',
   nsid: 'is.dame.page',
 };
@@ -30,67 +30,67 @@ export const DEFAULT = {
 export const PAGES = {
   '/': {
     label: '',
-    title: 'Dame is…',
+    title: 'dame.is',
     desc: 'An atmospheric personal website — statuses, posts, blogs, listens, and creations, interleaved and built atop the AT Protocol.',
     nsid: 'is.dame.page',
   },
   '/themself': {
     label: 'themself',
-    title: 'Dame is… themself',
+    title: 'dame.is themself',
     desc: 'Who dame is — a longer look at the person behind the pixels, drawn live from the AT Protocol.',
     nsid: 'is.dame.profile',
   },
   '/for-hire': {
     label: 'for hire',
-    title: 'Dame is… for hire',
+    title: 'dame.is for hire',
     desc: "Dame's résumé and work history — design, strategy, and building on the open social web.",
     nsid: 'is.dame.resume',
   },
   '/blogging': {
     label: 'blogging',
-    title: 'Dame is… blogging',
+    title: 'dame.is blogging',
     desc: 'Long-form essays on the open social web, atproto, and building in public.',
     nsid: 'site.standard.document',
   },
   '/creating': {
     label: 'creating',
-    title: 'Dame is… creating',
+    title: 'dame.is creating',
     desc: 'A portfolio of creative work — projects, experiments, and things made along the way.',
     nsid: 'is.dame.creating.work',
   },
   '/curating': {
     label: 'curating',
-    title: 'Dame is… curating',
+    title: 'dame.is curating',
     desc: 'Collected references and inspirations — channels of things worth keeping.',
     nsid: 'is.dame.arena.channel',
   },
   '/listening': {
     label: 'listening',
-    title: 'Dame is… listening',
+    title: 'dame.is listening',
     desc: 'A live scrobble of what dame is playing, streamed from the AT Protocol.',
     nsid: 'fm.teal.alpha.feed.play',
   },
   '/posting': {
     label: 'posting',
-    title: 'Dame is… posting',
+    title: 'dame.is posting',
     desc: "Dame's Bluesky posts, grouped by day and mirrored from the AT Protocol.",
     nsid: 'app.bsky.feed.post',
   },
   '/logging': {
     label: 'logging',
-    title: 'Dame is… logging',
+    title: 'dame.is logging',
     desc: 'Status updates and small signals of life, logged to the AT Protocol.',
     nsid: 'is.dame.now',
   },
   '/mothing': {
     label: 'mothing',
-    title: 'Dame is… mothing',
+    title: 'dame.is mothing',
     desc: 'Moths at the light — observations logged from nights spent watching the dark.',
     nsid: 'is.dame.mothing.observation',
   },
   '/sharing': {
     label: 'sharing',
-    title: 'Dame is… sharing',
+    title: 'dame.is sharing',
     desc: "Dame's ethos and the things worth passing on.",
     nsid: 'is.dame.page',
   },

--- a/og/records.js
+++ b/og/records.js
@@ -1,0 +1,84 @@
+// Edge-safe resolver for per-record page metadata (blog posts, creative works,
+// curated channels). middleware.js uses this to give record routes a real
+// "<record title> — dame.is" <title> + OG tags for crawlers, instead of the
+// generic site card. Plain fetch only, so it runs in the Edge runtime.
+//
+// A record route is /{section}/{rkey} where {section} maps to one or more AT
+// Protocol collections to try (the site addresses these by slug=rkey). We
+// resolve Dame's PDS via the PLC directory, then getRecord until one hits.
+// Everything is defensive: any failure returns null and the caller falls back
+// to the section card, so a slow/broken PDS never blocks the page.
+
+const ME_DID = 'did:plc:gq4fo3u6tqzzdkjlwzpb23tj'; // mirrors src/config.js ME_DID
+const PLC_DIRECTORY = 'https://plc.directory';
+const TIMEOUT_MS = 2500;
+
+// section (first path segment) → collections to try, in order. Mirrors the
+// slug-addressed record routes in src/App.jsx / src/lib/recordRoutes.js.
+const RECORD_COLLECTIONS = {
+  blogging: ['site.standard.document', 'pub.leaflet.document'],
+  creating: ['is.dame.creating.work'],
+  curating: ['is.dame.arena.channel'],
+};
+
+async function fetchJson(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolvePds(did) {
+  const doc = await fetchJson(`${PLC_DIRECTORY}/${did}`);
+  const services = doc?.service || [];
+  const pds = services.find((s) => s.id === '#atproto_pds')?.serviceEndpoint || services[0]?.serviceEndpoint;
+  return pds ? pds.replace(/\/$/, '') : null;
+}
+
+async function getRecordValue(pds, collection, rkey) {
+  const params = new URLSearchParams({ repo: ME_DID, collection, rkey });
+  const json = await fetchJson(`${pds}/xrpc/com.atproto.repo.getRecord?${params}`);
+  return json?.value || null;
+}
+
+/** True if `pathname` looks like a slug-addressed record route we can resolve. */
+export function isRecordRoute(pathname) {
+  const segs = (pathname || '').split('/').filter(Boolean);
+  return segs.length === 2 && Boolean(RECORD_COLLECTIONS[segs[0]]);
+}
+
+/**
+ * Resolve a record route to `{ title, description, section }`, or null if it's
+ * not a record route or the record can't be fetched. `title` is the record's
+ * own title; `description` is its summary/subtitle when present.
+ */
+export async function recordMeta(pathname) {
+  const segs = (pathname || '').split('/').filter(Boolean);
+  if (segs.length !== 2) return null;
+  const [section, rawRkey] = segs;
+  const collections = RECORD_COLLECTIONS[section];
+  if (!collections) return null;
+
+  let rkey = rawRkey;
+  try { rkey = decodeURIComponent(rawRkey); } catch {}
+
+  const pds = await resolvePds(ME_DID);
+  if (!pds) return null;
+
+  for (const collection of collections) {
+    const value = await getRecordValue(pds, collection, rkey);
+    const title = value && (value.title || value.name);
+    if (title) {
+      const description = value.description || value.summary || value.subtitle || '';
+      return { title: String(title).trim(), description: String(description).trim(), section };
+    }
+  }
+  return null;
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -27,7 +27,7 @@ export default function About() {
 
   return (
     <PageShell
-      headTitle="Themself — Dame is…"
+      headTitle="dame.is themself"
       atUri={`at://${ME_DID}/is.dame.profile/self`}
     >
       <section className="about-card">

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -35,7 +35,7 @@ export default function Admin() {
 
   if (loading) {
     return (
-      <PageShell title="Admin" headTitle="Admin — Dame is…">
+      <PageShell title="Admin" headTitle="Admin — dame.is">
         <p className="placeholder-card">Restoring session…</p>
       </PageShell>
     );
@@ -43,7 +43,7 @@ export default function Admin() {
 
   if (!session) {
     return (
-      <PageShell title="Admin" headTitle="Admin — Dame is…">
+      <PageShell title="Admin" headTitle="Admin — dame.is">
         <SignInGate signIn={signIn} />
       </PageShell>
     );
@@ -51,7 +51,7 @@ export default function Admin() {
 
   if (did !== ME_DID) {
     return (
-      <PageShell title="Admin" headTitle="Admin — Dame is…">
+      <PageShell title="Admin" headTitle="Admin — dame.is">
         <p className="placeholder-card">
           Signed in as <code>{did}</code>, but this editor is restricted to{' '}
           <code>{ME_DID}</code>.
@@ -243,7 +243,7 @@ function CollectionPicker() {
     <PageShell
       title="Admin"
       intro="Browse and edit the records that make up the site. Pick a surface below, or start something new."
-      headTitle="Admin — Dame is…"
+      headTitle="Admin — dame.is"
     >
       <div className="admin-quick-actions">
         <Link
@@ -417,7 +417,7 @@ function RecordList({
     <PageShell
       title={heading}
       intro={intro}
-      headTitle={`${heading} — Admin — Dame is…`}
+      headTitle={`${heading} — Admin — dame.is`}
     >
       <div className="admin-toolbar">
         <Link to="/admin" className="admin-link-subtle">← All collections</Link>
@@ -597,7 +597,7 @@ function PagesOverview({ agent, did }) {
     <PageShell
       title="Site pages"
       intro="Each page's title and intro can live in the site (Local) or as an is.dame.page record on your PDS. Manage that split here, then edit the raw records below."
-      headTitle="Site pages — Admin — Dame is…"
+      headTitle="Site pages — Admin — dame.is"
     >
       <div className="admin-toolbar">
         <Link to="/admin" className="admin-link-subtle">← All collections</Link>
@@ -753,7 +753,7 @@ function LegacyBlogMigration({ agent, did }) {
     <PageShell
       title="Legacy blog migration"
       intro="Publish the pre-rewrite Eleventy markdown posts to your PDS as standard.site blog documents. Images are uploaded as blobs and each post keeps its original slug, so old /blog links keep working. Re-running a migration overwrites the existing record rather than duplicating it."
-      headTitle="Legacy blog migration — Admin — Dame is…"
+      headTitle="Legacy blog migration — Admin — dame.is"
     >
       <div className="admin-toolbar">
         <Link to="/admin" className="admin-link-subtle">← All collections</Link>
@@ -942,7 +942,7 @@ function ListeningManager({ agent, did }) {
     <PageShell
       title="Listening"
       intro="Every play on your PDS. Select rows to bulk-delete, or open one in the record editor."
-      headTitle="Listening — Admin — Dame is…"
+      headTitle="Listening — Admin — dame.is"
     >
       <div className="admin-toolbar">
         <Link to="/admin" className="admin-link-subtle">← All collections</Link>
@@ -1037,7 +1037,7 @@ function RecordEditorPage({ agent, did, collection, rkey, preset = null }) {
       ? 'blog post'
       : lex?.label || collection;
   const title = isNew ? `New ${newLabel}` : `${lex?.label || collection}`;
-  const headTitle = `${title} — Admin — Dame is…`;
+  const headTitle = `${title} — Admin — dame.is`;
 
   return (
     <PageShell title={title} headTitle={headTitle}>

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -99,7 +99,7 @@ export default function BlogPost() {
 
   if (feedStatus === 'loading') {
     return (
-      <PageShell headTitle={`${id} — Dame is…`}>
+      <PageShell headTitle={`${id} — dame.is`}>
         <article className="blog-article">
           <BlogPostSkeleton paragraphs={4} />
         </article>
@@ -109,7 +109,7 @@ export default function BlogPost() {
 
   if (!resolution || !resolution.record) {
     return (
-      <PageShell title="Post not found" headTitle="Not found — Dame is…">
+      <PageShell title="Post not found" headTitle="Not found — dame.is">
         <p>
           No blog post with id <code>{id}</code>.{' '}
           <Link to="/blogging">Back to the index.</Link>
@@ -148,7 +148,7 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
       title={title}
       atUri={record?.uri}
       cid={record?.cid}
-      headTitle={`${title} — Dame is…`}
+      headTitle={`${title} — dame.is`}
       eyebrow={
         <Link to="/blogging" className="page-back small-caps">
           ← Blog

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -57,7 +57,7 @@ export default function Blogging() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/blogging`}
-      headTitle="Blogging — Dame is&hellip;"
+      headTitle="dame.is blogging"
     >
       {loading ? (
         <BloggingTocSkeleton rows={5} />

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -105,7 +105,7 @@ export default function Creating() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/creating`}
-      headTitle="Creating — Dame is&hellip;"
+      headTitle="dame.is creating"
     >
       <CreatingFilters kinds={kinds} counts={counts} />
       {showSkeleton ? (

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -62,7 +62,7 @@ export default function CreatingWork() {
 
   if (status === 'loading') {
     return (
-      <PageShell headTitle={`${slug} — Dame is…`}>
+      <PageShell headTitle={`${slug} — dame.is`}>
         <article className="creating-work-page">
           <CreatingWorkSkeleton />
         </article>
@@ -72,7 +72,7 @@ export default function CreatingWork() {
 
   if (!record) {
     return (
-      <PageShell title="Work not found" headTitle="Not found — Dame is…">
+      <PageShell title="Work not found" headTitle="Not found — dame.is">
         <p>
           No creative work with slug <code>{slug}</code>.{' '}
           <Link to="/creating">Back to the index.</Link>
@@ -88,7 +88,7 @@ export default function CreatingWork() {
       title={v?.title || slug}
       atUri={record?.uri}
       cid={record?.cid}
-      headTitle={v?.title ? `${v.title} — Dame is…` : `${slug} — Dame is…`}
+      headTitle={v?.title ? `${v.title} — dame.is` : `${slug} — dame.is`}
       eyebrow={
         <Link to="/creating" className="page-back small-caps">
           ← Portfolio

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -98,7 +98,7 @@ export default function Curating() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/curating`}
-      headTitle="Curating — Dame is&hellip;"
+      headTitle="dame.is curating"
     >
       {showSkeleton ? (
         <CreatingGridSkeleton cells={6} />

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -88,7 +88,7 @@ export default function CuratingChannel() {
 
   if (status === 'loading') {
     return (
-      <PageShell headTitle={`${slug} — Dame is…`}>
+      <PageShell headTitle={`${slug} — dame.is`}>
         <CreatingGridSkeleton cells={9} />
       </PageShell>
     );
@@ -99,7 +99,7 @@ export default function CuratingChannel() {
     return (
       <PageShell
         title={missing ? 'Gallery not found' : 'Gallery unavailable'}
-        headTitle="Not found — Dame is…"
+        headTitle="Not found — dame.is"
       >
         <p>
           {missing ? (
@@ -119,7 +119,7 @@ export default function CuratingChannel() {
     <PageShell
       title={gallery.title}
       intro={gallery.description || undefined}
-      headTitle={`${gallery.title} — Dame is…`}
+      headTitle={`${gallery.title} — dame.is`}
       eyebrow={
         <Link to="/curating" className="page-back small-caps">
           ← Curating

--- a/src/pages/Exploring.jsx
+++ b/src/pages/Exploring.jsx
@@ -63,7 +63,7 @@ export default function Exploring() {
   return (
     <PageShell
       title="Exploring"
-      headTitle={`${title} — Exploring — Dame is…`}
+      headTitle={`${title} — Exploring — dame.is`}
     >
       <SearchBox initial={repoInput} />
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -475,7 +475,7 @@ export default function Home() {
     <PageShell
       title={<HeroSentence shuffleRef={shuffleRef} />}
       atUri={`at://${ME_DID}/is.dame.page/home`}
-      headTitle="Dame is&hellip;"
+      headTitle="dame.is"
     >
       <nav className="home-hero-cta" aria-label="Primary destinations">
         <Link className="home-hero-cta-btn home-hero-cta-primary" to="/creating">

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -78,7 +78,7 @@ export default function Listening() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/listening`}
-      headTitle="Listening — Dame is&hellip;"
+      headTitle="dame.is listening"
     >
       {!loading && statsItems.length > 0 && <ListeningStats items={statsItems} />}
       {loading ? (

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -48,7 +48,7 @@ export default function Logging() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/logging`}
-      headTitle="Logging — Dame is&hellip;"
+      headTitle="dame.is logging"
     >
       {loading ? (
         <FeedSkeleton rows={5} label="Loading status updates" />

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -130,7 +130,7 @@ export default function Mothing() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/mothing`}
-      headTitle="Mothing — Dame is&hellip;"
+      headTitle="dame.is mothing"
     >
       {stats && (
         <section className="mothing-stats" aria-label="Mothing stats">

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <PageShell
       title="Nowhere to be found"
       intro="No record exists at this URL."
-      headTitle="Not found — Dame is…"
+      headTitle="Not found — dame.is"
     >
       <p>
         Try the <Link to="/">home page</Link>.

--- a/src/pages/OauthCallback.jsx
+++ b/src/pages/OauthCallback.jsx
@@ -22,7 +22,7 @@ export default function OauthCallback() {
   }, [loading, session, did, navigate]);
 
   return (
-    <PageShell title="Signing in…" headTitle="Signing in — Dame is…">
+    <PageShell title="Signing in…" headTitle="Signing in — dame.is">
       {error ? (
         <p className="placeholder-card">
           Sign-in failed: <code>{String(error?.message || error)}</code>

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -55,7 +55,7 @@ export default function Posting() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/posting`}
-      headTitle="Posting — Dame is&hellip;"
+      headTitle="dame.is posting"
     >
       <PostingFilters counts={counts} />
       {loading ? (

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -164,7 +164,7 @@ export default function Record({ verb, nsid, source }) {
 
   if (!collection) {
     return (
-      <PageShell title="Unknown record type" headTitle="Not found — Dame is…">
+      <PageShell title="Unknown record type" headTitle="Not found — dame.is">
         <p>
           No collection mapped for verb <code>{verb}</code>.{' '}
           <Link to="/">Back to the timeline.</Link>
@@ -175,7 +175,7 @@ export default function Record({ verb, nsid, source }) {
 
   if (missing && !item) {
     return (
-      <PageShell title="Record not found" headTitle="Not found — Dame is…">
+      <PageShell title="Record not found" headTitle="Not found — dame.is">
         <p>
           No <code>{collection}</code> record with rkey <code>{rkey}</code>.{' '}
           <Link to={`/${verb}`}>Back to {verb}.</Link>
@@ -665,36 +665,36 @@ function titleFor(verb, item) {
  * short-form, by snapshotting the body text.
  */
 function headTitleFor(verb, item) {
-  if (!item) return `${VERB_LABELS[verb] || verb} — Dame is…`;
+  if (!item) return `${VERB_LABELS[verb] || verb} — dame.is`;
   switch (verb) {
     case 'blogging':
-      return `${item.payload?.title || 'Untitled'} — Dame is…`;
+      return `${item.payload?.title || 'Untitled'} — dame.is`;
     case 'creating':
-      return `${item.payload?.title || 'Untitled work'} — Dame is…`;
+      return `${item.payload?.title || 'Untitled work'} — dame.is`;
     case 'listening': {
       const track = item.payload?.trackName;
       const artist = Array.isArray(item.payload?.artists)
         ? item.payload.artists.map((a) => a?.artistName).filter(Boolean).join(', ')
         : item.payload?.artist;
       const both = [track, artist].filter(Boolean).join(' · ');
-      return `${both || 'A play'} — Dame is…`;
+      return `${both || 'A play'} — dame.is`;
     }
     case 'posting': {
       const text = (item.payload?.text || '').trim();
-      return `${text ? truncate(text, 80) : 'A post'} — Dame is…`;
+      return `${text ? truncate(text, 80) : 'A post'} — dame.is`;
     }
     case 'reposting': {
       const handle = item.payload?.author?.handle;
       const text = (item.payload?.text || '').trim();
       const snippet = text ? truncate(text, 60) : 'a post';
-      return `Reposted: ${handle ? `@${handle} — ` : ''}${snippet} — Dame is…`;
+      return `Reposted: ${handle ? `@${handle} — ` : ''}${snippet} — dame.is`;
     }
     case 'logging': {
       const text = (item.payload?.status || item.payload?.text || '').trim();
-      return `${text ? truncate(text, 80) : 'A status'} — Dame is…`;
+      return `${text ? truncate(text, 80) : 'A status'} — dame.is`;
     }
     default:
-      return `${VERB_LABELS[verb] || verb} — Dame is…`;
+      return `${VERB_LABELS[verb] || verb} — dame.is`;
   }
 }
 

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -52,7 +52,7 @@ export default function Resume() {
 
   if (status === 'loading') {
     return (
-      <PageShell headTitle="For hire — Dame is…" atUri={`at://${ME_DID}/is.dame.page/resume`}>
+      <PageShell headTitle="dame.is for hire" atUri={`at://${ME_DID}/is.dame.page/resume`}>
         <p className="placeholder-card">Loading resume…</p>
       </PageShell>
     );
@@ -62,7 +62,7 @@ export default function Resume() {
     return (
       <PageShell
         title={pageTitle}
-        headTitle="For hire — Dame is…"
+        headTitle="dame.is for hire"
         atUri={`at://${ME_DID}/is.dame.page/resume`}
       >
         <p className="feed-empty">
@@ -84,7 +84,7 @@ export default function Resume() {
 
   return (
     <PageShell
-      headTitle={`${v.headline || pageTitle || 'For hire'} — Dame is…`}
+      headTitle={`${v.headline || pageTitle || 'For hire'} — dame.is`}
       atUri={resolved.uri}
       cid={resolved.cid}
     >

--- a/src/pages/Sharing.jsx
+++ b/src/pages/Sharing.jsx
@@ -14,7 +14,7 @@ export default function Sharing() {
       title={title}
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/sharing`}
-      headTitle="Sharing — Dame is&hellip;"
+      headTitle="dame.is sharing"
     >
       {loading ? (
         <ProseSkeleton paragraphs={4} />


### PR DESCRIPTION
Two title conventions, applied to both the crawler-facing OG/meta and the client-side tab titles:

- **Top-level surfaces read brand-first:** `dame.is themself`, `dame.is blogging`, `dame.is for hire` (home is just `dame.is`), instead of `Themself — Dame is…`.
- **Record / leaf pages read title-first:** `{record title} — dame.is`, e.g. `Why I started posting like it's the 2000s again — dame.is`.

## Changes
- **`og/pages.js`** — surface titles switched to `dame.is {label}`.
- **`og/records.js`** (new) — edge-safe resolver: maps `/blogging`, `/creating`, `/curating` `/{rkey}` to its AT-Protocol collection(s), resolves the PDS via PLC, and reads the record's title. Defensive (2.5s timeout; falls back on any miss).
- **`middleware.js`** — now also matches the slug record routes; injects `{record title} — dame.is` with the parent section's card as `og:image`, and degrades to the section's own `dame.is {label}` title/card if the record can't be fetched.
- **`index.html`** — baseline `<title>`/`og:title`/`twitter:title` → `dame.is`.
- **`src/pages/*.jsx`** — client tab titles updated to match (surfaces brand-first; leaf/utility pages `… — dame.is`).

## Notes
- Record pages now do one cached edge PDS lookup for their title (crawlers + first human hit per hour); it never blocks the page.

## Verification
Live resolver check: real blog slug → `Why I started posting like it's the 2000s again — dame.is`; sections → `dame.is blogging`; bogus slug → falls back to `dame.is blogging`. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019danisoicnsB6zQYSxHGit

---
_Generated by [Claude Code](https://claude.ai/code/session_019danisoicnsB6zQYSxHGit)_