### PR TITLE
Footer strip: smaller written/updated timestamp

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -21,3 +21,11 @@
   font-size: var(--text-xs);
   color: var(--ink-faint);
 }
+
+/* "written … · updated …" — mono reads optically larger than the
+   surrounding chrome text at the same size, so it steps down to the
+   0.85× scale the ledger's time labels use, landing it visually level
+   with the breadcrumb strip's content. */
+.page-footer .record-timestamp {
+  font-size: calc(var(--text-xs) * 0.85);
+}


### PR DESCRIPTION
## Summary

The footer strip's mono "written … · updated …" line (and its "latest record …" twin on feed pages) reads optically larger than the surrounding chrome text at the same nominal 12px. It steps down to the 0.85× scale the ledger's time labels use, landing it visually level with the breadcrumb strip's content and the "PUBLISHED ON THE AT PROTOCOL" tag beside it.

## Verification

- Production build passes
- Browser-verified at mobile width: timestamp renders at 10.2px, sitting level with the small-caps tag on the strip's right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_