### PR TITLE
Curating: fix description crash, render text blocks, show link titles

### DIFF
--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -48,6 +48,7 @@ import {
   fetchAllBlocks,
   arenaAccessToken,
   pickCoverThumb,
+  arenaText,
 } from '../src/lib/arena.js';
 import {
   buildUnifiedFeed,
@@ -188,8 +189,8 @@ async function main() {
     const gallery = {
       slug: g.rkey,
       arenaSlug: g.value.arenaSlug,
-      title: g.value.title || snap.meta?.title || g.rkey,
-      description: g.value.description || snap.meta?.description || '',
+      title: g.value.title || arenaText(snap.meta?.title) || g.rkey,
+      description: g.value.description || arenaText(snap.meta?.description) || '',
       blockCount: snap.blocks.length,
       cover: pickCoverThumb(snap.blocks, g.value.coverBlockId),
       order: g.value.order ?? 0,

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -964,12 +964,14 @@ function ArenaCoverField({ value, onChange, arenaSlug }) {
     fetchAllBlocks(slug, { maxPages: 2 })
       .then(({ blocks: bs, truncated }) => {
         if (cancelled) return;
-        setBlocks(bs);
+        // Only image/link blocks can be a cover — text tiles have no thumbnail.
+        const pickable = bs.filter((b) => b.thumb?.src);
+        setBlocks(pickable);
         setStatus(
-          bs.length === 0
+          pickable.length === 0
             ? 'No images found in that channel.'
             : truncated
-              ? `Showing the first ${bs.length} images.`
+              ? `Showing the first ${pickable.length} images.`
               : null,
         );
       })

--- a/src/lib/arena.js
+++ b/src/lib/arena.js
@@ -70,11 +70,27 @@ export function fetchChannelPage(arenaSlug, page = 1, per = 100) {
 
 /**
  * Normalize an are.na block to the compact shape the gallery pages (and
- * snapshots) use. Returns null for block types the gallery can't render —
- * Text, Media, Attachment, nested Channels, and Links without a preview
- * image.
+ * snapshots) use. Handles Image and Link blocks (with a preview image) and
+ * Text blocks (rendered as a text tile). Returns null for everything else —
+ * Media, Attachment, nested Channels, and images/links without a preview.
  */
 export function normalizeBlock(block) {
+  if (!block) return null;
+
+  // Text block → a text tile (are.na channels often mix single words / notes
+  // in with the images). content is `{ markdown, html, plain }` on v3.
+  if (block.type === 'Text') {
+    const text = arenaText(block.content).trim();
+    if (!text) return null;
+    return {
+      id: block.id,
+      type: 'text',
+      text,
+      position: block.connection?.position ?? null,
+      connectedAt: block.connection?.connected_at || null,
+    };
+  }
+
   const img = block?.image;
   if (!img?.src) return null;
   if (block.type !== 'Image' && block.type !== 'Link') return null;
@@ -94,9 +110,24 @@ export function normalizeBlock(block) {
     height: img.height || null,
     aspectRatio: img.aspect_ratio || null,
     sourceUrl: block.source?.url || null,
+    // The page title behind a Link block ("Polysemy - Wikipedia").
+    sourceTitle: block.source?.title || block.title || '',
     position: block.connection?.position ?? null,
     connectedAt: block.connection?.connected_at || null,
   };
+}
+
+/**
+ * are.na v3 returns rich-text fields (e.g. a channel description) as a
+ * `{ markdown, html, plain }` object — or a plain string on older/simple
+ * shapes. Coerce either into a display string (preferring the plain text) so
+ * it's never handed to React as an object child.
+ */
+export function arenaText(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return value.plain || value.markdown || '';
+  return String(value);
 }
 
 /**
@@ -110,7 +141,8 @@ export function pickCoverThumb(blocks, coverBlockId) {
     const chosen = list.find((b) => String(b?.id) === String(coverBlockId));
     if (chosen?.thumb) return chosen.thumb;
   }
-  return list[0]?.thumb || null;
+  // First block that actually has a thumbnail — text tiles have none.
+  return list.find((b) => b?.thumb)?.thumb || null;
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/pages/Curating.css
+++ b/src/pages/Curating.css
@@ -41,6 +41,33 @@
   object-fit: contain;
 }
 
+/* Text block → a square tile with the word(s) centred (are.na channels often
+   mix text notes in with the images). */
+.curating-text-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 1;
+  padding: var(--space-3);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-3);
+  background: var(--surface-raised);
+  overflow: hidden;
+}
+
+.curating-text-card span {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  line-height: 1.3;
+  color: var(--ink);
+  text-align: center;
+  /* Long notes stay contained; a single word (the common case) sits centred. */
+  max-height: 100%;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+}
+
 .curating-block-domain {
   display: block;
   padding-top: var(--space-1);

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -8,7 +8,7 @@ import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
-import { fetchChannelMeta, fetchChannelPage, normalizeBlock, pickCoverThumb } from '../lib/arena.js';
+import { fetchChannelMeta, fetchChannelPage, normalizeBlock, pickCoverThumb, arenaText } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Curating.css';
@@ -56,8 +56,8 @@ async function loadGalleries() {
       galleries.push({
         slug: g.rkey,
         arenaSlug: g.value.arenaSlug,
-        title: g.value.title || meta?.title || g.rkey,
-        description: g.value.description || meta?.description || '',
+        title: g.value.title || arenaText(meta?.title) || g.rkey,
+        description: g.value.description || arenaText(meta?.description) || '',
         blockCount: meta?.counts?.blocks ?? null,
         cover,
         order: g.value.order ?? 0,
@@ -127,7 +127,7 @@ export default function Curating() {
                 <div className="creating-grid-meta">
                   <h3 className="creating-grid-title">{g.title}</h3>
                   {g.blockCount != null && (
-                    <span className="gutter">{g.blockCount} images</span>
+                    <span className="gutter">{g.blockCount} {g.blockCount === 1 ? 'block' : 'blocks'}</span>
                   )}
                 </div>
               </Link>

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -6,7 +6,7 @@ import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, getRecord } from '../lib/atproto.js';
-import { fetchChannelMeta, fetchAllBlocks } from '../lib/arena.js';
+import { fetchChannelMeta, fetchAllBlocks, arenaText } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Curating.css';
 
@@ -68,8 +68,8 @@ export default function CuratingChannel() {
         gallery: {
           slug,
           arenaSlug: v.arenaSlug,
-          title: v.title || meta?.title || slug,
-          description: v.description || meta?.description || '',
+          title: v.title || arenaText(meta?.title) || slug,
+          description: v.description || arenaText(meta?.description) || '',
           blockCount: blocks.length,
           updatedAt: meta?.updated_at || null,
         },
@@ -114,11 +114,13 @@ export default function CuratingChannel() {
   }
 
   const { gallery, blocks, truncated } = items;
+  // Only image/link blocks are lightbox-navigable; text tiles are not.
+  const visualBlocks = blocks.filter((b) => b.type !== 'text');
 
   return (
     <PageShell
-      title={gallery.title}
-      intro={gallery.description || undefined}
+      title={arenaText(gallery.title) || undefined}
+      intro={arenaText(gallery.description) || undefined}
       headTitle={`${gallery.title} — dame.is`}
       eyebrow={
         <Link to="/curating" className="page-back small-caps">
@@ -127,23 +129,39 @@ export default function CuratingChannel() {
       }
     >
       <div className="curating-channel-meta gutter">
-        <span>{gallery.blockCount} images</span>
+        <span>{gallery.blockCount} {gallery.blockCount === 1 ? 'block' : 'blocks'}</span>
       </div>
 
       {blocks.length === 0 ? (
-        <p className="feed-empty">No images in this gallery yet.</p>
+        <p className="feed-empty">No blocks in this gallery yet.</p>
       ) : (
         <>
           <ul className="curating-block-grid reveal-stagger">
-            {blocks.map((b, i) => {
-              const domain = b.type === 'link' && b.sourceUrl ? hostname(b.sourceUrl) : null;
+            {blocks.map((b) => {
+              if (b.type === 'text') {
+                return (
+                  <li key={b.id} className="curating-block">
+                    <div className="curating-text-card">
+                      <span>{b.text}</span>
+                    </div>
+                  </li>
+                );
+              }
+              // Image / link tile — opens the lightbox at its position among
+              // the visual (non-text) blocks. A link tile is captioned with
+              // the page title, falling back to its domain.
+              const vIndex = visualBlocks.indexOf(b);
+              const caption =
+                b.type === 'link'
+                  ? b.sourceTitle || b.title || (b.sourceUrl ? hostname(b.sourceUrl) : null)
+                  : null;
               return (
                 <li key={b.id} className="curating-block">
                   <button
                     type="button"
                     className="curating-block-button"
-                    onClick={() => setLightbox(i)}
-                    aria-label={b.alt ? `View image: ${b.alt}` : `View image ${i + 1}`}
+                    onClick={() => setLightbox(vIndex)}
+                    aria-label={b.alt ? `View image: ${b.alt}` : `View image ${vIndex + 1}`}
                   >
                     <img
                       src={b.thumb.src}
@@ -152,7 +170,7 @@ export default function CuratingChannel() {
                       loading="lazy"
                       decoding="async"
                     />
-                    {domain && <span className="curating-block-domain gutter">{domain}</span>}
+                    {caption && <span className="curating-block-domain gutter">{caption}</span>}
                   </button>
                 </li>
               );
@@ -160,14 +178,14 @@ export default function CuratingChannel() {
           </ul>
           {truncated && (
             <p className="curating-truncated gutter">
-              Showing the first {blocks.length} images.
+              Showing the first {blocks.length} blocks.
             </p>
           )}
           <Lightbox
             open={lightbox >= 0}
             index={Math.max(0, lightbox)}
             onClose={() => setLightbox(-1)}
-            images={blocks.map((b) => ({
+            images={visualBlocks.map((b) => ({
               src: b.large,
               alt: b.alt,
               width: b.width || undefined,


### PR DESCRIPTION
## Summary

Three fixes for are.na galleries, verified against the `words-i-d-never-heard-of-until-now` channel.

- **Crash fix (React #31):** are.na v3 returns a channel `description` as a rich-text object `{ markdown, html, plain }`; the channel page rendered it directly as the intro and crashed. Added `arenaText()` to coerce such fields to a string, applied to channel title/description in the channel page (plus a defensive coerce at the render site for already-built snapshots), the index, and prefetch.
- **Render text blocks:** are.na channels often mix text notes / single words with images, but Text blocks were dropped entirely. `normalizeBlock` now emits a text tile (centred square card). Text tiles are excluded from the lightbox and cover picker, and `pickCoverThumb` skips them so the cover resolves to a real image.
- **Link titles:** link tiles caption with the page title (e.g. "Polysemy - Wikipedia") instead of the bare domain, falling back to the domain.

Count labels now read "blocks" instead of "images".

## Testing
- `vite build` passes.
- Verified against the live channel: 46 text + 6 link tiles normalized, link captions correct, cover skips the leading text block.
- Mixed grid layout confirmed via a rendered mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJoBk2aGCnviT79Ub13ob9)_