### PR TITLE
Add sky theme: hourly color mode tracking the dynamic avatar

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -383,6 +383,20 @@
   background: color-mix(in srgb, var(--accent) 20%, var(--page));
 }
 
+/* TEMPORARY: sky-theme test chip beside the theme toggle. A text button
+   (the current hour key, e.g. "3pm") rather than a glyph, since the
+   label IS the state being tested. Remove with the button in
+   ChromeBar.jsx once the sky theme has been vetted. */
+.chrome-nav.chrome-sky-hour {
+  width: auto;
+  min-width: 1.75rem;
+  padding: 0 0.45rem;
+  font-family: var(--mono-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  font-variant-numeric: tabular-nums;
+}
+
 /* The compass nav button is the menu trigger — promote it to a filled,
    accent-tinted primary so it reads as the main action among the
    bottom-bar controls. */

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Moon, Pencil, Search, Sun, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Moon, Pencil, Search, Sun, SunMoon, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
@@ -22,10 +22,12 @@ import InfoSheet from './InfoSheet.jsx';
 import Footer from './Footer.jsx';
 import './ChromeBar.css';
 
-// Per-theme glyph for the toggle button: sun for light, moon for dark.
+// Per-theme glyph for the toggle button: sun for light, moon for dark,
+// sun-and-moon for the hour-tracking sky theme.
 const THEME_ICON = {
   light: Sun,
   dark: Moon,
+  sky: SunMoon,
 };
 
 // The home handle is a router <Link>; wrap it so it can participate in the
@@ -288,8 +290,9 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const nearBottom = useNearPageBottom();
   const footerRef = useRef(null);
   const { available: filterAvailable } = useFeedFilter();
-  const { theme, cycle: cycleTheme } = useTheme();
+  const { theme, cycle: cycleTheme, options: themeOptions, skyHourKey, advanceSkyHour } = useTheme();
   const ThemeIcon = THEME_ICON[theme] || Sun;
+  const nextTheme = themeOptions[(themeOptions.indexOf(theme) + 1) % themeOptions.length];
   // The edit-mode toggle only exists for the site owner. It sits beside the
   // Info button and flips the site into a selectable "edit mode" (see
   // EditModeBar + useEditMode).
@@ -433,11 +436,27 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                   type="button"
                   className="chrome-nav chrome-theme-toggle"
                   onClick={cycleTheme}
-                  aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme (current: ${theme})`}
+                  aria-label={`Switch to ${nextTheme} theme (current: ${theme})`}
                   title={`Theme: ${theme} — tap to switch`}
                 >
                   <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
+                {/* TEMPORARY: sky-theme test chip. Shows the hour whose
+                    palette is on screen; each tap advances one hour
+                    (wrapping at midnight) so all 24 increments can be
+                    stepped through in place. Remove once the sky theme
+                    has been vetted. */}
+                {theme === 'sky' && (
+                  <button
+                    type="button"
+                    className="chrome-nav chrome-sky-hour"
+                    onClick={advanceSkyHour}
+                    aria-label={`Advance sky theme by one hour (showing ${skyHourKey})`}
+                    title={`Sky theme test — tap to advance one hour (showing ${skyHourKey})`}
+                  >
+                    {skyHourKey}
+                  </button>
+                )}
                 {filterAvailable && (
                   <button
                     type="button"

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -1,10 +1,19 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  applySkyTheme,
+  clearSkyTheme,
+  easternHour,
+  secondsUntilNextHour,
+  skyHourKey,
+} from '../lib/skyTheme.js';
 
 const ThemeContext = createContext(null);
 const STORAGE_KEY = 'dame.theme';
 
-// Two themes: warm light and dark green. The toggle flips between them.
-const VALID = ['light', 'dark'];
+// Three themes: warm light, dark green, and the hour-tracking sky mode
+// (palette derived from the current sky-avatar frame — see
+// src/lib/skyTheme.js). The toggle cycles light → dark → sky.
+const VALID = ['light', 'dark', 'sky'];
 
 // Retired monochrome variants map to their color equivalent so a
 // returning visitor who last used a mono theme keeps its light/dark
@@ -17,6 +26,8 @@ const THEME_ALIAS = {
 // Matches --surface-raised in theme.css. Used for the iOS Safari URL
 // bar surround / Android browser chrome so the OS UI blends with the
 // dame.is chrome bar instead of falling back to a system default.
+// The sky theme has no fixed value — its color comes from the hour's
+// computed palette in applyTheme.
 const THEME_COLOR = {
   light: '#e3d8ba',
   dark: '#13180f',
@@ -33,15 +44,21 @@ function migrateStoredTheme(stored) {
   return DEFAULT_THEME;
 }
 
-function applyTheme(theme) {
+function applyTheme(theme, skyHour) {
   document.documentElement.setAttribute('data-theme', theme);
-  applyThemeColor(theme);
+  let color = THEME_COLOR[theme] || THEME_COLOR.light;
+  if (theme === 'sky') {
+    const palette = applySkyTheme(skyHour ?? easternHour());
+    color = palette.themeColor;
+  } else {
+    clearSkyTheme();
+  }
+  applyThemeColor(color);
 }
 
-function applyThemeColor(theme) {
+function applyThemeColor(color) {
   if (typeof document === 'undefined') return;
   const head = document.head;
-  const color = THEME_COLOR[theme] || THEME_COLOR.light;
 
   head.querySelectorAll('meta[name="theme-color"]').forEach((m) => m.remove());
   const meta = document.createElement('meta');
@@ -68,33 +85,91 @@ export function ThemeProvider({ children }) {
     return migrateStoredTheme(localStorage.getItem(STORAGE_KEY));
   });
 
+  // Sky mode's clock. `liveHour` tracks the real Eastern hour; the
+  // override (driven by the temporary test button in the bottom bar)
+  // freezes the palette on an arbitrary hour so each step can be
+  // inspected. Leaving sky mode drops the override.
+  const [liveHour, setLiveHour] = useState(() => easternHour());
+  const [skyOverride, setSkyOverride] = useState(null);
+  const skyHour = skyOverride ?? liveHour;
+  // Mirror for callbacks that need the current hour without re-binding.
+  const skyHourRef = useRef(skyHour);
+  skyHourRef.current = skyHour;
+
   useEffect(() => {
-    applyTheme(theme);
+    applyTheme(theme, skyHour);
     try {
       localStorage.setItem(STORAGE_KEY, theme);
     } catch {}
+  }, [theme, skyHour]);
+
+  // While in sky mode, tick the palette over at the top of each Eastern
+  // hour (minutes/seconds track UTC, so the boundary is computable
+  // locally). Timers sleep in background tabs, so visibility-return also
+  // re-reads the clock — same pattern as the avatar's refresh tick.
+  useEffect(() => {
+    if (theme !== 'sky') return undefined;
+    let timer;
+    const schedule = () => {
+      // Small pad past the boundary so a clamped/early timer can't land
+      // still inside the old hour and stall until the next one.
+      timer = setTimeout(() => {
+        setLiveHour(easternHour());
+        schedule();
+      }, secondsUntilNextHour() * 1000 + 1000);
+    };
+    schedule();
+    const onVisible = () => {
+      if (!document.hidden) setLiveHour(easternHour());
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [theme]);
 
   const setTheme = useCallback((next) => {
     if (!VALID.includes(next)) return;
     // Apply synchronously inside the click handler so iOS Safari sees
     // the updated theme-color meta during the same user gesture.
-    applyTheme(next);
+    applyTheme(next, skyHourRef.current);
     setThemeState(next);
+    if (next !== 'sky') setSkyOverride(null);
   }, []);
 
   const cycle = useCallback(() => {
     setThemeState((prev) => {
       const idx = VALID.indexOf(prev);
       const next = VALID[(idx + 1) % VALID.length];
-      applyTheme(next);
+      applyTheme(next, skyHourRef.current);
+      if (next !== 'sky') setSkyOverride(null);
       return next;
     });
   }, []);
 
+  // TEMPORARY (sky-theme testing): step the sky palette forward one hour
+  // per call, wrapping at midnight. Wired to the hour chip in the bottom
+  // chrome bar so each of the 24 increments can be eyeballed in place.
+  const advanceSkyHour = useCallback(() => {
+    const next = (skyHourRef.current + 1) % 24;
+    // Sync apply for the same iOS theme-color gesture reason as setTheme.
+    applyTheme('sky', next);
+    setSkyOverride(next);
+  }, []);
+
   const value = useMemo(
-    () => ({ theme, setTheme, cycle, options: VALID }),
-    [theme, setTheme, cycle],
+    () => ({
+      theme,
+      setTheme,
+      cycle,
+      options: VALID,
+      skyHour,
+      skyHourKey: skyHourKey(skyHour),
+      skyOverridden: skyOverride != null,
+      advanceSkyHour,
+    }),
+    [theme, setTheme, cycle, skyHour, skyOverride, advanceSkyHour],
   );
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/src/lib/skyTheme.js
+++ b/src/lib/skyTheme.js
@@ -1,0 +1,258 @@
+// The "sky" theme: a third color mode that drifts through the day in
+// lockstep with Dame's hourly Bluesky avatar (and the favicon — see
+// api/favicon.js and og/time.js). Instead of two fixed palettes, every
+// Eastern hour gets its own palette derived from the actual sky gradient
+// in that hour's avatar frame.
+//
+// SKY_BANDS holds, per hour, the average color of the TOP and BOTTOM
+// quarter of images/sky-avatars/<key>.jpg (sampled with sharp; the middle
+// band is skipped because the "dame" wordmark pollutes it). The top band
+// is the deep sky, the bottom band is the horizon — at dawn/dusk that's
+// where the warm glow lives, so accents derived from it track the sunrise
+// and sunset just like the art does.
+//
+// From those two anchors, paletteForHour() derives the full set of theme
+// tokens (page, surfaces, ink ramp, rules, accents, scrims) with the same
+// relative steps the static light/dark themes use in styles/theme.css.
+// Daylight hours (7am–5pm) get dark ink on a sky-colored page; the rest
+// get light ink on a deep-sky page — mirroring the avatar's own wordmark
+// flip. Lightness is clamped into a readable range per polarity so every
+// hour keeps body-text contrast, while hue and saturation stay true to
+// the frame, which is what makes adjacent hours read as one incremental
+// step in the day's arc.
+//
+// applySkyTheme(hour) writes the palette as --sky-* custom properties on
+// <html>; styles/theme.css maps the real tokens onto those vars inside
+// [data-theme='sky'].
+
+import { easternHour, avatarKeys, secondsUntilNextHour } from '../../og/time.js';
+
+export { easternHour, secondsUntilNextHour };
+
+const KEYS = avatarKeys();
+
+/** The clock label ("12am" … "11pm") for an hour 0–23. */
+export function skyHourKey(hour) {
+  return KEYS[((hour % 24) + 24) % 24];
+}
+
+// Sampled top/bottom band averages per hour (0 = 12am … 23 = 11pm).
+const SKY_BANDS = [
+  { top: '#111111', bottom: '#101111' }, // 12am
+  { top: '#121314', bottom: '#161616' }, // 1am
+  { top: '#161b1e', bottom: '#171818' }, // 2am
+  { top: '#0f1213', bottom: '#212121' }, // 3am
+  { top: '#090808', bottom: '#2b2215' }, // 4am
+  { top: '#07091b', bottom: '#43290c' }, // 5am
+  { top: '#181e3c', bottom: '#5f3c06' }, // 6am
+  { top: '#3660df', bottom: '#cc9543' }, // 7am
+  { top: '#3369ff', bottom: '#c5ac94' }, // 8am
+  { top: '#658eff', bottom: '#bccbfc' }, // 9am
+  { top: '#96b5ff', bottom: '#87cffa' }, // 10am
+  { top: '#8aebf0', bottom: '#afdff6' }, // 11am
+  { top: '#2ce9f3', bottom: '#a0dff7' }, // 12pm
+  { top: '#1dd7fc', bottom: '#82eff4' }, // 1pm
+  { top: '#00c2ff', bottom: '#5be9f7' }, // 2pm
+  { top: '#0ad1fd', bottom: '#84cffd' }, // 3pm
+  { top: '#0dc7ff', bottom: '#82b1ff' }, // 4pm
+  { top: '#0088ff', bottom: '#8082fb' }, // 5pm
+  { top: '#1055ff', bottom: '#b36e8f' }, // 6pm
+  { top: '#191793', bottom: '#66225c' }, // 7pm
+  { top: '#101256', bottom: '#382354' }, // 8pm
+  { top: '#030611', bottom: '#2c1a34' }, // 9pm
+  { top: '#010105', bottom: '#100b18' }, // 10pm
+  { top: '#0a0b10', bottom: '#0a0b0c' }, // 11pm
+];
+
+// Daylight (dark ink on a light sky page) runs 7am–5pm; everything else
+// is a night palette (light ink on a deep sky page). The flip points
+// match where the avatar's own wordmark switches polarity.
+const FIRST_DAY_HOUR = 7;
+const LAST_DAY_HOUR = 17;
+
+/* ---------- small color kit (hex ⇄ rgb ⇄ hsl) ---------- */
+
+const clamp01 = (v) => Math.min(1, Math.max(0, v));
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+function hexToRgb(hex) {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex([r, g, b]) {
+  return (
+    '#' + [r, g, b].map((v) => Math.round(clamp(v, 0, 255)).toString(16).padStart(2, '0')).join('')
+  );
+}
+
+function rgbToHsl([r, g, b]) {
+  r /= 255; g /= 255; b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h;
+  switch (max) {
+    case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+    case g: h = (b - r) / d + 2; break;
+    default: h = (r - g) / d + 4;
+  }
+  return [h * 60, s, l];
+}
+
+function hslToRgb([h, s, l]) {
+  h = ((h % 360) + 360) % 360 / 360;
+  s = clamp01(s); l = clamp01(l);
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return [v, v, v];
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hue = (t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  return [
+    Math.round(hue(h + 1 / 3) * 255),
+    Math.round(hue(h) * 255),
+    Math.round(hue(h - 1 / 3) * 255),
+  ];
+}
+
+const hsl = (h, s, l) => rgbToHex(hslToRgb([h, s, l]));
+const rgba = ([r, g, b], a) => `rgba(${r}, ${g}, ${b}, ${a})`;
+
+/* ---------- palette derivation ---------- */
+
+/**
+ * The full token set for one hour of sky, as a map of --sky-* custom
+ * properties plus the meta bits (theme-color, color-scheme, label).
+ */
+export function paletteForHour(hour) {
+  const h24 = ((hour % 24) + 24) % 24;
+  const { top, bottom } = SKY_BANDS[h24];
+  const topRgb = hexToRgb(top);
+  const botRgb = hexToRgb(bottom);
+  const base = topRgb.map((v, i) => (v + botRgb[i]) / 2);
+  const [bh, bs, bl] = rgbToHsl(base);
+  const [th, ts] = rgbToHsl(topRgb);
+  const [hh, hs] = rgbToHsl(botRgb); // horizon band
+  const day = h24 >= FIRST_DAY_HOUR && h24 <= LAST_DAY_HOUR;
+
+  let vars;
+  let themeColor;
+
+  if (day) {
+    // Sky-colored page, dark ink. Lightness is lifted into a readable
+    // band; hue + saturation carry the hour's identity.
+    const s = Math.min(bs, 0.7);
+    const l = clamp(bl, 0.7, 0.84);
+    const ink = hslToRgb([bh, 0.25, 0.11]);
+    const accent = hslToRgb([th, clamp(ts, 0.35, 0.8), 0.3]);
+    vars = {
+      '--sky-page': hsl(bh, s, l),
+      '--sky-page-edge': hsl(bh, s, l - 0.06),
+      '--sky-surface-raised': hsl(bh, s, l - 0.08),
+      '--sky-surface-deep': hsl(bh, s, l - 0.03),
+      '--sky-ink': rgbToHex(ink),
+      '--sky-ink-soft': hsl(bh, 0.18, 0.24),
+      '--sky-ink-muted': hsl(bh, 0.15, 0.36),
+      '--sky-ink-faint': hsl(bh, 0.12, 0.48),
+      '--sky-rule': hsl(bh, s * 0.45, l - 0.18),
+      '--sky-rule-soft': hsl(bh, s * 0.5, l - 0.1),
+      // Deep-sky accent (from the frame's top band) and a horizon accent
+      // (from its bottom band) — the sky-mode stand-ins for moss + tan.
+      '--sky-accent': rgbToHex(accent),
+      '--sky-accent-soft': hsl(th, clamp(ts * 0.6, 0.25, 0.55), 0.45),
+      '--sky-tan': hsl(hh, clamp(hs, 0.3, 0.65), 0.38),
+      '--sky-highlight': rgba(accent, 0.16),
+      '--sky-shadow': rgba(hslToRgb([bh, 0.3, 0.09]), 0.16),
+      '--sky-scrim': rgba(hslToRgb([bh, s, l - 0.04]), 0.86),
+      '--sky-scrim-clear': rgba(hslToRgb([bh, s, l - 0.04]), 0),
+      '--sky-scrim-ink': rgba(ink, 0.9),
+      // Muted/faint re-tuned for text sitting on --surface-raised
+      // (mirrors the [data-theme] .chrome-bar rules in theme.css).
+      '--sky-ink-muted-raised': hsl(bh, 0.16, 0.3),
+      '--sky-ink-faint-raised': hsl(bh, 0.13, 0.4),
+      '--sky-paper-rule': rgba(ink, 0.07),
+      '--sky-paper-dot': rgba(ink, 0.1),
+    };
+    themeColor = vars['--sky-surface-raised'];
+  } else {
+    // Deep-sky page, light ink. The accent comes from the horizon band,
+    // so pre-dawn glows amber, dusk glows orchid, and dead-of-night
+    // (horizon too desaturated to mean anything) falls back to a pale
+    // moonlit cast of the sky's own hue.
+    const s = Math.min(bs, 0.45);
+    const l = clamp(bl, 0.09, 0.15);
+    const ink = hslToRgb([bh, 0.14, 0.89]);
+    const glowHue = hs < 0.1 ? bh : hh;
+    const glowSat = hs < 0.1 ? 0.22 : hs;
+    const accent = hslToRgb([glowHue, clamp(glowSat, 0.3, 0.6), 0.7]);
+    vars = {
+      '--sky-page': hsl(bh, s, l),
+      '--sky-page-edge': hsl(bh, s, Math.max(l - 0.02, 0.05)),
+      '--sky-surface-raised': hsl(bh, s, Math.max(l - 0.045, 0.035)),
+      '--sky-surface-deep': hsl(bh, s, Math.max(l - 0.075, 0.02)),
+      '--sky-ink': rgbToHex(ink),
+      '--sky-ink-soft': hsl(bh, 0.11, 0.78),
+      '--sky-ink-muted': hsl(bh, 0.09, 0.61),
+      '--sky-ink-faint': hsl(bh, 0.08, 0.45),
+      '--sky-rule': hsl(bh, Math.min(s + 0.05, 0.35), l + 0.12),
+      '--sky-rule-soft': hsl(bh, Math.min(s + 0.03, 0.3), l + 0.06),
+      '--sky-accent': rgbToHex(accent),
+      '--sky-accent-soft': hsl(glowHue, clamp(glowSat * 0.8, 0.25, 0.5), 0.58),
+      '--sky-tan': hsl(glowHue, clamp(glowSat, 0.25, 0.55), 0.64),
+      '--sky-highlight': rgba(accent, 0.16),
+      '--sky-shadow': 'rgba(0, 0, 0, 0.45)',
+      '--sky-scrim': rgba(hslToRgb([bh, s, Math.max(l - 0.06, 0.02)]), 0.8),
+      '--sky-scrim-clear': rgba(hslToRgb([bh, s, Math.max(l - 0.06, 0.02)]), 0),
+      '--sky-scrim-ink': rgba(ink, 0.9),
+      // Night muted already clears the darker raised surface; only faint
+      // needs a lift (same shape as the static dark theme's re-tune).
+      '--sky-ink-muted-raised': hsl(bh, 0.09, 0.61),
+      '--sky-ink-faint-raised': hsl(bh, 0.08, 0.52),
+      '--sky-paper-rule': rgba(ink, 0.055),
+      '--sky-paper-dot': rgba(ink, 0.08),
+    };
+    themeColor = vars['--sky-surface-raised'];
+  }
+
+  return {
+    hour: h24,
+    key: KEYS[h24],
+    day,
+    colorScheme: day ? 'light' : 'dark',
+    themeColor,
+    vars,
+  };
+}
+
+// Every var name paletteForHour emits, so clearSkyTheme can sweep them all.
+const SKY_VAR_NAMES = Object.keys(paletteForHour(0).vars);
+
+/** Write the given hour's palette onto <html> as --sky-* vars. */
+export function applySkyTheme(hour) {
+  const palette = paletteForHour(hour);
+  const root = document.documentElement;
+  for (const name of SKY_VAR_NAMES) root.style.setProperty(name, palette.vars[name]);
+  // Inline so form controls / scrollbars flip with the hour; theme.css's
+  // static `color-scheme: dark` inside [data-theme='sky'] is the fallback.
+  root.style.colorScheme = palette.colorScheme;
+  return palette;
+}
+
+/** Remove every inline --sky-* var (leaving the static themes untouched). */
+export function clearSkyTheme() {
+  const root = document.documentElement;
+  for (const name of SKY_VAR_NAMES) root.style.removeProperty(name);
+  root.style.removeProperty('color-scheme');
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import { PAPER_ENABLED } from './hooks/usePaper.jsx';
+import { applySkyTheme, easternHour } from './lib/skyTheme.js';
 import './styles/reset.css';
 import './styles/theme.css';
 import './styles/typography.css';
@@ -10,11 +11,11 @@ import './styles/app.css';
 import './styles/paper.css';
 
 // Theme selection happens here (before React mounts) so the first
-// paint is in the correct palette. Two themes; retired monochrome
-// variants alias to their color equivalent, and legacy/missing values
-// fall to light. Keep VALID_THEMES + THEME_COLORS + THEME_ALIASES in
-// sync with useTheme.jsx.
-const VALID_THEMES = ['light', 'dark'];
+// paint is in the correct palette. Three themes (light / dark / the
+// hour-tracking sky mode); retired monochrome variants alias to their
+// color equivalent, and legacy/missing values fall to light. Keep
+// VALID_THEMES + THEME_COLORS + THEME_ALIASES in sync with useTheme.jsx.
+const VALID_THEMES = ['light', 'dark', 'sky'];
 const THEME_ALIASES = { 'light-mono': 'light', 'dark-mono': 'dark' };
 const THEME_COLORS = {
   light: '#e3d8ba',
@@ -27,10 +28,17 @@ const resolvedStoredTheme = THEME_ALIASES[storedTheme] || storedTheme;
 const initialTheme = VALID_THEMES.includes(resolvedStoredTheme) ? resolvedStoredTheme : 'light';
 document.documentElement.setAttribute('data-theme', initialTheme);
 
+// Sky mode's palette is computed, not static — derive this hour's tokens
+// before the first paint, and take the browser-chrome tint from them.
+let initialThemeColor = THEME_COLORS[initialTheme];
+if (initialTheme === 'sky') {
+  initialThemeColor = applySkyTheme(easternHour()).themeColor;
+}
+
 document.querySelectorAll('meta[name="theme-color"]').forEach((m) => m.remove());
 const themeColorMeta = document.createElement('meta');
 themeColorMeta.setAttribute('name', 'theme-color');
-themeColorMeta.setAttribute('content', THEME_COLORS[initialTheme]);
+themeColorMeta.setAttribute('content', initialThemeColor);
 document.head.appendChild(themeColorMeta);
 
 // Paper texture behind long-form text (blank / ruled / dots). Set before

--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -33,6 +33,14 @@
   --paper-dot:  rgba(236, 228, 203, 0.08);
 }
 
+/* Sky theme: ink shifts hue with the hour, so the texture tints are
+   computed alongside the palette in src/lib/skyTheme.js. Fallbacks match
+   the midnight palette. */
+[data-theme='sky'] {
+  --paper-rule: var(--sky-paper-rule, rgba(223, 231, 231, 0.055));
+  --paper-dot:  var(--sky-paper-dot, rgba(223, 231, 231, 0.08));
+}
+
 /* `--paper-drop`: distance the rule/dot row sits above each line-box
    bottom, landing it just below the descenders. The tight density packs
    a shorter line box, so it uses a smaller drop. Both feed post text and

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -108,6 +108,38 @@
   color-scheme: dark;
 }
 
+/* Sky theme: the palette drifts through the day in lockstep with the
+   hourly sky avatar. All tokens are computed per Eastern hour by
+   src/lib/skyTheme.js and written onto <html> as --sky-* custom
+   properties; this block just maps the real tokens onto them. The
+   fallbacks are the midnight palette so any pre-JS flash lands on a
+   quiet near-black rather than an unstyled page. */
+[data-theme='sky'] {
+  --page:           var(--sky-page, #171717);
+  --page-edge:      var(--sky-page-edge, #121212);
+  --surface-raised: var(--sky-surface-raised, #0b0c0c);
+  --surface-deep:   var(--sky-surface-deep, #050505);
+  --ink:            var(--sky-ink, #dfe7e7);
+  --ink-soft:       var(--sky-ink-soft, #c1cdcd);
+  --ink-muted:      var(--sky-ink-muted, #93a5a5);
+  --ink-faint:      var(--sky-ink-faint, #6a7c7c);
+  --rule:           var(--sky-rule, #323939);
+  --rule-soft:      var(--sky-rule-soft, #252828);
+  --accent:         var(--sky-accent, #9cc9c9);
+  --accent-soft:    var(--sky-accent-soft, #79afaf);
+  --tan:            var(--sky-tan, #8cbaba);
+  --highlight:      var(--sky-highlight, rgba(156, 201, 201, 0.16));
+  --shadow:         var(--sky-shadow, rgba(0, 0, 0, 0.45));
+
+  --scrim:          var(--sky-scrim, rgba(8, 8, 8, 0.8));
+  --scrim-clear:    var(--sky-scrim-clear, rgba(8, 8, 8, 0));
+  --scrim-ink:      var(--sky-scrim-ink, rgba(223, 231, 231, 0.9));
+
+  /* Daylight hours override this to `light` via an inline style set by
+     skyTheme.js (inline wins over this static fallback). */
+  color-scheme: dark;
+}
+
 /* Raised-surface ink re-tuning.
 
    The --ink-muted / --ink-faint steps are calibrated for text on
@@ -134,6 +166,15 @@
 [data-theme='dark'] .chrome-bar,
 [data-theme='dark'] .modal-panel {
   --ink-faint: #857f68;
+}
+
+/* Sky theme's raised-surface re-tune, computed per hour alongside the
+   rest of the palette (day hours deepen both steps; night hours only
+   lift the faint step, mirroring the static themes above). */
+[data-theme='sky'] .chrome-bar,
+[data-theme='sky'] .modal-panel {
+  --ink-muted: var(--sky-ink-muted-raised, var(--sky-ink-muted, #93a5a5));
+  --ink-faint: var(--sky-ink-faint-raised, var(--sky-ink-faint, #7b8e8e));
 }
 
 html, body {


### PR DESCRIPTION
A third color mode alongside light/dark. Every Eastern hour gets its own palette derived from the top/bottom gradient bands of that hour's sky-avatar frame (sampled from `images/sky-avatars`), so the site's colors drift through the day in lockstep with the Bluesky avatar and favicon.

- **Palette engine** (`src/lib/skyTheme.js`): 24 sampled sky anchors → full token set (page, surfaces, ink ramp, rules, accents, scrims, paper tints) per hour, written as `--sky-*` custom properties that `theme.css` maps onto the real tokens inside `[data-theme='sky']`.
- **Polarity flips like the avatar wordmark**: 7am–5pm run dark ink on a sky-colored page; the rest run light ink on a deep-sky page. Accents derive from the horizon band, so dawn glows amber and dusk glows orchid.
- **Lockstep with the avatar/favicon**: reuses `og/time.js`'s DST-aware Eastern-hour logic; re-derives at the top of each hour and on tab return.
- **Toggle** now cycles light → dark → sky (sun-moon glyph); first paint handled in `main.jsx`.
- **TEMPORARY test chip** in the bottom action row (sky mode only): shows the current hour and advances the palette one hour per tap, wrapping at midnight, so all 24 increments can be reviewed in place. Marked for removal once the theme is vetted.

Verified with a production build plus Playwright screenshots of all 24 hourly increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS)_