### PR TITLE
Theme toggle: SwatchBook glyph; sky becomes the default theme

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Moon, Pencil, Search, Sun, SunMoon, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Search, SwatchBook, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { useAvatar } from '../hooks/useAvatar.js';
@@ -22,14 +22,6 @@ import SearchSheet from './SearchSheet.jsx';
 import InfoSheet from './InfoSheet.jsx';
 import Footer from './Footer.jsx';
 import './ChromeBar.css';
-
-// Per-theme glyph for the toggle button: sun for light, moon for dark,
-// sun-and-moon for the hour-tracking sky theme.
-const THEME_ICON = {
-  light: Sun,
-  dark: Moon,
-  sky: SunMoon,
-};
 
 // The home handle is a router <Link>; wrap it so it can participate in the
 // bottom bar's presence/layout animation (fade in/out, slide to make room).
@@ -309,7 +301,6 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const footerRef = useRef(null);
   const { available: filterAvailable } = useFeedFilter();
   const { theme, cycle: cycleTheme, options: themeOptions, skyHourKey, advanceSkyHour } = useTheme();
-  const ThemeIcon = THEME_ICON[theme] || Sun;
   const nextTheme = themeOptions[(themeOptions.indexOf(theme) + 1) % themeOptions.length];
   // The edit-mode toggle only exists for the site owner. It sits beside the
   // Info button and flips the site into a selectable "edit mode" (see
@@ -457,7 +448,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                   aria-label={`Switch to ${nextTheme} theme (current: ${theme})`}
                   title={`Theme: ${theme} — tap to switch`}
                 >
-                  <ThemeIcon className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  <SwatchBook className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
                 {/* TEMPORARY: sky-theme test chip. Shows the hour whose
                     palette is on screen; each tap advances one hour

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -33,14 +33,14 @@ const THEME_COLOR = {
   dark: '#13180f',
 };
 
-const DEFAULT_THEME = 'light';
+const DEFAULT_THEME = 'sky';
 
 function migrateStoredTheme(stored) {
   const resolved = THEME_ALIAS[stored] || stored;
   if (VALID.includes(resolved)) return resolved;
-  // Legacy / missing values land on the light theme so new visitors
-  // get a predictable first paint — they can flip to dark from the
-  // chrome bar.
+  // Legacy / missing values land on the sky theme, so new visitors get
+  // the hour-tracking palette by default — they can flip to a static
+  // light/dark from the chrome bar.
   return DEFAULT_THEME;
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,7 +13,7 @@ import './styles/paper.css';
 // Theme selection happens here (before React mounts) so the first
 // paint is in the correct palette. Three themes (light / dark / the
 // hour-tracking sky mode); retired monochrome variants alias to their
-// color equivalent, and legacy/missing values fall to light. Keep
+// color equivalent, and legacy/missing values fall to sky. Keep
 // VALID_THEMES + THEME_COLORS + THEME_ALIASES in sync with useTheme.jsx.
 const VALID_THEMES = ['light', 'dark', 'sky'];
 const THEME_ALIASES = { 'light-mono': 'light', 'dark-mono': 'dark' };
@@ -23,9 +23,9 @@ const THEME_COLORS = {
 };
 const storedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.theme') : null;
 const resolvedStoredTheme = THEME_ALIASES[storedTheme] || storedTheme;
-// Default to light for new visitors (and legacy `system` / other
-// invalid values). Keep in sync with DEFAULT_THEME in useTheme.
-const initialTheme = VALID_THEMES.includes(resolvedStoredTheme) ? resolvedStoredTheme : 'light';
+// Default to the sky theme for new visitors (and legacy `system` /
+// other invalid values). Keep in sync with DEFAULT_THEME in useTheme.
+const initialTheme = VALID_THEMES.includes(resolvedStoredTheme) ? resolvedStoredTheme : 'sky';
 document.documentElement.setAttribute('data-theme', initialTheme);
 
 // Sky mode's palette is computed, not static — derive this hour's tokens


### PR DESCRIPTION
- The theme toggle now carries a single `<SwatchBook />` glyph instead of a per-theme sun/moon icon — it reads as "pick a palette" rather than implying a binary flip, now that there are three modes.
- New visitors (and legacy/invalid stored values) default to the hour-tracking **sky** theme instead of light; returning visitors with a stored light/dark choice keep it. The pre-mount first-paint path in `main.jsx` already computes the current hour's palette, so no flash.

Verified with a fresh-profile browser run: no stored theme → lands on sky with the swatch-book glyph, and the cycle runs sky → light → dark → sky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS)_