### PR TITLE
Show one active resume on /for-hire, pick it from admin

### DIFF
--- a/src/lib/resumeHelpers.js
+++ b/src/lib/resumeHelpers.js
@@ -165,13 +165,14 @@ export function resolveResume(resumeRecord, jobs, education) {
 const renderable = (r) => r?.value && (r.value.visibility || 'public') !== 'private';
 
 /**
- * Choose the resume to show at /resume (no slug): the featured one, else the
- * first public one, else any renderable one. `private` resumes are skipped.
+ * Choose the single active resume shown at /for-hire: the one flagged
+ * `featured` (set from the admin panel), else the first public one, else any
+ * renderable one. `private` resumes are skipped.
  */
 export function pickDefaultResume(resumes) {
   const list = (resumes || []).filter(renderable);
   return (
-    list.find((r) => r.value.featured && r.value.visibility !== 'unlisted') ||
+    list.find((r) => r.value.featured) ||
     list.find((r) => (r.value.visibility || 'public') === 'public') ||
     list[0] ||
     null
@@ -184,12 +185,5 @@ export function findResumeBySlug(resumes, slug) {
     (resumes || [])
       .filter(renderable)
       .find((r) => (r.value.slug || rkeyFromAtUri(r.uri)) === slug) || null
-  );
-}
-
-/** Public, listed resumes (for the version switcher). */
-export function listPublicResumes(resumes) {
-  return (resumes || []).filter(
-    (r) => r?.value && (r.value.visibility || 'public') === 'public',
   );
 }

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -248,6 +248,90 @@
   color: var(--ink);
 }
 
+/* Active resume selector: pick the single version shown at /for-hire. */
+.admin-active-resume {
+  border: 1px solid var(--rule-soft);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.admin-active-resume-label {
+  margin: 0;
+  font-variant: all-small-caps;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+}
+
+.admin-active-resume-note {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+}
+
+.admin-active-resume-list {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-1) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.admin-active-resume-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  background: none;
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 200ms ease, background 200ms ease;
+}
+
+.admin-active-resume-btn:not(:disabled):hover {
+  border-color: var(--accent-soft);
+}
+
+.admin-active-resume-btn:disabled {
+  cursor: default;
+}
+
+.admin-active-resume-radio {
+  flex-shrink: 0;
+  width: 0.85em;
+  height: 0.85em;
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+}
+
+.admin-active-resume-btn.is-active .admin-active-resume-radio {
+  border-color: var(--accent);
+  background: radial-gradient(circle, var(--accent) 0 45%, transparent 55%);
+}
+
+.admin-active-resume-btn.is-active {
+  border-color: var(--accent);
+}
+
+.admin-active-resume-name {
+  flex: 1;
+}
+
+.admin-active-resume-vis {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+}
+
 /* Multi-select record management (e.g. the listening manager): a sticky-feeling
    action row above a list of checkbox rows. */
 .admin-multiselect-toolbar {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -435,6 +435,10 @@ function RecordList({
 
       {pageSlug && <PageContentPanel agent={agent} did={did} slug={pageSlug} />}
 
+      {collection === COLLECTIONS.resume && records.length > 0 && (
+        <ResumeActiveSelector agent={agent} did={did} records={records} onChanged={reload} />
+      )}
+
       {error && <p className="admin-error">{error}</p>}
 
       {visibleRecords.length === 0 && !loading && !error && (
@@ -492,6 +496,92 @@ function previewFor(value, lex) {
 function truncate(s, n) {
   if (!s) return '';
   return s.length <= n ? s : s.slice(0, n - 1).trimEnd() + '…';
+}
+
+/* ------------------------------------------------------------------ */
+/* Active resume selector                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Picks which resume version is "active" — the single one shown at /for-hire.
+ * Active-ness is stored as the `featured` flag on the resume record; choosing
+ * one here sets `featured: true` on it and clears it on every other version,
+ * so at most one is ever active.
+ */
+function ResumeActiveSelector({ agent, did, records, onChanged }) {
+  const [busy, setBusy] = useState(null); // rkey currently being set
+  const [error, setError] = useState(null);
+
+  const activeRkey = useMemo(() => {
+    const found = records.find((rec) => rec.value?.featured);
+    return found ? rkeyFromUri(found.uri) : null;
+  }, [records]);
+
+  async function setActive(rkey) {
+    if (busy) return;
+    setBusy(rkey);
+    setError(null);
+    try {
+      // Flip only the records whose featured flag needs to change.
+      for (const rec of records) {
+        const r = rkeyFromUri(rec.uri);
+        const shouldBeActive = r === rkey;
+        const isActive = !!rec.value?.featured;
+        if (shouldBeActive === isActive) continue;
+        await agent.com.atproto.repo.putRecord({
+          repo: did,
+          collection: COLLECTIONS.resume,
+          rkey: r,
+          record: {
+            ...rec.value,
+            featured: shouldBeActive,
+            updatedAt: new Date().toISOString(),
+          },
+        });
+      }
+      onChanged?.();
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="admin-active-resume">
+      <p className="admin-active-resume-label small-caps">Active version</p>
+      <p className="admin-active-resume-note">
+        The one version shown on <code>/for-hire</code>.
+      </p>
+      <ul className="admin-active-resume-list">
+        {records.map((rec) => {
+          const r = rkeyFromUri(rec.uri);
+          const isActive = r === activeRkey;
+          const label = rec.value?.title || rec.value?.slug || r;
+          const vis = rec.value?.visibility || 'private';
+          return (
+            <li key={rec.uri} className="admin-active-resume-item">
+              <button
+                type="button"
+                className={`admin-active-resume-btn ${isActive ? 'is-active' : ''}`}
+                onClick={() => !isActive && setActive(r)}
+                disabled={!!busy || isActive}
+                aria-pressed={isActive}
+              >
+                <span className="admin-active-resume-radio" aria-hidden="true" />
+                <span className="admin-active-resume-name">{label}</span>
+                {vis !== 'public' && (
+                  <span className="admin-active-resume-vis">{vis}</span>
+                )}
+                {busy === r && <span className="admin-active-resume-vis">saving…</span>}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {error && <p className="admin-error">{error}</p>}
+    </div>
+  );
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -88,37 +88,6 @@
   border-color: var(--accent-soft);
 }
 
-/* --- Version switcher ------------------------------------------------ */
-.resume-versions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-top: var(--space-2);
-}
-
-.resume-version-chip {
-  font-family: var(--sans);
-  font-size: var(--text-sm);
-  text-decoration: none;
-  color: var(--ink-soft);
-  padding: var(--space-1) var(--space-3);
-  border: 1px solid var(--rule-soft);
-  border-radius: 0;
-  transition: border-color 200ms ease, color 200ms ease, background 200ms ease;
-}
-
-.resume-version-chip:hover {
-  border-color: var(--accent-soft);
-  color: var(--ink);
-}
-
-.resume-version-chip.is-active {
-  color: var(--page);
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
 /* --- Sections ------------------------------------------------------- */
 .resume-section {
   display: flex;
@@ -324,7 +293,6 @@
 /* --- Print: a clean one-document resume ----------------------------- */
 @media print {
   .resume-print-btn,
-  .resume-versions,
   .resume-record-link,
   .resume-footnote {
     display: none !important;

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -10,7 +10,6 @@ import {
   resolveResume,
   pickDefaultResume,
   findResumeBySlug,
-  listPublicResumes,
 } from '../lib/resumeHelpers.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Resume.css';
@@ -42,8 +41,6 @@ export default function Resume() {
     const chosen = slug ? findResumeBySlug(resumes, slug) : pickDefaultResume(resumes);
     return chosen ? resolveResume(chosen, items?.jobs, items?.education) : null;
   }, [resumes, items, slug]);
-
-  const versions = useMemo(() => listPublicResumes(resumes), [resumes]);
 
   const summaryHtml = useMemo(() => {
     const v = resolved?.value;
@@ -123,26 +120,6 @@ export default function Resume() {
                 </li>
               ))}
             </ul>
-          )}
-
-          {versions.length > 1 && (
-            <nav className="resume-versions" aria-label="Resume versions">
-              <span className="small-caps">Versions</span>
-              {versions.map((r) => {
-                const s = r.value.slug;
-                const active = s === resolved.slug;
-                return (
-                  <Link
-                    key={r.uri}
-                    to={`/for-hire/${s}`}
-                    className={`resume-version-chip ${active ? 'is-active' : ''}`}
-                    aria-current={active ? 'page' : undefined}
-                  >
-                    {r.value.title || s}
-                  </Link>
-                );
-              })}
-            </nav>
           )}
         </header>
 


### PR DESCRIPTION
## Summary

The `/for-hire` page now shows a single **active** resume version with no on-page toggle, and the active version is chosen from the admin panel.

- Removed the "Versions" chip switcher from the for-hire page (and its dead import, memo, and CSS).
- The page always renders the active version — the resume flagged `featured` — falling back to the first public one, then any renderable one. `private` versions are never rendered.
- Added an **Active version** radio-style selector to the top of the Resume list in the admin. Choosing a version sets `featured: true` on that record and clears it on the others, so at most one is ever active (also stamps `updatedAt`).

## Notes

- The `/for-hire/:slug` route still resolves for direct links to a specific version — it just isn't surfaced with a toggle anymore.
- Verified with a clean `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xoNKvCGjSAtHfgmQq7kKA)_