### PR TITLE
Ledger: tap a listening session to expand its track list; repost colon

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1509,6 +1509,55 @@ a.ledger-verb:focus-visible {
   font-size: var(--text-sm);
 }
 
+/* Listening sessions: tapping the row (or its "N songs +" toggle, the
+   keyboard-accessible affordance) expands the batch into one sub-row
+   per track. */
+.feed-item-ledger-expandable {
+  cursor: pointer;
+}
+
+.ledger-count-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.ledger-count-toggle:hover,
+.ledger-count-toggle:focus-visible {
+  color: var(--accent);
+}
+
+.ledger-count-caret {
+  margin-left: 0.35em;
+}
+
+/* Expanded tracks reuse the row's grid: each play's time lands in the
+   time column and its "track — artist" line in the summary column,
+   with the verb column left empty. Auto-placement makes one implicit
+   grid row per track. */
+.ledger-track-time {
+  grid-column: 2;
+}
+
+.ledger-track {
+  grid-column: 3;
+  font-size: var(--text-sm);
+}
+
+.ledger-track a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ledger-track a:hover,
+.ledger-track a:focus-visible {
+  color: var(--accent);
+}
+
 /* Muted placeholder when a record has no text of its own ("a gallery",
    "an unavailable post"). */
 .ledger-placeholder {

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Check, CornerDownRight } from 'lucide-react';
 import { useEditMode } from '../hooks/useEditMode.jsx';
@@ -15,7 +16,7 @@ import GeneratorCard from './cards/GeneratorCard.jsx';
 import CommentCard from './cards/CommentCard.jsx';
 import VoteCard from './cards/VoteCard.jsx';
 import VerbIcon from './VerbIcon.jsx';
-import FeedLedgerRow from './FeedLedgerRow.jsx';
+import FeedLedgerRow, { isListenBatch } from './FeedLedgerRow.jsx';
 import { rkeyFromAtUri } from '../lib/atproto.js';
 import { getReplyHint } from '../lib/postReplyHint.js';
 import { verbConfig, recordHrefFor } from '../lib/verbRegistry.js';
@@ -96,6 +97,9 @@ function hrefFor(item) {
 export default function FeedItem({ item, showVerb = true, layout = 'default' }) {
   const navigate = useNavigate();
   const edit = useEditMode();
+  // Ledger-only: whether a collapsed listening session is showing its
+  // full track list (see handleRowClick / FeedLedgerRow).
+  const [ledgerExpanded, setLedgerExpanded] = useState(false);
   const cfg = verbConfig(item.verb);
   if (!cfg) return null;
   const Component = cfg.renderer ? RENDERERS[cfg.renderer] : null;
@@ -129,6 +133,11 @@ export default function FeedItem({ item, showVerb = true, layout = 'default' }) 
   // verb badge / card component entirely; the whole row still
   // navigates via handleRowClick below.
   const ledger = layout === 'ledger';
+  // In the ledger, a collapsed listening session repurposes the row tap:
+  // instead of navigating, it expands/collapses the session's track list
+  // (each expanded track links to its own record page, and the verb cell
+  // still links to the session's record).
+  const ledgerListenBatch = ledger && isListenBatch(item);
 
   // Make the whole row tappable as a convenience — handy on mobile where the
   // verb badge / timestamp are small hit targets. We bail when the click
@@ -137,13 +146,17 @@ export default function FeedItem({ item, showVerb = true, layout = 'default' }) 
   // (Cmd/Ctrl/middle-click — let the browser open it in a new tab via the
   // verb badge / timestamp links instead).
   function handleRowClick(e) {
-    if (!href) return;
+    if (!href && !ledgerListenBatch) return;
     if (e.defaultPrevented) return;
     if (e.button !== undefined && e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     if (e.target.closest('a, button, input, textarea, label, select, [role="button"], [role="link"]')) return;
     const sel = typeof window !== 'undefined' ? window.getSelection() : null;
     if (sel && sel.toString().length > 0) return;
+    if (ledgerListenBatch) {
+      setLedgerExpanded((v) => !v);
+      return;
+    }
     navigate(href);
   }
   // When a post is a continuation of a self-reply thread that is already
@@ -193,6 +206,7 @@ export default function FeedItem({ item, showVerb = true, layout = 'default' }) 
     'feed-item',
     `feed-item-${item.verb}`,
     ledger ? 'feed-item-ledger' : '',
+    ledgerListenBatch ? 'feed-item-ledger-expandable' : '',
     item._thread ? 'feed-item-thread' : '',
     item._thread?.isFirst ? 'feed-item-thread-first' : '',
     item._thread?.isLast ? 'feed-item-thread-last' : '',
@@ -209,7 +223,11 @@ export default function FeedItem({ item, showVerb = true, layout = 'default' }) 
       data-thread-position={item._thread?.position}
       data-thread-length={item._thread?.length}
       onClickCapture={selectable ? handleSelectCapture : undefined}
-      onClick={!selectable && !listeningEdit && href ? handleRowClick : undefined}
+      onClick={
+        !selectable && !listeningEdit && (href || ledgerListenBatch)
+          ? handleRowClick
+          : undefined
+      }
       role={selectable ? 'button' : undefined}
       aria-pressed={selectable ? selected : undefined}
     >
@@ -221,7 +239,14 @@ export default function FeedItem({ item, showVerb = true, layout = 'default' }) 
           {selected && <Check size={12} strokeWidth={2.5} />}
         </span>
       )}
-      {ledger && <FeedLedgerRow item={item} href={href} />}
+      {ledger && (
+        <FeedLedgerRow
+          item={item}
+          href={href}
+          expanded={ledgerExpanded}
+          onToggle={ledgerListenBatch ? () => setLedgerExpanded((v) => !v) : null}
+        />
+      )}
       {!ledger && showVerb && (() => {
         const verbEl = href && !listeningEdit ? (
           <Link className={verbClassName} to={href}>

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { formatTime } from '../lib/time.js';
 import { renderPostText } from '../lib/postRichText.jsx';
@@ -20,10 +21,24 @@ import { ME_DID } from '../config.js';
  * treatment.
  */
 
+/**
+ * A collapsed listening session (many plays batched into one row) can
+ * expand into its full track list. FeedItem owns the expanded state —
+ * tapping anywhere on the row toggles it — and passes it down here.
+ */
+export function isListenBatch(item) {
+  return (
+    item.verb === 'listening' &&
+    (item.count || 0) > 1 &&
+    Array.isArray(item.plays) &&
+    item.plays.length > 1
+  );
+}
+
 /* Verb column labels are the same gerunds the site is named around
    ("dame.is …ing") — the registry verb itself, with replies shown as
    "replying" and self-thread follow-ons as "continuing". */
-export default function FeedLedgerRow({ item, href }) {
+export default function FeedLedgerRow({ item, href, expanded = false, onToggle = null }) {
   const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
   const threadContinuation = item.verb === 'posting' && item._thread?.continuesPrev;
   const label = threadContinuation
@@ -33,7 +48,7 @@ export default function FeedLedgerRow({ item, href }) {
       : item.verb;
   const ts =
     item.createdAt || item.payload?.createdAt || item.payload?.indexedAt || null;
-  const summary = summarize(item);
+  const summary = summarize(item, { expanded, onToggle });
   const embed = ledgerEmbed(item);
   return (
     <>
@@ -53,6 +68,21 @@ export default function FeedLedgerRow({ item, href }) {
           </div>
         )}
       </div>
+      {expanded && isListenBatch(item) && item.plays.map((play) => {
+        const playTs = play?.createdAt || play?.payload?.playedTime || null;
+        const playHref = recordPathFromAtUri(play?.atUri);
+        const line = trackLine(play?.payload);
+        return (
+          <Fragment key={play?.atUri || playTs}>
+            <span className="ledger-time ledger-track-time">
+              {playTs ? formatTime(playTs) : ''}
+            </span>
+            <p className="ledger-text ledger-track">
+              {playHref ? <Link to={playHref}>{line || <em>—</em>}</Link> : line || <em>—</em>}
+            </p>
+          </Fragment>
+        );
+      })}
     </>
   );
 }
@@ -71,7 +101,7 @@ function ledgerEmbed(item) {
   return { embed, did: payload.author?.did };
 }
 
-function summarize(item) {
+function summarize(item, listenControls) {
   const payload = item.payload || {};
   switch (item.verb) {
     case 'logging':
@@ -82,7 +112,7 @@ function summarize(item) {
     case 'blogging':
       return plain(payload.title || payload.name, 'an untitled entry');
     case 'listening':
-      return summarizeListen(item);
+      return summarizeListen(item, listenControls);
     case 'creating':
       return plain(payload.title || payload.slug, 'an untitled work');
     case 'photographing': {
@@ -157,7 +187,7 @@ function summarizePost(item) {
       >
         @{author.handle}
       </a>
-      {body && <> — {body}</>}
+      {body && <>: {body}</>}
     </>
   );
 }
@@ -165,17 +195,36 @@ function summarizePost(item) {
 /**
  * "track — artist" for a single play; a collapsed session leads with
  * its artist pool (dedup'd, latest first) plus the song count, same
- * logic as ListenRow's top line.
+ * logic as ListenRow's top line. When the session is expandable the
+ * song count doubles as the accessible expand/collapse toggle —
+ * FeedItem also toggles on taps anywhere else in the row.
  */
-function summarizeListen(item) {
+function summarizeListen(item, { expanded = false, onToggle = null } = {}) {
   const payload = item.payload || {};
-  const plays = Array.isArray(item.plays) ? item.plays : [];
-  const isBatch = (item.count || 0) > 1 && plays.length > 1;
+  const isBatch = isListenBatch(item);
   const countTag = isBatch ? (
-    <span className="ledger-count"> · {item.count} songs</span>
+    <span className="ledger-count">
+      {' · '}
+      {onToggle ? (
+        <button
+          type="button"
+          className="ledger-count-toggle"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-label={`${expanded ? 'Hide' : 'Show'} all ${item.count} songs`}
+        >
+          {item.count} songs
+          <span className="ledger-count-caret" aria-hidden="true">
+            {expanded ? '−' : '+'}
+          </span>
+        </button>
+      ) : (
+        `${item.count} songs`
+      )}
+    </span>
   ) : null;
   if (isBatch) {
-    const artists = uniqueArtistNames(plays);
+    const artists = uniqueArtistNames(item.plays);
     if (artists.length > 1) {
       const shown = artists.slice(0, 4).join(', ');
       const extra = artists.length > 4 ? ` + ${artists.length - 4} more` : '';
@@ -187,17 +236,29 @@ function summarizeListen(item) {
       );
     }
   }
-  const track = payload.trackName || payload.track || '';
-  const artist = Array.isArray(payload.artists)
+  const line = trackLine(payload);
+  if (!line) return <Placeholder>a play</Placeholder>;
+  return (
+    <>
+      {line}
+      {countTag}
+    </>
+  );
+}
+
+/** "track — artist" fragment shared by the summary line and the
+    expanded per-track rows. Null when the play has neither. */
+function trackLine(payload) {
+  const track = payload?.trackName || payload?.track || '';
+  const artist = Array.isArray(payload?.artists)
     ? payload.artists.map((a) => a?.artistName).filter(Boolean).join(', ')
-    : payload.artist || '';
-  if (!track && !artist) return <Placeholder>a play</Placeholder>;
+    : payload?.artist || '';
+  if (!track && !artist) return null;
   return (
     <>
       {track}
       {track && artist ? ' — ' : ''}
       {artist && <span className="ledger-accent">{artist}</span>}
-      {countTag}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Two more ledger-layout refinements:

- **Expandable listening sessions** — tapping a batched listening row (or its "N songs +" button, the keyboard-accessible affordance) toggles the session open into one sub-row per track. Each track's play time lands in the ledger's time column and its "track — artist" line in the summary column (verb column stays empty), linking to that play's record page. Single plays still navigate on tap, and the "listening" verb cell still links to the session record.
- **Repost format** — repost summaries read `@handle: text` instead of `@handle — text`.

## Verification

- Production build passes
- Browser-tested against live data: row tap expands, second tap collapses, the songs button toggles both directions with `aria-expanded`, expanded track links navigate to their record pages, and single-play rows still navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_