### PR TITLE
Masonry on the curating index + authenticate are.na at runtime

### DIFF
--- a/api/arena.js
+++ b/api/arena.js
@@ -1,0 +1,47 @@
+// Vercel serverless function: same-origin proxy for read-only are.na channel
+// requests, so the browser's live gallery refresh can use the account's access
+// token (raising the rate ceiling above the 30 req/min guest tier) without the
+// secret ever reaching the client bundle. The token stays server-side here.
+//
+// Only `/channels/…` paths are forwarded, and only to api.are.na — this is not
+// a general-purpose proxy.
+
+const ARENA_API = 'https://api.are.na/v3';
+
+/** Read the token under any of the accepted env-var names. Server-side only. */
+function arenaToken() {
+  return (
+    process.env.ARENA_ACCESS_TOKEN ||
+    process.env.ARENA_TOKEN ||
+    process.env.ARENA_API_KEY ||
+    ''
+  );
+}
+
+export default async function handler(req, res) {
+  const path = req.query?.path;
+  if (typeof path !== 'string' || !path.startsWith('/channels/') || path.includes('..')) {
+    return res.status(400).json({ error: 'Pass an are.na `path` beginning with /channels/.' });
+  }
+  try {
+    const headers = {
+      Accept: 'application/json',
+      'User-Agent': 'dame.is (+https://dame.is)',
+    };
+    const token = arenaToken();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const upstream = await fetch(`${ARENA_API}${path}`, { headers });
+    const body = await upstream.text();
+    res.setHeader('content-type', 'application/json; charset=utf-8');
+    // Cache successes at the edge (titles/counts change rarely); never pin an
+    // error or a rate-limit response.
+    res.setHeader(
+      'cache-control',
+      upstream.ok ? 'public, max-age=300, s-maxage=900, stale-while-revalidate=3600' : 'no-store',
+    );
+    return res.status(upstream.status).end(body);
+  } catch (err) {
+    res.setHeader('cache-control', 'no-store');
+    return res.status(502).json({ error: err?.message || 'are.na proxy failed' });
+  }
+}

--- a/src/components/MasonryGrid.jsx
+++ b/src/components/MasonryGrid.jsx
@@ -1,0 +1,56 @@
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+// Masonry column sizing — keep in step with `.creating-grid` in Creating.css.
+const MIN_COL_REM = 16;
+const GAP_REM = 1.5; // --space-5
+
+/**
+ * Responsive masonry column count derived from the container's own width.
+ */
+function useMasonryColumns() {
+  const ref = useRef(null);
+  const [cols, setCols] = useState(1);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    const rem = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    const minCol = MIN_COL_REM * rem;
+    const gap = GAP_REM * rem;
+    const measure = () => {
+      const w = el.clientWidth;
+      if (w > 0) setCols(Math.max(1, Math.floor((w + gap) / (minCol + gap))));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, cols];
+}
+
+/**
+ * Masonry laid out as side-by-side flex columns. Items are dealt round-robin
+ * across the columns (item i → column i % n), so an already-sorted list reads
+ * left-to-right — newest along the top row — while each column still packs to
+ * its own varying heights (the irregular mosaic, not rows aligned to the
+ * tallest card). `renderItem(item, index)` must return a `<li>` and attach its
+ * own key.
+ */
+export default function MasonryGrid({ items, renderItem, className = 'creating-grid' }) {
+  const [gridRef, columnCount] = useMasonryColumns();
+  const columns = useMemo(() => {
+    const buckets = Array.from({ length: columnCount }, () => []);
+    items.forEach((it, i) => buckets[i % columnCount].push({ it, i }));
+    return buckets;
+  }, [items, columnCount]);
+
+  return (
+    <div className={className} ref={gridRef}>
+      {columns.map((col, ci) => (
+        <ul className="creating-grid-col reveal-stagger" key={ci}>
+          {col.map(({ it, i }) => renderItem(it, i))}
+        </ul>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/arena.js
+++ b/src/lib/arena.js
@@ -1,15 +1,19 @@
 // Tiny isomorphic Are.na v3 client. No SDK — just fetch + JSON, so it runs
 // in both `scripts/prefetch.mjs` (Node) and the browser.
 //
-// Public channels need no auth and the API sends `access-control-allow-origin:
-// *`, so the browser's live refresh works unauthenticated (guest tier,
-// 30 req/min — a gallery page view makes at most ~11 requests). At build time
-// an optional read-only personal access token (ARENA_ACCESS_TOKEN) raises the
-// rate ceiling to the account's tier (premium = 300/min). The env var is
-// deliberately not VITE_-prefixed so Vite can never inline it into the
-// client bundle.
+// A read-only personal access token (ARENA_ACCESS_TOKEN) raises the rate
+// ceiling from the 30 req/min guest tier to the account's tier. It is applied
+// two ways so both the build and the live site are authenticated, while the
+// secret never reaches the client bundle:
+//   - Node (build-time prefetch): sent straight to api.are.na as a Bearer.
+//   - Browser (live refresh): requests go through our same-origin `/api/arena`
+//     serverless proxy, which injects the token server-side.
+// The env var is deliberately not VITE_-prefixed so Vite can never inline it.
 
 const ARENA_API = 'https://api.are.na/v3';
+
+// Browser calls hit the serverless proxy instead of api.are.na directly.
+const ARENA_PROXY = '/api/arena';
 
 // Courtesy identification for build-time requests so are.na can see who
 // is calling. Node only — browsers forbid setting User-Agent, but their
@@ -18,17 +22,30 @@ const ARENA_USER_AGENT = 'dame.is prefetch (+https://dame.is)';
 
 const IS_NODE = typeof process !== 'undefined' && Boolean(process.versions?.node);
 
-/** Build-time only: undefined in the browser. */
+/**
+ * Build-time only: undefined in the browser. Accepts a few common env-var
+ * names so a token set under any of them is picked up.
+ */
 export function arenaAccessToken() {
-  return typeof process !== 'undefined' ? process.env?.ARENA_ACCESS_TOKEN : undefined;
+  if (typeof process === 'undefined') return undefined;
+  const env = process.env || {};
+  return env.ARENA_ACCESS_TOKEN || env.ARENA_TOKEN || env.ARENA_API_KEY || undefined;
 }
 
 async function arenaJson(path) {
-  const token = arenaAccessToken();
   const headers = {};
-  if (token) headers.Authorization = `Bearer ${token}`;
-  if (IS_NODE) headers['User-Agent'] = ARENA_USER_AGENT;
-  const res = await fetch(`${ARENA_API}${path}`, {
+  let url;
+  if (IS_NODE) {
+    // Build time: talk to are.na directly, authenticating with the token.
+    const token = arenaAccessToken();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    headers['User-Agent'] = ARENA_USER_AGENT;
+    url = `${ARENA_API}${path}`;
+  } else {
+    // Browser: go through the same-origin proxy, which adds the token.
+    url = `${ARENA_PROXY}?path=${encodeURIComponent(path)}`;
+  }
+  const res = await fetch(url, {
     headers: Object.keys(headers).length ? headers : undefined,
   });
   if (!res.ok) {

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import MasonryGrid from '../components/MasonryGrid.jsx';
 import CreatingFilters, { filterCreatingItems } from '../components/CreatingFilters.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
@@ -17,37 +18,6 @@ import '../components/FeedFilters.css';
 import './Creating.css';
 
 const STANDARD_DOC = 'site.standard.document';
-
-// Masonry column sizing — keep in step with `.creating-grid` in Creating.css.
-const MASONRY_MIN_COL_REM = 16;
-const MASONRY_GAP_REM = 1.5; // --space-5
-
-/**
- * Responsive masonry column count from the container's own width. Distributing
- * items round-robin across this many columns (item i → column i % n) keeps the
- * tight, non-aligned masonry look while preserving left-to-right reading order
- * — newest across the top row rather than straight down the first column.
- */
-function useMasonryColumns() {
-  const ref = useRef(null);
-  const [cols, setCols] = useState(1);
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return undefined;
-    const rem = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-    const minCol = MASONRY_MIN_COL_REM * rem;
-    const gap = MASONRY_GAP_REM * rem;
-    const measure = () => {
-      const w = el.clientWidth;
-      if (w > 0) setCols(Math.max(1, Math.floor((w + gap) / (minCol + gap))));
-    };
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-  return [ref, cols];
-}
 
 function WorkCard({ record }) {
   const v = record.value || {};
@@ -154,15 +124,6 @@ export default function Creating() {
   }, [loading, coversReady]);
   const showSkeleton = loading || (filtered.length > 0 && !revealed);
 
-  // Deal the (newest-first) works round-robin into responsive columns so the
-  // masonry reads left-to-right, newest along the top.
-  const [gridRef, columnCount] = useMasonryColumns();
-  const columns = useMemo(() => {
-    const buckets = Array.from({ length: columnCount }, () => []);
-    filtered.forEach((r, i) => buckets[i % columnCount].push(r));
-    return buckets;
-  }, [filtered, columnCount]);
-
   return (
     <PageShell
       title={title}
@@ -178,15 +139,10 @@ export default function Creating() {
           {q ? 'No works match that search.' : 'No works yet.'}
         </p>
       ) : (
-        <div className="creating-grid" ref={gridRef}>
-          {columns.map((col, ci) => (
-            <ul className="creating-grid-col reveal-stagger" key={ci}>
-              {col.map((r, i) => (
-                <WorkCard key={r.uri || `${ci}-${i}`} record={r} />
-              ))}
-            </ul>
-          ))}
-        </div>
+        <MasonryGrid
+          items={filtered}
+          renderItem={(r, i) => <WorkCard key={r.uri || i} record={r} />}
+        />
       )}
     </PageShell>
   );

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import MasonryGrid from '../components/MasonryGrid.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { useImagesReady } from '../hooks/useImagesReady.js';
@@ -105,8 +106,9 @@ export default function Curating() {
       ) : list.length === 0 ? (
         <p className="feed-empty">No galleries yet.</p>
       ) : (
-        <ul className="creating-grid reveal-stagger">
-          {list.map((g) => (
+        <MasonryGrid
+          items={list}
+          renderItem={(g) => (
             <li key={g.slug} className="creating-grid-cell">
               <Link to={`/curating/${g.slug}`} className="creating-grid-link">
                 {g.cover?.src ? (
@@ -127,8 +129,8 @@ export default function Curating() {
                 </div>
               </Link>
             </li>
-          ))}
-        </ul>
+          )}
+        />
       )}
     </PageShell>
   );


### PR DESCRIPTION
## Summary

### Curating masonry
The curating index still used the old single-`<ul>` `.creating-grid` markup, which broke once that class became a flex column container. Extract the responsive round-robin masonry (column count + left-to-right distribution) into a reusable `<MasonryGrid>` and use it for both the creating and curating indexes.

### Authenticate are.na at runtime
The access token was only ever applied in Node (build-time prefetch), so the browser's live gallery refresh always ran as the 30 req/min guest tier and the env var couldn't help it.

- Add `/api/arena`, a same-origin serverless proxy that injects the token server-side and forwards only read-only `/channels/…` requests to are.na — live requests are authenticated without exposing the secret to the client.
- Route the browser's are.na client through that proxy (Node still talks to are.na directly at build time).
- Accept the token under `ARENA_ACCESS_TOKEN`, `ARENA_TOKEN`, or `ARENA_API_KEY`.

## Testing
- `vite build` passes.
- Proxy path handling verified: valid `/channels/…` paths (with query strings) forward; non-channel and traversal paths are rejected 400.

Note: the token must be set in Vercel for the Production environment; the proxy only runs on a real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_