### PR TITLE
Tidy bottom-chrome sheets: edit-bar inset, full-height info, dock coordination

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -127,6 +127,13 @@
   color: var(--accent);
 }
 
+/* The list's top hairline (.dock-routes) plus each row's border-bottom draw
+   the ruled lines; the last row's bottom rule would sit right above the
+   panel's own bottom edge, so drop it to close the list cleanly. */
+.dock-route:last-child {
+  border-bottom: none;
+}
+
 .dock-route-label {
   font-family: var(--serif);
   font-size: var(--text-base);

--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -26,7 +26,10 @@
   justify-content: space-between;
   gap: var(--space-3);
   min-height: 2.75rem;
-  padding: var(--space-2) var(--space-4);
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x)
+     so "Tap items to select" and the action buttons line up with the
+     bottom-bar buttons, the nav dock, and the breadcrumb. */
+  padding: var(--space-2) var(--chrome-pad-x);
   /* Match the bottom bar's own raised surface + hairlines so the expanded
      strip looks continuous with the chrome it grows out of. */
   background: var(--surface-raised);

--- a/src/components/InfoSheet.jsx
+++ b/src/components/InfoSheet.jsx
@@ -14,7 +14,7 @@ export default function InfoSheet() {
   const open = panel === 'info';
 
   return (
-    <BottomSheet open={open} onClose={closePanel} label="About this site" id="chrome-info-sheet" className="info-sheet-panel">
+    <BottomSheet open={open} onClose={closePanel} label="About this site" id="chrome-info-sheet" size="fill" className="info-sheet-panel">
       <div className="info-sheet-header">
         <span className="small-caps">about this site</span>
         <button

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useActionDock } from './useActionDock.jsx';
 
 const EditModeContext = createContext(null);
 
@@ -46,6 +47,7 @@ export function EditModeProvider({ children }) {
   // loading, canDelete } or null.
   const [sheetEditor, setSheetEditor] = useState(null);
   const location = useLocation();
+  const { open: dockOpen } = useActionDock();
 
   const clearSelection = useCallback(() => {
     setSelected((prev) => (prev.size === 0 ? prev : new Map()));
@@ -92,6 +94,15 @@ export function EditModeProvider({ children }) {
     // the route changes so it never hangs over an unrelated page.
     setEditSheet(null);
   }, [location.pathname, clearSelection]);
+
+  // The nav dock and the quick-edit sheet share the bottom-chrome slot, and
+  // the dock opens on top of everything — so opening the dock folds the
+  // quick-edit sheet away (it would otherwise sit hidden behind the dock).
+  // Mirrors useChromePanel's dock↔panel rule; edit MODE (and its action bar)
+  // stays put — the dock rides above the bar via --edit-bar-h.
+  useEffect(() => {
+    if (dockOpen) setEditSheet(null);
+  }, [dockOpen]);
 
   const toggleSelect = useCallback((item) => {
     const uri = item?.atUri;


### PR DESCRIPTION
Four small bottom-chrome tweaks.

## Edit-mode action bar inset
`.edit-mode-bar-inner` now tracks the shared `--chrome-pad-x` column instead of a flat `--space-4`, so "Tap items to select" and the action buttons line up with the bottom-bar buttons, nav dock, and breadcrumb (was ~40px left of the column below 65rem).

## Info sheet fills to the top
Render the info panel as a `fill` `BottomSheet` so it occupies the whole gap up to the top chrome and butts its border seamlessly — matching the nav dock — instead of a shorter, content-height sheet with a dividing top hairline. *Verified: panel top meets the top chrome (114px) with `border-top: 0`.*

## Nav dock folds the quick-edit sheet away
The dock already closed the search/filter/info panels on open; the owner quick-edit sheet didn't (it would sit hidden behind the dock, which paints on top). Added the mirror rule in `useEditMode`. Edit **mode** and its action bar stay put — the dock rides above the bar via `--edit-bar-h`.

## Last nav route border
Drop `border-bottom` on `.dock-route:last-child` so the route list closes cleanly instead of drawing a rule right above the panel's own bottom edge. *Verified: 8 routes, first has a 1px rule, `mothing` has none.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7)_