### PR TITLE
Ledger by default; chrome strip gains lowercase date + live NSID indicator

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -184,10 +184,30 @@
   font-size: var(--text-xs);
   letter-spacing: 0.02em;
   color: var(--ink-faint);
+  text-transform: lowercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+}
+
+/* The AT Protocol collection in view, pinned to the strip's right edge —
+   the top visible feed record's NSID on feed pages, the page's own
+   backing record elsewhere. */
+.chrome-crumb-nsid {
+  flex: 0 1 auto;
+  margin-left: auto;
+  padding: var(--space-2) 0;
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+  text-transform: lowercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  text-align: right;
 }
 
 .chrome-crumb-sep {

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-do
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Moon, Pencil, Search, Sun, SunMoon, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
@@ -64,6 +65,14 @@ export default function ChromeBar() {
   const scrolledDown = useScrolledDown();
   const dayLabel = useCurrentDayLabel();
   const showBreadcrumb = scrolledDown && (crumbs.length > 0 || !!dayLabel);
+
+  // Right edge of the strip: the AT Protocol collection you're looking
+  // at. On feed pages it tracks the record at the top of the scroll
+  // position; elsewhere it's the page's own backing record (registered
+  // by PageShell).
+  const { pageRecord } = useEditMode();
+  const feedNsid = useTopFeedNsid();
+  const stripNsid = feedNsid || nsidFromAtUri(pageRecord?.atUri);
 
   // Publish the top chrome's live occupied bottom as `--chrome-top-h` on
   // <html> — the y-coordinate where the top chrome ends and the content
@@ -270,6 +279,7 @@ export default function ChromeBar() {
               </nav>
             )}
             {dayLabel && <span className="chrome-crumb-day">{dayLabel}</span>}
+            {stripNsid && <span className="chrome-crumb-nsid">{stripNsid}</span>}
           </motion.div>
         </div>
       </header>
@@ -705,6 +715,47 @@ function useCurrentDayLabel() {
     };
   }, [location.pathname]);
   return label;
+}
+
+/** NSID of the feed record at the top of the scroll position — the first
+ *  feed row still (partly) visible below the chrome — or null on pages
+ *  without feed rows. Same DOM-driven, rAF-throttled sweep as
+ *  useCurrentDayLabel above; rows publish their collection via the
+ *  `data-nsid` attribute FeedItem stamps on each <li>. */
+function useTopFeedNsid() {
+  const [nsid, setNsid] = useState(null);
+  const location = useLocation();
+  useEffect(() => {
+    let frame = 0;
+    const apply = () => {
+      const chromeBottom =
+        parseFloat(
+          getComputedStyle(document.documentElement).getPropertyValue('--chrome-top-h'),
+        ) || 0;
+      let current = null;
+      for (const el of document.querySelectorAll('.feed-item[data-nsid]')) {
+        const rect = el.getBoundingClientRect();
+        if (rect.height > 0 && rect.bottom > chromeBottom + 12) {
+          current = el.dataset.nsid;
+          break;
+        }
+      }
+      setNsid(current);
+    };
+    const schedule = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(apply);
+    };
+    schedule();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  }, [location.pathname]);
+  return nsid;
 }
 
 function useScrolledDown(threshold = 220) {

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1460,9 +1460,6 @@ a.reference-card-profile:focus-visible {
   color: var(--ink-faint);
   text-decoration: none;
   transition: color 120ms ease;
-  /* Labels hug the summary column's left edge rather than the page
-     margin, mirroring the right-aligned time on the other side. */
-  text-align: right;
   /* Safety valve: a gerund that outgrows the fixed column wraps inside
      it instead of colliding with the time column. */
   min-width: 0;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -87,14 +87,14 @@ function hrefFor(item) {
  * registry. The verb badge doubles as the link to the underlying record
  * page (or generic JSON fallback for verbs without a specialized one).
  *
- * `layout` switches the row treatment: 'default' renders the full card
+ * `layout` switches the row treatment: 'cards' renders the full card
  * (verb badge + per-verb component), 'ledger' renders the condensed
  * multi-column row (see FeedLedgerRow.jsx). Home decides which to pass
- * — including falling back to 'default' while owner edit mode is
- * active, so this component never has to reconcile ledger rows with
- * the selection UI.
+ * — including falling back to 'cards' while owner edit mode is active,
+ * so this component never has to reconcile ledger rows with the
+ * selection UI.
  */
-export default function FeedItem({ item, showVerb = true, layout = 'default' }) {
+export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
   const navigate = useNavigate();
   const edit = useEditMode();
   // Ledger-only: whether a collapsed listening session is showing its

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -19,7 +19,7 @@ import VerbIcon from './VerbIcon.jsx';
 import FeedLedgerRow, { isListenBatch } from './FeedLedgerRow.jsx';
 import { rkeyFromAtUri } from '../lib/atproto.js';
 import { getReplyHint } from '../lib/postReplyHint.js';
-import { verbConfig, recordHrefFor } from '../lib/verbRegistry.js';
+import { verbConfig, recordHrefFor, nsidFromAtUri } from '../lib/verbRegistry.js';
 
 /**
  * Per-verb label overrides for the feed's verb column. Most verbs read
@@ -220,6 +220,7 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
     <li
       className={liClassName}
       data-verb={item.verb}
+      data-nsid={nsidFromAtUri(item.atUri) || undefined}
       data-thread-position={item._thread?.position}
       data-thread-length={item._thread?.length}
       onClickCapture={selectable ? handleSelectCapture : undefined}

--- a/src/components/LayoutToggle.jsx
+++ b/src/components/LayoutToggle.jsx
@@ -3,19 +3,19 @@ import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import './LayoutToggle.css';
 
 const LABELS = {
-  default: 'Feed layout: default',
   ledger: 'Feed layout: ledger',
+  cards: 'Feed layout: cards',
 };
 
 const GLYPHS = {
-  default: Rows2,
   ledger: Table2,
+  cards: Rows2,
 };
 
 /**
- * Two-way switch for the home feed's layout: `default` keeps the full
- * card treatment, `ledger` swaps in the condensed multi-column
- * typographic view (see FeedLedgerRow.jsx).
+ * Two-way switch for the home feed's layout: `ledger` (the default) is
+ * the condensed multi-column typographic view (see FeedLedgerRow.jsx),
+ * `cards` the full card treatment.
  */
 export default function LayoutToggle() {
   const { layout, setLayout, options } = useFeedLayout();

--- a/src/hooks/useFeedLayout.jsx
+++ b/src/hooks/useFeedLayout.jsx
@@ -1,44 +1,35 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 const FeedLayoutContext = createContext(null);
 const STORAGE_KEY = 'dame.feedLayout';
-// Older builds stored a tri-state density ('normal' | 'compact' | 'tight')
-// and, before that, a boolean `dame.compact`. Both fold into the two-mode
-// layout below.
-const LEGACY_DENSITY_KEY = 'dame.density';
-const LEGACY_COMPACT_KEY = 'dame.compact';
-const VALID = ['default', 'ledger'];
-const DEFAULT = 'default';
+const VALID = ['ledger', 'cards'];
+const DEFAULT = 'ledger';
 
 /**
- * Migrate the retired density preferences into the two-mode
- * `dame.feedLayout`. Anyone who had opted into a denser view
- * ('compact' / 'tight' / legacy boolean) lands on the ledger layout;
- * everyone else keeps the default. Once `dame.feedLayout` is written,
- * the legacy keys are ignored on subsequent reads.
+ * Resolve the stored layout preference. Only explicit choices count:
+ * the brief cards-by-default era auto-wrote `'default'` (the card
+ * view's old name) on every visit, so that value — like the retired
+ * `dame.density` / `dame.compact` keys, whose denser modes map to
+ * today's ledger default anyway — doesn't override it.
  */
 function readInitial() {
   if (typeof localStorage === 'undefined') return DEFAULT;
   const stored = localStorage.getItem(STORAGE_KEY);
   if (VALID.includes(stored)) return stored;
-  const density = localStorage.getItem(LEGACY_DENSITY_KEY);
-  if (density === 'compact' || density === 'tight') return 'ledger';
-  if (localStorage.getItem(LEGACY_COMPACT_KEY) === 'true') return 'ledger';
   return DEFAULT;
 }
 
 export function FeedLayoutProvider({ children }) {
   const [layout, setLayoutState] = useState(readInitial);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, layout);
-    } catch {}
-  }, [layout]);
-
+  // Persist only on an explicit pick — never the default — so a future
+  // change of default reaches everyone who hasn't chosen otherwise.
   const setLayout = useCallback((next) => {
     if (!VALID.includes(next)) return;
     setLayoutState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {}
   }, []);
 
   const value = useMemo(

--- a/src/lib/verbRegistry.js
+++ b/src/lib/verbRegistry.js
@@ -285,7 +285,8 @@ export function recordHrefFor(verb, { atUri, rkey, slug, source, payload } = {})
   return `/${nsid}/${encodeURIComponent(rkey)}`;
 }
 
-function nsidFromAtUri(atUri) {
+/** Collection NSID out of an at:// URI (e.g. "app.bsky.feed.post"). */
+export function nsidFromAtUri(atUri) {
   if (!atUri) return null;
   const m = String(atUri).match(/^at:\/\/[^/]+\/([^/]+)\//);
   return m ? m[1] : null;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -554,7 +554,7 @@ export default function Home() {
                             delay: reduce ? 0 : stagger,
                           }}
                         >
-                          <FeedItem item={item} layout={ledger ? 'ledger' : 'default'} />
+                          <FeedItem item={item} layout={ledger ? 'ledger' : 'cards'} />
                         </motion.li>
                       );
                     })}


### PR DESCRIPTION
## Summary

- **Ledger becomes the home feed's default layout.** The two modes are now `ledger` (default) and `cards`. The stored preference only counts when explicitly picked from the toggle — the provider no longer auto-writes the current layout on every visit, so this default flip (and any future one) reaches everyone who hasn't chosen otherwise; the old auto-written `default` value from the brief cards-by-default era doesn't pin returning visitors to cards.
- **Chrome strip refinements:** the day label renders lowercase ("july 8, 2026"), and the strip's right edge shows the AT Protocol collection in view — on feed pages it live-tracks the record at the top of the scroll position (rows publish their collection via a `data-nsid` attribute), elsewhere it falls back to the page's own backing record registered by PageShell.
- **Gerund column returns to left-aligned** (reverting the right-align from #165).

## Verification

- Production build passes
- Browser-verified: fresh visitors get the ledger with nothing persisted; visitors with the old auto-written value get the ledger; an explicit cards pick persists across reload. The NSID chip flips between `fm.teal.alpha.feed.play` / `app.bsky.feed.repost` etc. while scrolling the home feed, and shows `app.bsky.feed.post` on a post's record page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_