### PR TITLE
Let a curating gallery choose its cover image

### DIFF
--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -47,6 +47,7 @@ import {
   fetchChannelMeta,
   fetchAllBlocks,
   arenaAccessToken,
+  pickCoverThumb,
 } from '../src/lib/arena.js';
 import {
   buildUnifiedFeed,
@@ -190,7 +191,7 @@ async function main() {
       title: g.value.title || snap.meta?.title || g.rkey,
       description: g.value.description || snap.meta?.description || '',
       blockCount: snap.blocks.length,
-      cover: snap.blocks[0]?.thumb || null,
+      cover: pickCoverThumb(snap.blocks, g.value.coverBlockId),
       order: g.value.order ?? 0,
       // Channel-level change marker: lets the client skip re-paginating
       // contents when the channel hasn't changed since this snapshot.

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -3,6 +3,7 @@ import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { resolvePds } from '../lib/atproto.js';
 import { annotateBlobUrl, annotateLeafletBlobs } from '../lib/feedBuilder.js';
+import { fetchAllBlocks } from '../lib/arena.js';
 import BlocksEditor from './blocks/BlocksEditor.jsx';
 import { uploadImageFile } from './blocks/ImageBlockEditor.jsx';
 import LeafletDocument from './LeafletDocument.jsx';
@@ -442,6 +443,7 @@ function FormEditor({ lex, value, onChange, agent, did, coverPreview, onSetCover
           key={f.key}
           field={f}
           value={value[f.key]}
+          record={value}
           onChange={(v) => onChange(f.key, v)}
           agent={agent}
           did={did}
@@ -511,7 +513,7 @@ function RecordPreview({ lex, record }) {
   );
 }
 
-function Field({ field, value, onChange, agent, did, onSetCover, externalPreview }) {
+function Field({ field, value, record, onChange, agent, did, onSetCover, externalPreview }) {
   const id = `record-editor-field-${field.key}`;
   let control;
   switch (field.type) {
@@ -651,6 +653,11 @@ function Field({ field, value, onChange, agent, did, onSetCover, externalPreview
           agent={agent}
           externalPreview={externalPreview}
         />
+      );
+      break;
+    case 'arenaCover':
+      control = (
+        <ArenaCoverField value={value} onChange={onChange} arenaSlug={record?.arenaSlug} />
       );
       break;
     case 'publicationPicker':
@@ -907,6 +914,83 @@ function ImageField({ id, value, onChange, agent, externalPreview }) {
         <button type="button" className="admin-link-subtle" onClick={() => onChange(undefined)}>
           Remove image
         </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Cover picker for an are.na gallery (`is.dame.arena.channel`). Loads the
+ * channel's images (through the same-origin proxy) and lets the author click
+ * one to front the gallery; the stored value is that block's are.na id.
+ */
+function ArenaCoverField({ value, onChange, arenaSlug }) {
+  const [blocks, setBlocks] = useState(null);
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const slug = (arenaSlug || '').trim();
+    if (!slug) {
+      setBlocks(null);
+      setStatus('Enter the are.na channel slug first, then reopen this record to pick a cover.');
+      return undefined;
+    }
+    setStatus('Loading images…');
+    setBlocks(null);
+    // Cap the pull so a huge channel doesn't hammer the API — enough to choose from.
+    fetchAllBlocks(slug, { maxPages: 2 })
+      .then(({ blocks: bs, truncated }) => {
+        if (cancelled) return;
+        setBlocks(bs);
+        setStatus(
+          bs.length === 0
+            ? 'No images found in that channel.'
+            : truncated
+              ? `Showing the first ${bs.length} images.`
+              : null,
+        );
+      })
+      .catch((err) => {
+        if (!cancelled) setStatus(`Could not load images: ${err?.message || err}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [arenaSlug]);
+
+  return (
+    <div className="arena-cover-field">
+      <div className="arena-cover-actions">
+        <span className="admin-field-hint">
+          {value ? 'Selected image fronts the gallery.' : 'Using the first image (default).'}
+        </span>
+        {value != null && value !== '' && (
+          <button type="button" className="admin-link-subtle" onClick={() => onChange(undefined)}>
+            Use first image
+          </button>
+        )}
+      </div>
+      {status && <p className="admin-field-hint">{status}</p>}
+      {Array.isArray(blocks) && blocks.length > 0 && (
+        <ul className="arena-cover-grid">
+          {blocks.map((b) => {
+            const selected = String(b.id) === String(value);
+            return (
+              <li key={b.id}>
+                <button
+                  type="button"
+                  className={`arena-cover-thumb${selected ? ' is-selected' : ''}`}
+                  onClick={() => onChange(selected ? undefined : b.id)}
+                  title={b.title || 'Untitled block'}
+                  aria-pressed={selected}
+                >
+                  <img src={b.thumb?.src} alt={b.alt || ''} loading="lazy" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
       )}
     </div>
   );

--- a/src/lib/arena.js
+++ b/src/lib/arena.js
@@ -99,6 +99,20 @@ export function normalizeBlock(block) {
   };
 }
 
+/**
+ * Pick a gallery's cover thumbnail from its normalized blocks. Honours an
+ * author-chosen `coverBlockId` (the are.na block id) when that block is present;
+ * otherwise falls back to the first block — the historical default.
+ */
+export function pickCoverThumb(blocks, coverBlockId) {
+  const list = Array.isArray(blocks) ? blocks : [];
+  if (coverBlockId != null && coverBlockId !== '') {
+    const chosen = list.find((b) => String(b?.id) === String(coverBlockId));
+    if (chosen?.thumb) return chosen.thumb;
+  }
+  return list[0]?.thumb || null;
+}
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -295,6 +295,10 @@ export const LEXICONS = {
       },
       { key: 'title', label: 'Title override', type: 'text', hint: 'Blank = channel title from are.na.' },
       { key: 'description', label: 'Description override', type: 'textarea', hint: 'Blank = channel description from are.na.' },
+      {
+        key: 'coverBlockId', label: 'Cover image', type: 'arenaCover',
+        hint: 'Pick which image fronts this gallery on /curating. Blank = the first image in the channel.',
+      },
       { key: 'order', label: 'Order', type: 'number', default: 0, hint: 'Lower numbers sort first on /curating.' },
       { key: 'enabled', label: 'Enabled (shown on the site)', type: 'boolean', default: true },
       ...COMMON_TIMESTAMPS,

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -390,6 +390,63 @@
   gap: var(--space-2);
 }
 
+/* are.na gallery cover picker (is.dame.arena.channel → coverBlockId). */
+.arena-cover-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.arena-cover-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.arena-cover-actions .admin-field-hint {
+  margin: 0;
+}
+
+.arena-cover-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(5rem, 1fr));
+  gap: var(--space-2);
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.arena-cover-thumb {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  padding: 0;
+  border: 1px solid var(--rule-soft);
+  border-radius: 0;
+  background: var(--page);
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.arena-cover-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.arena-cover-thumb:hover {
+  border-color: var(--accent-soft);
+}
+
+.arena-cover-thumb.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
 .admin-field-label {
   font-family: var(--sans);
   font-variant: all-small-caps;

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -8,7 +8,7 @@ import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
-import { fetchChannelMeta, fetchChannelPage, normalizeBlock } from '../lib/arena.js';
+import { fetchChannelMeta, fetchChannelPage, normalizeBlock, pickCoverThumb } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Curating.css';
@@ -47,8 +47,11 @@ async function loadGalleries() {
       const meta = await fetchChannelMeta(g.value.arenaSlug);
       let cover = snapCovers.get(g.rkey) || null;
       if (!cover) {
+        // No snapshot cover yet — derive one from the first page, honouring the
+        // author's chosen cover block when it happens to be on that page.
         const page = await fetchChannelPage(g.value.arenaSlug, 1, 10);
-        cover = (page?.data || []).map(normalizeBlock).find(Boolean)?.thumb || null;
+        const blocks = (page?.data || []).map(normalizeBlock).filter(Boolean);
+        cover = pickCoverThumb(blocks, g.value.coverBlockId);
       }
       galleries.push({
         slug: g.rkey,


### PR DESCRIPTION
## Summary

Curating galleries always fronted with the channel's first are.na image. This adds an author-picked cover.

- New `coverBlockId` field on `is.dame.arena.channel`, edited by a **thumbnail picker** in the record editor that loads the channel's images (through the are.na proxy) and stores the chosen block's id. Click a thumbnail to select, click again to deselect, or "Use first image" to clear.
- `pickCoverThumb(blocks, coverBlockId)` resolves that id to a thumbnail, falling back to the first block. Used by both the build-time snapshot (the primary cover source that drives `/curating`) and the runtime fallback.

## Notes
- The channel slug must be saved before the picker can load images.
- The public `/curating` cover reflects the choice after the next prefetch/deploy (covers are snapshot-driven); the editor shows the selection immediately.

## Testing
- `vite build` passes.
- `pickCoverThumb` verified for chosen id (number/string), missing-id fallback, and empty blocks.
- Picker grid + selection highlight verified via a rendered mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_