### PR TITLE
Stabilize the bottom-chrome divider and rework its button animation

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -30,6 +30,16 @@
   margin: 0 auto;
   z-index: 31;
   overflow: hidden;
+  /* Bottom-anchor the panel inside the height-animating clip: the panel is
+     its full height from the first frame and the clip reveals it from the bar
+     upward, so its bottom edge (and border-bottom divider) sits at the clip's
+     bottom the whole time. Anchoring at the top instead lets the panel
+     overflow the clip's BOTTOM mid-animation, clipping the divider away while
+     the opaque panel still covers the bar's own border-top — the seam then
+     vanishes until the animation settles. */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   pointer-events: none;
 }
 
@@ -42,6 +52,11 @@
    scroll when a view (the route list, the debug dump) overflows. */
 .dock-panel {
   pointer-events: auto;
+  /* Keep full height inside the bottom-anchored clip (see .dock-sheet-wrap):
+     the clip reveals the panel from the bar upward, clipping its TOP rather
+     than shrinking it, so the border-bottom divider stays put and the content
+     doesn't reflow mid-animation. */
+  flex: 0 0 auto;
   /* Deeper than the bar's --surface-raised so the expanded sheet reads
      as its own layer above the toolbar. */
   background: var(--surface-deep);

--- a/src/components/BottomSheet.css
+++ b/src/components/BottomSheet.css
@@ -28,11 +28,23 @@
   margin: 0 auto;
   z-index: 31;
   overflow: hidden;
+  /* Bottom-anchor the panel inside the height-animating clip so its
+     border-bottom divider sits at the clip's bottom the whole time. Anchored
+     at the top instead, the panel overflows the clip's BOTTOM mid-animation,
+     clipping the divider away while the opaque panel still covers the bar's
+     own border-top — the seam then vanishes until the animation settles. */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   pointer-events: none;
 }
 
 .bottom-sheet-panel {
   pointer-events: auto;
+  /* Full height inside the bottom-anchored clip: the clip reveals the panel
+     from the bar upward, clipping its TOP rather than shrinking it, so the
+     divider holds and the content doesn't reflow mid-animation. */
+  flex: 0 0 auto;
   /* Deeper than the bar's --surface-raised so the expanded panel reads as
      its own layer above the toolbar. */
   background: var(--surface-deep);

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -28,6 +28,10 @@ const THEME_ICON = {
   dark: Moon,
 };
 
+// The home handle is a router <Link>; wrap it so it can participate in the
+// bottom bar's presence/layout animation (fade in/out, slide to make room).
+const MotionLink = motion.create(Link);
+
 export default function ChromeBar() {
   const { expanded, toggle } = useChromeBar();
   const { open: dockOpen, toggle: toggleDock } = useActionDock();
@@ -360,6 +364,20 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
     window.scrollTo({ top: h, behavior: reduce ? 'auto' : 'smooth' });
   }
 
+  // Shared enter/exit for the bottom bar's on-demand controls (back, home,
+  // the scrolled-past count). They cross-fade rather than sliding in on a
+  // transform, and `layout` on the whole right cluster eases the persistent
+  // buttons (scroll-jump, menu) over to fill the gap instead of letting them
+  // jump — so a control never just pops in or out. `layout` is dropped under
+  // reduced-motion so nothing translates.
+  const controlFade = {
+    initial: reduce ? false : { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: reduce ? 0 : 0.2, ease: [0.22, 0.61, 0.36, 1] },
+  };
+  const layoutProp = reduce ? undefined : true;
+
   return (
     <div className="chrome-bar chrome-bar-bottom" role="toolbar" aria-label="Global actions">
       <div className="chrome-bottom-row">
@@ -374,10 +392,10 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
               <motion.div
                 key="tools"
                 className="chrome-bottom-cluster"
-                initial={reduce ? false : { opacity: 0, y: 5 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={reduce ? { opacity: 0 } : { opacity: 0, y: 5 }}
-                transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
+                initial={reduce ? false : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: reduce ? 0 : 0.18, ease: [0.22, 0.61, 0.36, 1] }}
               >
                 <DensityToggle />
                 {PAPER_ENABLED && <PaperToggle />}
@@ -406,10 +424,10 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
               <motion.div
                 key="default"
                 className="chrome-bottom-cluster"
-                initial={reduce ? false : { opacity: 0, y: 5 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={reduce ? { opacity: 0 } : { opacity: 0, y: 5 }}
-                transition={{ duration: reduce ? 0 : 0.16, ease: [0.22, 0.61, 0.36, 1] }}
+                initial={reduce ? false : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: reduce ? 0 : 0.18, ease: [0.22, 0.61, 0.36, 1] }}
               >
                 <button
                   type="button"
@@ -485,32 +503,38 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           </AnimatePresence>
         </div>
         <div className="chrome-bottom-spacer" aria-hidden="true" />
-        {!onHomePage && (
-          <button
-            type="button"
-            className="chrome-nav chrome-back-btn"
-            onClick={goBack}
-            aria-label="Go back"
-          >
-            <ArrowLeft className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-          </button>
-        )}
-        <AnimatePresence initial={false}>
+        {/* Right cluster. The on-demand controls (back, count, home) fade in
+            and out inside a popLayout presence; the persistent scroll-jump and
+            menu buttons carry `layout` so they slide over to fill the freed
+            space rather than jumping when a control comes or goes. */}
+        <AnimatePresence mode="popLayout" initial={false}>
+          {!onHomePage && (
+            <motion.button
+              key="back"
+              layout={layoutProp}
+              type="button"
+              className="chrome-nav chrome-back-btn"
+              onClick={goBack}
+              aria-label="Go back"
+              {...controlFade}
+            >
+              <ArrowLeft className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+            </motion.button>
+          )}
           {scrolledPast > 0 && (
             <motion.span
               key="scroll-count"
+              layout={layoutProp}
               className="chrome-scroll-count gutter"
-              initial={reduce ? false : { opacity: 0, x: 6 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={reduce ? { opacity: 0 } : { opacity: 0, x: 6 }}
-              transition={{ duration: reduce ? 0 : 0.18, ease: 'easeOut' }}
               aria-label={`${scrolledPast} items scrolled past`}
+              {...controlFade}
             >
               {scrolledPast}
             </motion.span>
           )}
         </AnimatePresence>
-        <button
+        <motion.button
+          layout={layoutProp}
           type="button"
           className="chrome-nav chrome-scroll-jump"
           onClick={atTop ? scrollToBottom : scrollToTop}
@@ -521,23 +545,29 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           ) : (
             <ArrowUp className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
           )}
-        </button>
-        {!onHomePage && (
-          <Link
-            to="/"
-            className="chrome-nav chrome-home-btn"
-            aria-label="Go home"
-            onClick={() => {
-              // Collapse the open menu on the way home so it animates
-              // out (via the dock's AnimatePresence exit) instead of
-              // being left open over the freshly-loaded home page.
-              if (dockOpen) toggleDock();
-            }}
-          >
-            <Home className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-          </Link>
-        )}
-        <button
+        </motion.button>
+        <AnimatePresence mode="popLayout" initial={false}>
+          {!onHomePage && (
+            <MotionLink
+              key="home"
+              layout={layoutProp}
+              to="/"
+              className="chrome-nav chrome-home-btn"
+              aria-label="Go home"
+              onClick={() => {
+                // Collapse the open menu on the way home so it animates
+                // out (via the dock's AnimatePresence exit) instead of
+                // being left open over the freshly-loaded home page.
+                if (dockOpen) toggleDock();
+              }}
+              {...controlFade}
+            >
+              <Home className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+            </MotionLink>
+          )}
+        </AnimatePresence>
+        <motion.button
+          layout={layoutProp}
           type="button"
           className={`chrome-nav chrome-nav-bottom ${dockOpen ? 'is-open' : ''}`}
           onClick={toggleDock}
@@ -546,7 +576,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
           aria-label={dockOpen ? 'Close menu' : 'Open menu'}
         >
           <Compass className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-        </button>
+        </motion.button>
       </div>
 
       {/* Footer strip: the bottom-bar mirror of the top bar's breadcrumb.

--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -16,11 +16,20 @@
   max-width: 65rem;
   margin: 0 auto;
   overflow: hidden;
+  /* Bottom-anchor the strip inside the height-animating clip so its top
+     hairline holds steady during the reveal instead of being clipped away
+     mid-animation — see the matching note in BottomSheet.css. */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   pointer-events: none;
 }
 
 .edit-mode-bar-inner {
   pointer-events: auto;
+  /* Full height inside the bottom-anchored clip — clipped from the top on
+     reveal rather than shrunk. */
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/EditSheet.css
+++ b/src/components/EditSheet.css
@@ -26,11 +26,21 @@
   margin: 0 auto;
   z-index: 32;
   overflow: hidden;
+  /* Bottom-anchor the panel inside the height-animating clip so its bottom
+     edge (and the divider to the button row) holds steady the whole time
+     instead of being clipped away mid-animation — see EditSheet.jsx / the
+     matching note in BottomSheet.css. */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   pointer-events: none;
 }
 
 .edit-sheet-panel {
   pointer-events: auto;
+  /* Full height inside the bottom-anchored clip — clipped from the top on
+     reveal rather than shrunk, so the head/body/foot don't reflow. */
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   background: var(--surface-deep);


### PR DESCRIPTION
Two bottom-chrome polish fixes.

## Divider no longer flickers while sheets expand/collapse

The nav dock, search/info/filter sheets, the owner edit sheet, and the edit-mode bar all expand out of the bottom chrome via a fixed, `overflow:hidden` wrap whose *height* animates 0↔auto. The panel inside was anchored at the wrap's **top**, so mid-animation it overflowed the wrap's **bottom** and its `border-bottom` divider was clipped away — while the opaque panel still covered the bar's own `border-top`. The seam between the sheet and the button row vanished for the whole animation, then snapped back.

Bottom-anchor the panel in each clip (`justify-content: flex-end` + panel `flex: 0 0 auto`), so the clip reveals the panel from the bar upward — clipping its *top* — and the divider holds at the clip's bottom edge from the first frame to the last. Verified stable through open/close on the dock, search, and info sheets.

The top chrome doesn't share the bug: its atmosphere row animates height in flow inside the header (the divider is the header's own always-painted `border-bottom`), and the breadcrumb slides via transform (no height clip).

## Bottom-bar controls fade instead of sliding or popping

- The left cluster swap (page controls ↔ dock tools) no longer slides in on a `y`-transform — it cross-fades.
- The back handle, home handle, and scrolled-past count move into a `popLayout` presence so they fade on enter/exit; the persistent scroll-jump and menu buttons carry `layout` and ease over to fill the freed space instead of jumping. No control just pops in or out anymore.
- All motion is opacity + layout (no translate); both are disabled under `prefers-reduced-motion`.

## Verification

Measured the divider position frame-by-frame during the open animation (clip offset 0 throughout, vs 125px clipped before). Drove a live subpage→home navigation to confirm back/home fade while the neighbours slide over. No console/page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8DQxpeuYPDQzuSoXiQp7)_