### PR TITLE
Ledger layout follow-ups: gerund labels, condensed embeds, grid-aligned day header

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1389,33 +1389,44 @@ a.reference-card-profile:focus-visible {
    FeedLedgerRow.jsx.
    ---------------------------------------------------------------------- */
 
+/* Shared column metrics — the day header lays out on the same grid as
+   the rows, so both read from these. The verb column is sized to the
+   longest gerund ("photographing") at the mono x-small size. */
+.feed-ledger {
+  --ledger-verb-col: 6.5rem;
+  --ledger-time-col: 4.5rem;
+  --ledger-col-gap: var(--space-3);
+}
+
 /* Rows are separated by their own rules, not flex gaps. */
 .feed-ledger .feed-list {
   gap: 0;
 }
 
-/* Day header becomes a single line: the (short) date on the left, the
-   day's stats right-aligned, with a full-strength rule anchoring the
-   day's table of rows beneath it. */
+/* Day header becomes a single line on the rows' grid: the (short) date
+   stretches across the verb + time columns, the day's stats sit
+   right-aligned in the summary column, and a full-strength rule anchors
+   the day's table of rows beneath it. */
 .feed-ledger .day-section-header {
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: var(--ledger-verb-col) var(--ledger-time-col) minmax(0, 1fr);
+  column-gap: var(--ledger-col-gap);
   align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-4);
   margin-bottom: 0;
   padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--rule);
 }
 
 .feed-ledger .day-header {
+  grid-column: 1 / 3;
   font-size: var(--text-lg);
 }
 
 .feed-ledger .day-header-meta {
+  grid-column: 3;
   font-family: var(--mono);
   font-size: calc(var(--text-xs) * 0.95);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-align: right;
 }
@@ -1423,12 +1434,11 @@ a.reference-card-profile:focus-visible {
 /* One record, one ruled row. The two label columns are fixed-width so
    they align down the whole page (each row is its own grid). Baseline
    alignment keeps the small mono labels sitting on the serif summary's
-   first line. The verb column is sized to the longest gerund
-   ("photographing", "listening to") at the mono x-small size. */
+   first line. */
 .feed-ledger .feed-item-ledger {
   display: grid;
-  grid-template-columns: 7rem 4.5rem minmax(0, 1fr);
-  column-gap: var(--space-3);
+  grid-template-columns: var(--ledger-verb-col) var(--ledger-time-col) minmax(0, 1fr);
+  column-gap: var(--ledger-col-gap);
   align-items: baseline;
   padding: var(--space-3) 0;
   margin-top: 0; /* cancel the thread-continuation pull-up */
@@ -1438,14 +1448,12 @@ a.reference-card-profile:focus-visible {
 .ledger-verb {
   font-family: var(--mono);
   font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-decoration: none;
   transition: color 120ms ease;
   /* Safety valve: a gerund that outgrows the fixed column wraps inside
-     it ("listening to" breaks at the space) instead of colliding with
-     the time column. */
+     it instead of colliding with the time column. */
   min-width: 0;
   overflow-wrap: anywhere;
 }
@@ -1465,13 +1473,16 @@ a.ledger-verb:focus-visible {
 }
 
 .ledger-body {
+  min-width: 0;
+  max-width: var(--measure);
+}
+
+.ledger-text {
   font-family: var(--serif);
   font-size: var(--text-base);
   line-height: var(--leading-tight);
   color: var(--ink);
   margin: 0;
-  min-width: 0;
-  max-width: var(--measure);
   overflow-wrap: anywhere;
 }
 
@@ -1498,22 +1509,140 @@ a.ledger-verb:focus-visible {
   font-size: var(--text-sm);
 }
 
-/* Muted placeholder when a record has no text of its own ("an image",
-   "a gallery", "an unavailable post"). */
+/* Muted placeholder when a record has no text of its own ("a gallery",
+   "an unavailable post"). */
 .ledger-placeholder {
   color: var(--ink-muted);
 }
 
+/* Post embeds (images / video / link card / quote) ride along under
+   the summary line in a condensed form — hard height caps, a tight
+   one-line link strip, a clamped quote teaser — enough to see what was
+   shared without turning the row back into a full card. Higher
+   specificity than PostEmbed.css's own rules (including its narrow-
+   viewport link-card stack), so these win regardless of import order. */
+.ledger-embed {
+  margin-top: var(--space-2);
+}
+
+/* .ledger-embed owns the gap above; kill the embeds' own card-rhythm
+   margin. */
+.ledger-embed .post-embed-images,
+.ledger-embed .post-embed-video,
+.ledger-embed .post-embed-link-card,
+.ledger-embed .post-embed-quote {
+  margin-top: 0;
+}
+
+.ledger-embed .post-embed-images {
+  gap: var(--space-1);
+  max-width: 20rem;
+}
+
+.ledger-embed .post-embed-images[data-count='1'] .post-embed-image img {
+  max-height: 10rem;
+}
+
+/* Multi-image grids get uniform landscape crops so two rows of images
+   never stack taller than a short paragraph. */
+.ledger-embed .post-embed-images:not([data-count='1']) .post-embed-image {
+  aspect-ratio: 3 / 2;
+}
+
+.ledger-embed .post-embed-video {
+  max-width: 20rem;
+  max-height: 10rem;
+}
+
+.ledger-embed .post-embed-video video,
+.ledger-embed .post-embed-video img {
+  max-height: 10rem;
+}
+
+/* Link card: one tight strip — small thumb, host + one-line title,
+   description dropped. */
+.ledger-embed .post-embed-link-card {
+  grid-template-columns: minmax(0, 3.75rem) 1fr;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  max-width: 26rem;
+}
+
+.ledger-embed .post-embed-link-card-thumb img {
+  max-height: 3.75rem;
+}
+
+.ledger-embed .post-embed-link-card-title {
+  font-size: var(--text-sm);
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+}
+
+.ledger-embed .post-embed-link-card-desc {
+  display: none;
+}
+
+/* Quote box: a two-line teaser with a small author chip; nested media
+   inside the quote drops out entirely. */
+.ledger-embed .post-embed-quote {
+  gap: var(--space-1);
+  padding: var(--space-2);
+  max-width: 26rem;
+}
+
+.ledger-embed .post-embed-quote-avatar {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.ledger-embed .post-embed-quote-text {
+  font-size: var(--text-sm);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ledger-embed .post-embed-quote .post-embed-images,
+.ledger-embed .post-embed-quote .post-embed-video,
+.ledger-embed .post-embed-quote .post-embed-link-card,
+.ledger-embed .post-embed-quote .post-embed-quote {
+  display: none;
+}
+
+/* Text-less posts: the embed is the row's only content. Baseline row
+   alignment would sink the verb/time labels to the embed's bottom
+   edge, so those rows top-align instead, with a nudge that sits the
+   labels on the embed's top edge. */
+.ledger-body > .ledger-embed:first-child {
+  margin-top: 0;
+}
+
+.feed-ledger .feed-item-ledger:has(.ledger-body > .ledger-embed:first-child) {
+  align-items: start;
+}
+
+.feed-ledger .feed-item-ledger:has(.ledger-body > .ledger-embed:first-child) .ledger-verb,
+.feed-ledger .feed-item-ledger:has(.ledger-body > .ledger-embed:first-child) .ledger-time {
+  padding-top: 0.1rem;
+}
+
 @media (max-width: 600px) {
-  .feed-ledger .feed-item-ledger {
-    grid-template-columns: 6rem 3.9rem minmax(0, 1fr);
-    column-gap: var(--space-2);
+  .feed-ledger {
+    --ledger-verb-col: 5.75rem;
+    --ledger-time-col: 3.9rem;
+    --ledger-col-gap: var(--space-2);
   }
 
-  /* Slightly smaller labels so the longest gerunds still fit the
-     narrower mobile column on one line. */
+  /* Slightly smaller type so the longest gerunds and full dates still
+     fit their narrower mobile columns on one line. */
   .feed-ledger .ledger-verb,
   .feed-ledger .ledger-time {
     font-size: calc(var(--text-xs) * 0.9);
+  }
+
+  .feed-ledger .day-header {
+    font-size: var(--text-base);
   }
 }

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1423,10 +1423,11 @@ a.reference-card-profile:focus-visible {
 /* One record, one ruled row. The two label columns are fixed-width so
    they align down the whole page (each row is its own grid). Baseline
    alignment keeps the small mono labels sitting on the serif summary's
-   first line. */
+   first line. The verb column is sized to the longest gerund
+   ("photographing", "listening to") at the mono x-small size. */
 .feed-ledger .feed-item-ledger {
   display: grid;
-  grid-template-columns: 6.5rem 4.5rem minmax(0, 1fr);
+  grid-template-columns: 7rem 4.5rem minmax(0, 1fr);
   column-gap: var(--space-3);
   align-items: baseline;
   padding: var(--space-3) 0;
@@ -1442,6 +1443,11 @@ a.reference-card-profile:focus-visible {
   color: var(--ink-faint);
   text-decoration: none;
   transition: color 120ms ease;
+  /* Safety valve: a gerund that outgrows the fixed column wraps inside
+     it ("listening to" breaks at the space) instead of colliding with
+     the time column. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 a.ledger-verb:hover,
@@ -1500,7 +1506,14 @@ a.ledger-verb:focus-visible {
 
 @media (max-width: 600px) {
   .feed-ledger .feed-item-ledger {
-    grid-template-columns: 5.25rem 3.9rem minmax(0, 1fr);
+    grid-template-columns: 6rem 3.9rem minmax(0, 1fr);
     column-gap: var(--space-2);
+  }
+
+  /* Slightly smaller labels so the longest gerunds still fit the
+     narrower mobile column on one line. */
+  .feed-ledger .ledger-verb,
+  .feed-ledger .ledger-time {
+    font-size: calc(var(--text-xs) * 0.9);
   }
 }

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -19,35 +19,21 @@ import { ME_DID } from '../config.js';
  * treatment.
  */
 
-/* Verb column labels. Mirrors the screenshot's mixed register — nouns
-   for the things themselves ("post", "feed"), past tense for actions
-   taken on something else ("listened", "followed"). Kept ≤9 characters
-   so the fixed verb column never wraps. */
+/* Verb column labels are the same gerunds the site is named around
+   ("dame.is …ing") — the registry verb itself, with the same overrides
+   the card layout's verb column uses: "listening to" reads as a phrase,
+   replies become "replying", and self-thread follow-ons "continuing". */
 const LEDGER_VERB_LABELS = {
-  logging: 'logged',
-  posting: 'post',
-  blogging: 'blogged',
-  listening: 'listened',
-  creating: 'created',
-  photographing: 'photos',
-  mothing: 'spotted',
-  observing: 'observed',
-  liking: 'liked',
-  reposting: 'reposted',
-  following: 'followed',
-  listing: 'curated',
-  feeding: 'feed',
-  commenting: 'commented',
-  voting: 'voted',
+  listening: 'listening to',
 };
 
 export default function FeedLedgerRow({ item, href }) {
   const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
   const threadContinuation = item.verb === 'posting' && item._thread?.continuesPrev;
   const label = threadContinuation
-    ? 'thread'
+    ? 'continuing'
     : replyHint
-      ? 'reply'
+      ? 'replying'
       : LEDGER_VERB_LABELS[item.verb] || item.verb;
   const ts =
     item.createdAt || item.payload?.createdAt || item.payload?.indexedAt || null;

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -4,6 +4,7 @@ import { renderPostText } from '../lib/postRichText.jsx';
 import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import PostEmbed from './PostEmbed.jsx';
 import { ME_DID } from '../config.js';
 
 /**
@@ -20,13 +21,8 @@ import { ME_DID } from '../config.js';
  */
 
 /* Verb column labels are the same gerunds the site is named around
-   ("dame.is …ing") — the registry verb itself, with the same overrides
-   the card layout's verb column uses: "listening to" reads as a phrase,
-   replies become "replying", and self-thread follow-ons "continuing". */
-const LEDGER_VERB_LABELS = {
-  listening: 'listening to',
-};
-
+   ("dame.is …ing") — the registry verb itself, with replies shown as
+   "replying" and self-thread follow-ons as "continuing". */
 export default function FeedLedgerRow({ item, href }) {
   const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
   const threadContinuation = item.verb === 'posting' && item._thread?.continuesPrev;
@@ -34,9 +30,11 @@ export default function FeedLedgerRow({ item, href }) {
     ? 'continuing'
     : replyHint
       ? 'replying'
-      : LEDGER_VERB_LABELS[item.verb] || item.verb;
+      : item.verb;
   const ts =
     item.createdAt || item.payload?.createdAt || item.payload?.indexedAt || null;
+  const summary = summarize(item);
+  const embed = ledgerEmbed(item);
   return (
     <>
       {href ? (
@@ -47,9 +45,30 @@ export default function FeedLedgerRow({ item, href }) {
         <span className="ledger-verb">{label}</span>
       )}
       <span className="ledger-time">{ts ? formatTime(ts) : ''}</span>
-      <p className="ledger-body">{summarize(item)}</p>
+      <div className="ledger-body">
+        {summary && <p className="ledger-text">{summary}</p>}
+        {embed && (
+          <div className="ledger-embed">
+            <PostEmbed embed={embed.embed} did={embed.did} />
+          </div>
+        )}
+      </div>
     </>
   );
+}
+
+/**
+ * Post embeds (images / video / link card / quote) ride along under the
+ * summary line in a condensed, height-capped form (see the .ledger-embed
+ * rules in Feed.css). Only posting/reposting rows carry one.
+ */
+function ledgerEmbed(item) {
+  if (item.verb !== 'posting' && item.verb !== 'reposting') return null;
+  const payload = item.payload || {};
+  if (payload.subjectMissing) return null;
+  const embed = payload.embed || payload.embedRecord || null;
+  if (!embed) return null;
+  return { embed, did: payload.author?.did };
 }
 
 function summarize(item) {
@@ -110,19 +129,21 @@ function Placeholder({ children }) {
 
 /**
  * Posts keep their rich text (links / mentions render as anchors).
- * Text-less posts fall back to a muted noun for the embed; foreign
- * authors (reposts) get a leading @handle so attribution survives the
- * loss of the card's author header.
+ * Text-less posts return null when an embed exists — the condensed
+ * embed below carries the row on its own. Foreign authors (reposts)
+ * get a leading @handle so attribution survives the loss of the
+ * card's author header.
  */
 function summarizePost(item) {
   const payload = item.payload || {};
   if (payload.subjectMissing) return <Placeholder>an unavailable post</Placeholder>;
   const text = payload.text || '';
-  const body = text ? (
-    renderPostText(text, payload.facets || null)
-  ) : (
-    <Placeholder>{embedNoun(payload.embed || payload.embedRecord)}</Placeholder>
-  );
+  const hasEmbed = Boolean(payload.embed || payload.embedRecord);
+  const body = text
+    ? renderPostText(text, payload.facets || null)
+    : hasEmbed
+      ? null
+      : <Placeholder>a post</Placeholder>;
   const author = payload.author;
   const foreignAuthor = author?.did && author.did !== ME_DID && author?.handle;
   if (!foreignAuthor) return body;
@@ -136,33 +157,9 @@ function summarizePost(item) {
       >
         @{author.handle}
       </a>
-      {' — '}
-      {body}
+      {body && <> — {body}</>}
     </>
   );
-}
-
-function embedNoun(embed) {
-  switch (embed?.$type) {
-    case 'app.bsky.embed.images#view':
-    case 'app.bsky.embed.images': {
-      const n = (embed.images || []).length || 0;
-      return n > 1 ? `${n} images` : 'an image';
-    }
-    case 'app.bsky.embed.video#view':
-    case 'app.bsky.embed.video':
-      return 'a video';
-    case 'app.bsky.embed.external#view':
-    case 'app.bsky.embed.external':
-      return 'a link';
-    case 'app.bsky.embed.record#view':
-    case 'app.bsky.embed.record':
-    case 'app.bsky.embed.recordWithMedia#view':
-    case 'app.bsky.embed.recordWithMedia':
-      return 'a quote post';
-    default:
-      return 'a post';
-  }
 }
 
 /**

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -77,34 +77,29 @@ function loadUnifiedSnapshot() {
 }
 
 /**
- * Per-day summary line shown under each day header in the home feed.
- * Counts:
- *   - records  — real underlying records (listen batches expand to
- *                their `count` so a session of 10 songs reads as 10
- *                records, not 1).
- *   - posts    — items whose verb is `posting`.
- *   - engagements — sum of like/repost/reply counts across this day's
- *                   posting items. Reflects how much activity those
- *                   posts attracted on Bluesky.
+ * Per-day summary line shown beside each day header in the home feed,
+ * e.g. "59 items, 120 interactions".
+ *   - items — real underlying records (listen batches expand to their
+ *             `count` so a session of 10 songs reads as 10 items, not 1).
+ *   - interactions — sum of like/repost/reply counts across this day's
+ *                    posting items; how much activity those posts
+ *                    attracted on Bluesky.
  * Parts with a zero count are omitted so quieter days read clean.
  */
 function dayStatsLine(items) {
-  let records = 0;
-  let posts = 0;
-  let engagements = 0;
+  let count = 0;
+  let interactions = 0;
   for (const item of items || []) {
-    records += item?.count || 1;
+    count += item?.count || 1;
     if (item?.verb === 'posting') {
-      posts += 1;
       const p = item.payload || {};
-      engagements += (p.likeCount || 0) + (p.repostCount || 0) + (p.replyCount || 0);
+      interactions += (p.likeCount || 0) + (p.repostCount || 0) + (p.replyCount || 0);
     }
   }
   const parts = [];
-  if (records) parts.push(`${records} ${records === 1 ? 'record' : 'records'}`);
-  if (posts) parts.push(`${posts} ${posts === 1 ? 'post' : 'posts'}`);
-  if (engagements) parts.push(`${engagements} ${engagements === 1 ? 'engagement' : 'engagements'}`);
-  return parts.join(' · ');
+  if (count) parts.push(`${count} ${count === 1 ? 'item' : 'items'}`);
+  if (interactions) parts.push(`${interactions} ${interactions === 1 ? 'interaction' : 'interactions'}`);
+  return parts.join(', ');
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up refinements to the ledger feed layout introduced in #160:

- **Gerund verb column** — labels are the site's own gerunds (`logging`, `listening`, `reposting`, …) instead of past-tense forms, with `replying` / `continuing` for replies and self-threads
- **Condensed post embeds** — posting/reposting rows carry their embeds under the summary line in a height-capped form: images/video top out at 10rem (multi-image grids get uniform landscape crops), link cards collapse to a host + one-line-title strip, quotes clamp to a two-line teaser with nested media/quotes dropped. Text-less posts let the embed carry the row (top-aligned labels instead of baseline).
- **Day header on the row grid** — the date spans the gerund + time columns (no more wrapped dates on mobile) with the stats right-aligned in the summary column
- **Quieter labels** — day stats simplify to "N items, N interactions", and the verb/stats text drops the all-caps treatment

## Verification

- Production build passes
- Verified against live data with Playwright at desktop and mobile widths: image, video, link-card, and quote embeds measured at or under their height caps in the DOM; lightbox and row-click navigation still work; the default card layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_