### PR TITLE
Ledger polish: column reorder, dame.is label, dashed thread connector, quote spacing

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1654,6 +1654,14 @@ a.ledger-verb:focus-visible {
   height: 1.25rem;
 }
 
+/* The author chip's name/handle stack inherits the body's roomy
+   leading; pull the two lines together so the condensed quote head
+   stays one tight cluster. */
+.ledger-embed .post-embed-quote-name,
+.ledger-embed .post-embed-quote-handle {
+  line-height: 1.25;
+}
+
 .ledger-embed .post-embed-quote-text {
   font-size: var(--text-sm);
   display: -webkit-box;

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1403,27 +1403,26 @@ a.reference-card-profile:focus-visible {
   gap: 0;
 }
 
-/* Day header becomes a single line on the rows' grid: the (short) date
-   stretches across the verb + time columns, the day's stats sit
-   right-aligned in the summary column, and a full-strength rule anchors
-   the day's table of rows beneath it. */
+/* Day header is a single line: the (short) date on the left — never
+   shrunk, so it can't wrap mid-date — the day's stats right-aligned,
+   and a full-strength rule anchoring the day's table of rows beneath
+   it. */
 .feed-ledger .day-section-header {
-  display: grid;
-  grid-template-columns: var(--ledger-verb-col) var(--ledger-time-col) minmax(0, 1fr);
-  column-gap: var(--ledger-col-gap);
+  flex-direction: row;
   align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
   margin-bottom: 0;
   padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--rule);
 }
 
 .feed-ledger .day-header {
-  grid-column: 1 / 3;
+  flex: 0 0 auto;
   font-size: var(--text-lg);
 }
 
 .feed-ledger .day-header-meta {
-  grid-column: 3;
   font-family: var(--mono);
   font-size: calc(var(--text-xs) * 0.95);
   letter-spacing: 0.02em;
@@ -1431,13 +1430,14 @@ a.reference-card-profile:focus-visible {
   text-align: right;
 }
 
-/* One record, one ruled row. The two label columns are fixed-width so
-   they align down the whole page (each row is its own grid). Baseline
-   alignment keeps the small mono labels sitting on the serif summary's
-   first line. */
+/* One record, one ruled row: verb · summary · time, with the time
+   right-aligned on the row's far edge. The two label columns are
+   fixed-width so they align down the whole page (each row is its own
+   grid). Baseline alignment keeps the small mono labels sitting on the
+   serif summary's first line. */
 .feed-ledger .feed-item-ledger {
   display: grid;
-  grid-template-columns: var(--ledger-verb-col) var(--ledger-time-col) minmax(0, 1fr);
+  grid-template-columns: var(--ledger-verb-col) minmax(0, 1fr) var(--ledger-time-col);
   column-gap: var(--ledger-col-gap);
   align-items: baseline;
   padding: var(--space-3) 0;
@@ -1470,6 +1470,8 @@ a.ledger-verb:focus-visible {
   color: var(--ink-faint);
   /* formatTime yields "9:41 AM"; the ledger reads lowercase. */
   text-transform: lowercase;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .ledger-body {
@@ -1535,17 +1537,17 @@ a.ledger-verb:focus-visible {
   margin-left: 0.35em;
 }
 
-/* Expanded tracks reuse the row's grid: each play's time lands in the
-   time column and its "track — artist" line in the summary column,
-   with the verb column left empty. Auto-placement makes one implicit
-   grid row per track. */
-.ledger-track-time {
+/* Expanded tracks reuse the row's grid: each play's "track — artist"
+   line lands in the summary column and its time in the right-aligned
+   time column, with the verb column left empty. Auto-placement makes
+   one implicit grid row per track. */
+.ledger-track {
   grid-column: 2;
+  font-size: var(--text-sm);
 }
 
-.ledger-track {
+.ledger-track-time {
   grid-column: 3;
-  font-size: var(--text-sm);
 }
 
 .ledger-track a {

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1445,6 +1445,14 @@ a.reference-card-profile:focus-visible {
   border-bottom: 1px solid color-mix(in srgb, var(--rule-soft) 60%, transparent);
 }
 
+/* Self-thread continuations carry no verb label; instead the rule
+   separating them from the post they continue goes dashed — i.e. the
+   PREVIOUS row's bottom border. Rows sit inside Home's motion.li
+   wrappers, so the sibling hop happens on those. */
+.feed-ledger .feed-list > li:has(+ li .feed-item-thread-continuation) .feed-item-ledger {
+  border-bottom-style: dashed;
+}
+
 .ledger-verb {
   font-family: var(--mono);
   font-size: var(--text-xs);

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -36,23 +36,34 @@ export function isListenBatch(item) {
 }
 
 /* Verb column labels are the same gerunds the site is named around
-   ("dame.is …ing") — the registry verb itself, with replies shown as
-   "replying" and self-thread follow-ons as "continuing". */
+   ("dame.is …ing") — the registry verb itself, with two exceptions:
+   replies show "replying", and logging statuses show "dame.is" (the
+   status text completes the sentence, mirroring StatusEntry's prefix).
+   Self-thread follow-ons show no label at all — the dashed rule above
+   the row (see Feed.css) marks them as connected to the post above. */
+const LEDGER_VERB_LABELS = {
+  logging: 'dame.is',
+};
+
 export default function FeedLedgerRow({ item, href, expanded = false, onToggle = null }) {
   const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
   const threadContinuation = item.verb === 'posting' && item._thread?.continuesPrev;
   const label = threadContinuation
-    ? 'continuing'
+    ? null
     : replyHint
       ? 'replying'
-      : item.verb;
+      : LEDGER_VERB_LABELS[item.verb] || item.verb;
   const ts =
     item.createdAt || item.payload?.createdAt || item.payload?.indexedAt || null;
   const summary = summarize(item, { expanded, onToggle });
   const embed = ledgerEmbed(item);
   return (
     <>
-      {href ? (
+      {/* Label-less rows (thread continuations) keep an empty verb cell
+          so grid auto-placement still lands the summary in column 2. */}
+      {!label ? (
+        <span className="ledger-verb" aria-hidden="true" />
+      ) : href ? (
         <Link className="ledger-verb" to={href}>
           {label}
         </Link>

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -59,7 +59,6 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
       ) : (
         <span className="ledger-verb">{label}</span>
       )}
-      <span className="ledger-time">{ts ? formatTime(ts) : ''}</span>
       <div className="ledger-body">
         {summary && <p className="ledger-text">{summary}</p>}
         {embed && (
@@ -68,18 +67,19 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
           </div>
         )}
       </div>
+      <span className="ledger-time">{ts ? formatTime(ts) : ''}</span>
       {expanded && isListenBatch(item) && item.plays.map((play) => {
         const playTs = play?.createdAt || play?.payload?.playedTime || null;
         const playHref = recordPathFromAtUri(play?.atUri);
         const line = trackLine(play?.payload);
         return (
           <Fragment key={play?.atUri || playTs}>
-            <span className="ledger-time ledger-track-time">
-              {playTs ? formatTime(playTs) : ''}
-            </span>
             <p className="ledger-text ledger-track">
               {playHref ? <Link to={playHref}>{line || <em>—</em>}</Link> : line || <em>—</em>}
             </p>
+            <span className="ledger-time ledger-track-time">
+              {playTs ? formatTime(playTs) : ''}
+            </span>
           </Fragment>
         );
       })}


### PR DESCRIPTION
## Summary

Three more rounds of ledger-layout polish:

- **Column reorder** — rows now read verb · summary · time, with the timestamp right-aligned on the row's far edge (expanded session tracks follow the same order). The day header returns to a simple flex line — date left and never shrunk, stats right.
- **"dame.is" logging label** — logging statuses complete the site's sentence: the verb column reads `dame.is` so the row scans as "dame.is &lt;status&gt;", mirroring StatusEntry's prefix.
- **Dashed thread connector** — self-thread continuations drop their verb label entirely; the rule above them (the previous post's bottom border) renders dashed to mark the posts as one connected thread.
- **Quote author spacing** — the condensed quote embed's name/handle stack drops the inherited 1.6 body leading for a tight 1.25, closing the gap between display name and handle.

## Verification

- Production build passes
- Browser-verified against live data at desktop and mobile widths: timestamps align down the right edge, continuation rows show an empty verb cell under a dashed rule (confirmed via computed styles), logging rows read "dame.is", and the quote chip's two lines now sit flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_