### PR TITLE
Chrome + ledger typography polish: small-caps strip, smaller metadata, mobile column rebalance

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -199,7 +199,7 @@
   margin-left: auto;
   padding: var(--space-2) 0;
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * 0.85);
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-transform: lowercase;

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -195,16 +195,16 @@
 
 /* The AT Protocol collection in view, pinned to the strip's right edge —
    the top visible feed record's NSID on feed pages, the page's own
-   backing record elsewhere. */
+   backing record elsewhere. Same small-caps voice as the day label. */
 .chrome-crumb-nsid {
   flex: 0 1 auto;
   margin-left: auto;
   padding: var(--space-2) 0;
-  font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.85);
-  letter-spacing: 0.02em;
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
   color: var(--ink-faint);
-  text-transform: lowercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -306,6 +306,14 @@
 .chrome-signals-secondary {
   flex-wrap: wrap;
   row-gap: var(--space-3);
+}
+
+/* FOLLOWED BY anchors the atmosphere row's right edge on desktop;
+   narrow screens keep the wrapped, left-aligned stack. */
+@media (min-width: 701px) {
+  .chrome-signals-secondary .chrome-signal-stats {
+    margin-left: auto;
+  }
 }
 
 .chrome-signal {

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -180,11 +180,13 @@
 .chrome-crumb-day {
   flex: 0 1 auto;
   padding: var(--space-2) 0;
-  font-family: var(--mono);
+  /* Same small-caps voice as the atmosphere row's "LISTENING TO" /
+     "FOLLOWED BY" labels (.chrome-signal-label) one bar up. */
+  font-family: var(--sans);
+  font-variant: all-small-caps;
   font-size: var(--text-xs);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.12em;
   color: var(--ink-faint);
-  text-transform: lowercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1394,7 +1394,7 @@ a.reference-card-profile:focus-visible {
    longest gerund ("photographing") at the mono x-small size. */
 .feed-ledger {
   --ledger-verb-col: 6.5rem;
-  --ledger-time-col: 4.5rem;
+  --ledger-time-col: 4rem;
   --ledger-col-gap: var(--space-3);
 }
 
@@ -1473,7 +1473,7 @@ a.ledger-verb:focus-visible {
 
 .ledger-time {
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * 0.85);
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   /* formatTime yields "9:41 AM"; the ledger reads lowercase. */
@@ -1696,17 +1696,18 @@ a.ledger-verb:focus-visible {
 }
 
 @media (max-width: 600px) {
+  /* Narrower label columns give the content column the extra width;
+     the label type steps down further so even the longest gerund
+     ("photographing") still fits its column on one line. */
   .feed-ledger {
-    --ledger-verb-col: 5.75rem;
-    --ledger-time-col: 3.9rem;
+    --ledger-verb-col: 5rem;
+    --ledger-time-col: 3.5rem;
     --ledger-col-gap: var(--space-2);
   }
 
-  /* Slightly smaller type so the longest gerunds and full dates still
-     fit their narrower mobile columns on one line. */
   .feed-ledger .ledger-verb,
   .feed-ledger .ledger-time {
-    font-size: calc(var(--text-xs) * 0.9);
+    font-size: calc(var(--text-xs) * 0.8);
   }
 
   .feed-ledger .day-header {


### PR DESCRIPTION
## Summary

Three rounds of typographic polish on the ledger + chrome strip:

- **Smaller metadata type** — the ledger's time column steps down to 0.85× x-small (and narrows to match); on mobile the label columns tighten to 5rem / 3.5rem at 0.8× type, handing ~1.15rem of extra width to the content column while the longest gerund ("photographing") still fits on one line (verified against the real mono font).
- **Small-caps strip** — the breadcrumb strip's day label and NSID chip both adopt the atmosphere row's all-small-caps voice ("JULY 8, 2026" left, "APP.BSKY.FEED.POST" right), replacing the lowercase mono treatment.
- **FOLLOWED BY right-aligned on desktop** — the atmosphere row's stats signal anchors the right edge, mirroring the strip below it; narrow screens keep the wrapped, left-aligned stack.

## Verification

- Production build passes
- Browser-verified at desktop and mobile widths against live data: gerund fit stress-tested with "photographing" (no wrap/overflow), strip renders small caps at both widths, FOLLOWED BY sits at the right edge on desktop only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_