### PR TITLE
Account view overhaul, admin skeleton loaders, and debug-pane empty-state polish

### DIFF
--- a/src/components/DebugOverlay.css
+++ b/src/components/DebugOverlay.css
@@ -108,7 +108,9 @@
 }
 
 .debug-overlay-empty {
+  margin-top: var(--space-3);
   color: var(--ink-muted);
+  font-size: var(--text-xs);
   font-style: italic;
 }
 

--- a/src/components/PageContentPanel.jsx
+++ b/src/components/PageContentPanel.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { pageDefault } from '../lib/pageRegistry.js';
 import { blankRecordFor } from '../lib/lexicons.js';
 import { COLLECTIONS } from '../config.js';
+import { Skeleton } from './Skeleton.jsx';
 
 /**
  * Local-vs-PDS control for a single page's chrome (title / intro / body).
@@ -94,21 +95,31 @@ export default function PageContentPanel({ agent, did, slug, exists: initialExis
     <div className="admin-page-panel">
       <div className="admin-page-panel-head">
         <span className="admin-page-panel-label">{def.label} — page content</span>
-        <span className={`admin-badge ${exists ? 'admin-badge-pds' : 'admin-badge-local'}`}>
-          {checking ? '…' : exists ? 'PDS' : 'Local'}
+        <span
+          className={`admin-badge ${
+            checking ? '' : exists ? 'admin-badge-pds' : 'admin-badge-local'
+          }`}
+        >
+          {checking ? (
+            <Skeleton width="1.75rem" height="0.7rem" />
+          ) : exists ? (
+            'PDS'
+          ) : (
+            'Local'
+          )}
         </span>
       </div>
       <p className="admin-page-panel-desc">
         {checking ? (
-          'Checking status…'
+          <Skeleton width="70%" height="0.85em" />
         ) : exists ? (
-          <>
+          <span className="reveal">
             Title &amp; intro are served from <code>is.dame.page/{slug}</code> on your PDS.
-          </>
+          </span>
         ) : (
-          <>
+          <span className="reveal">
             Title &amp; intro are hardcoded in the site. Migrate to edit them on your PDS.
-          </>
+          </span>
         )}
       </p>
       <div className="admin-page-panel-actions">

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -7,6 +7,7 @@ import { fetchAllBlocks } from '../lib/arena.js';
 import BlocksEditor from './blocks/BlocksEditor.jsx';
 import { uploadImageFile } from './blocks/ImageBlockEditor.jsx';
 import LeafletDocument from './LeafletDocument.jsx';
+import { AdminEditorSkeleton } from './Skeleton.jsx';
 import {
   HighlightsField,
   RecordRefsField,
@@ -333,11 +334,11 @@ const RecordEditor = forwardRef(function RecordEditor({
   }, [saving, deleting, loading, isNew, onStatus]);
 
   if (loading) {
-    return <p className="placeholder-card">Loading record…</p>;
+    return <AdminEditorSkeleton fields={compact ? 3 : 4} />;
   }
 
   return (
-    <div className={`record-editor${compact ? ' record-editor-compact' : ''}`}>
+    <div className={`record-editor reveal${compact ? ' record-editor-compact' : ''}`}>
       <div className="admin-toolbar admin-toolbar-inline">
         {lex && !preview && (
           <button

--- a/src/components/SignInPanel.css
+++ b/src/components/SignInPanel.css
@@ -89,3 +89,192 @@
 .signin-admin-link {
   text-decoration: none;
 }
+
+/* ------------------------------------------------------------------ */
+/* Signed-in account card                                              */
+/* ------------------------------------------------------------------ */
+
+.account-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* Identity: avatar beside the "signed in" eyebrow + name / handle. */
+.account-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.account-avatar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  overflow: hidden;
+  border: 1px solid var(--rule-soft);
+  border-radius: 50%;
+  background: var(--page-edge);
+}
+
+.account-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.account-avatar-empty {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  color: var(--ink-faint);
+}
+
+.account-identity-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.account-eyebrow {
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  color: var(--ink-faint);
+}
+
+.account-name {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  line-height: 1.15;
+  color: var(--ink);
+  word-break: break-word;
+}
+
+.account-handle {
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  word-break: break-all;
+}
+
+.account-handle-did {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+}
+
+/* Stat row: followers / following / posts, framed by hairlines. */
+.account-stats {
+  display: flex;
+  gap: var(--space-5);
+  margin: 0;
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--rule-soft);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.account-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.account-stat-label {
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+}
+
+.account-stat-value {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  line-height: 1.1;
+  color: var(--ink);
+}
+
+/* did / pds ledger — a two-column readout echoing the atmosphere pane. */
+.account-meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.account-meta-row {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: var(--space-3);
+  align-items: baseline;
+}
+
+.account-meta-row dt {
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+}
+
+.account-meta-row dd {
+  margin: 0;
+  min-width: 0;
+}
+
+.account-meta-row dd code {
+  padding: 0;
+  background: none;
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-soft);
+  word-break: break-all;
+}
+
+/* Actions: a ruled list echoing the menu's .dock-routes — label on the
+   line, glyph riding the right edge, hover lifts to the accent. */
+.account-actions {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.account-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-2) 0;
+  border: 0;
+  border-bottom: 1px solid var(--rule-soft);
+  background: none;
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  color: var(--ink);
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.account-action:last-child {
+  border-bottom: none;
+}
+
+.account-action:hover,
+.account-action:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.account-action-glyph {
+  font-family: var(--mono-ui);
+  font-size: var(--text-sm);
+  color: var(--ink-faint);
+  transition: color 120ms ease;
+}
+
+.account-action:hover .account-action-glyph,
+.account-action:focus-visible .account-action-glyph {
+  color: var(--accent);
+}

--- a/src/components/SignInPanel.jsx
+++ b/src/components/SignInPanel.jsx
@@ -2,33 +2,47 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { ME_DID } from '../config.js';
-import { getProfile } from '../lib/atproto.js';
+import { getProfile, resolvePds } from '../lib/atproto.js';
+import { Skeleton } from './Skeleton.jsx';
 import './SignInPanel.css';
 
 /**
- * Sign-in surface that lives inside the ActionDock's Tools section.
+ * Sign-in surface that lives inside the ActionDock's Account view.
  *
  *   - Signed out → a tiny handle / DID / PDS-URL field that kicks off the
  *     OAuth flow.
- *   - Signed in → identity readout + sign out. If the signed-in DID is the
- *     site owner, also expose a link to /admin.
+ *   - Signed in → an identity card: avatar, name/handle, a follower /
+ *     following / posts stat row, a did / pds ledger, and the account
+ *     actions (Admin for the owner, Sign out). The profile and PDS are
+ *     fetched lazily, so each block fades from a skeleton into the real
+ *     value as it resolves.
  */
 export default function SignInPanel({ onAction }) {
   const { session, did, loading, signIn, signOut } = useAtprotoSession();
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
-  const [handle, setHandle] = useState(null);
+  const [profile, setProfile] = useState(null);
+  const [profileLoading, setProfileLoading] = useState(false);
+  const [pdsHost, setPdsHost] = useState(null);
 
   useEffect(() => {
-    setHandle(null);
+    setProfile(null);
+    setPdsHost(null);
     if (!did) return undefined;
     let cancelled = false;
+    setProfileLoading(true);
     getProfile(did)
-      .then((profile) => {
-        if (cancelled) return;
-        const h = profile?.handle;
-        if (h && h !== 'handle.invalid') setHandle(h);
+      .then((p) => {
+        if (!cancelled && p) setProfile(p);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setProfileLoading(false);
+      });
+    resolvePds(did)
+      .then((pds) => {
+        if (!cancelled && pds) setPdsHost(prettyHost(pds));
       })
       .catch(() => {});
     return () => {
@@ -65,26 +79,80 @@ export default function SignInPanel({ onAction }) {
 
   if (session) {
     const isOwner = did === ME_DID;
+    const handle =
+      profile?.handle && profile.handle !== 'handle.invalid' ? profile.handle : null;
+    const displayName = profile?.displayName?.trim() || null;
+
     return (
-      <div className="signin-panel">
-        <div className="signin-status">
-          <span className="small-caps signin-status-label">signed in</span>
-          {handle ? (
-            <span className="signin-handle" title={did || ''}>@{handle}</span>
-          ) : (
-            <code className="signin-did" title={did || ''}>{shortDid(did)}</code>
-          )}
+      <div className="account-panel">
+        <div className="account-identity">
+          <span className="account-avatar">
+            {profile?.avatar ? (
+              <img src={profile.avatar} alt="" className="account-avatar-img" />
+            ) : profileLoading ? (
+              <Skeleton style={{ width: '100%', height: '100%' }} />
+            ) : (
+              <span className="account-avatar-empty" aria-hidden="true">@</span>
+            )}
+          </span>
+          <span className="account-identity-text">
+            <span className="small-caps account-eyebrow">signed in</span>
+            {displayName && <span className="account-name reveal">{displayName}</span>}
+            {handle ? (
+              <span className="account-handle reveal" title={did || ''}>
+                @{handle}
+              </span>
+            ) : profileLoading ? (
+              <Skeleton width="9rem" height="1.05em" />
+            ) : (
+              <code className="account-handle account-handle-did" title={did || ''}>
+                {shortDid(did)}
+              </code>
+            )}
+          </span>
         </div>
-        {isOwner && (
-          <Link to="/admin" className="dock-tool" onClick={onAction}>
-            <span className="dock-tool-label">Admin</span>
-            <span className="dock-tool-key">&rsaquo;</span>
-          </Link>
-        )}
-        <button type="button" className="dock-tool" onClick={handleSignOut}>
-          <span className="dock-tool-label">Sign out</span>
-          <span className="dock-tool-key">×</span>
-        </button>
+
+        <dl className="account-stats">
+          <AccountStat label="followers" value={profile?.followersCount} loading={profileLoading} />
+          <AccountStat label="following" value={profile?.followsCount} loading={profileLoading} />
+          <AccountStat label="posts" value={profile?.postsCount} loading={profileLoading} />
+        </dl>
+
+        <dl className="account-meta">
+          <div className="account-meta-row">
+            <dt className="small-caps">did</dt>
+            <dd>
+              <code>{did}</code>
+            </dd>
+          </div>
+          <div className="account-meta-row">
+            <dt className="small-caps">pds</dt>
+            <dd>
+              {pdsHost ? (
+                <code className="reveal">{pdsHost}</code>
+              ) : (
+                <Skeleton width="7rem" height="0.8em" />
+              )}
+            </dd>
+          </div>
+        </dl>
+
+        <nav className="account-actions">
+          {isOwner && (
+            <Link to="/admin" className="account-action" onClick={onAction}>
+              <span className="account-action-label">Admin</span>
+              <span className="account-action-glyph" aria-hidden="true">
+                &rsaquo;
+              </span>
+            </Link>
+          )}
+          <button type="button" className="account-action" onClick={handleSignOut}>
+            <span className="account-action-label">Sign out</span>
+            <span className="account-action-glyph" aria-hidden="true">
+              ×
+            </span>
+          </button>
+        </nav>
       </div>
     );
   }
@@ -111,6 +179,34 @@ export default function SignInPanel({ onAction }) {
       {error && <p className="signin-error">{error}</p>}
     </form>
   );
+}
+
+/**
+ * One stat in the account identity row — a large serif count above a
+ * small-caps label, or a skeleton while the profile is still loading.
+ */
+function AccountStat({ label, value, loading }) {
+  const hasValue = typeof value === 'number';
+  return (
+    <div className="account-stat">
+      <dt className="account-stat-label small-caps">{label}</dt>
+      <dd className="account-stat-value">
+        {hasValue ? (
+          <span className="reveal">{value.toLocaleString()}</span>
+        ) : loading ? (
+          <Skeleton width="2.5rem" height="1.1em" />
+        ) : (
+          '—'
+        )}
+      </dd>
+    </div>
+  );
+}
+
+function prettyHost(url) {
+  return String(url || '')
+    .replace(/^https?:\/\//, '')
+    .replace(/\/$/, '');
 }
 
 function shortDid(did) {

--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -389,6 +389,155 @@
   padding-left: calc(1.75rem + var(--space-3));
 }
 
+/* Variant: admin record list. Mirrors .admin-record-list rows — a fixed
+   rkey column beside a flexible preview line, with the same hairline
+   dividers and row padding so the swap to real rows doesn't reflow. */
+.skeleton-admin-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.skeleton-admin-toolbar-back {
+  width: 8rem;
+  height: 0.85rem;
+}
+
+.skeleton-admin-toolbar-nsid {
+  width: 11rem;
+  height: 0.75rem;
+}
+
+.skeleton-admin-toolbar-btn {
+  width: 6.5rem;
+  height: 1.6rem;
+  margin-left: auto;
+}
+
+.skeleton-admin-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.skeleton-admin-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.skeleton-admin-row:first-child {
+  border-top: 0;
+}
+
+.skeleton-admin-rkey {
+  flex: 0 0 auto;
+  width: 9ch;
+  height: 0.8rem;
+}
+
+.skeleton-admin-preview {
+  flex: 1 1 auto;
+  height: 1.05em;
+  max-width: var(--measure);
+}
+
+/* Variant: admin "Local vs PDS" page panels. Mirrors .admin-page-panel —
+   a bordered block with a label + badge head, a description line, and an
+   actions row. */
+.skeleton-admin-panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.skeleton-admin-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--rule-soft);
+}
+
+.skeleton-admin-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.skeleton-admin-panel-label {
+  height: 1.2rem;
+}
+
+.skeleton-admin-panel-badge {
+  flex: 0 0 auto;
+  width: 2.75rem;
+  height: 1.2rem;
+}
+
+.skeleton-admin-panel-desc {
+  height: 0.85em;
+}
+
+.skeleton-admin-panel-actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-1);
+}
+
+.skeleton-admin-panel-btn {
+  width: 4.5rem;
+  height: 1.6rem;
+}
+
+/* Variant: admin record-editor form. Mirrors the .admin-form field stack —
+   a small-caps label above each input, the last field a tall textarea,
+   then an actions row. */
+.skeleton-admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.skeleton-admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-admin-field-label {
+  height: 0.7rem;
+}
+
+.skeleton-admin-field-input {
+  width: 100%;
+  height: 2.25rem;
+}
+
+.skeleton-admin-field-input-tall {
+  height: 9rem;
+}
+
+.skeleton-admin-actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.skeleton-admin-action-btn {
+  width: 5.5rem;
+  height: 2.1rem;
+}
+
 /* Stagger the breathing across multi-item skeletons so the list doesn't
    pulse in lockstep. Negative delays seed each row at a different phase
    in the cycle without changing the cycle length. */
@@ -396,18 +545,24 @@
 .skeleton-toc-entry:nth-child(3n)       .skeleton,
 .skeleton-grid-cell:nth-child(3n)       .skeleton,
 .skeleton-mothing-cell:nth-child(3n)    .skeleton,
+.skeleton-admin-row:nth-child(3n)       .skeleton,
+.skeleton-admin-panel:nth-child(3n)     .skeleton,
 .skeleton-comments-item:nth-child(3n)   .skeleton { animation-delay: -0.5s; }
 
 .skeleton-feed-item:nth-child(3n + 1)     .skeleton,
 .skeleton-toc-entry:nth-child(3n + 1)     .skeleton,
 .skeleton-grid-cell:nth-child(3n + 1)     .skeleton,
 .skeleton-mothing-cell:nth-child(3n + 1)  .skeleton,
+.skeleton-admin-row:nth-child(3n + 1)     .skeleton,
+.skeleton-admin-panel:nth-child(3n + 1)   .skeleton,
 .skeleton-comments-item:nth-child(3n + 1) .skeleton { animation-delay: -1.2s; }
 
 .skeleton-feed-item:nth-child(3n + 2)     .skeleton,
 .skeleton-toc-entry:nth-child(3n + 2)     .skeleton,
 .skeleton-grid-cell:nth-child(3n + 2)     .skeleton,
 .skeleton-mothing-cell:nth-child(3n + 2)  .skeleton,
+.skeleton-admin-row:nth-child(3n + 2)     .skeleton,
+.skeleton-admin-panel:nth-child(3n + 2)   .skeleton,
 .skeleton-comments-item:nth-child(3n + 2) .skeleton { animation-delay: -1.9s; }
 
 /* -------------------------------------------------------------------- */

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -370,3 +370,108 @@ export function ProseSkeleton({ paragraphs = 3 }) {
     </SkeletonShell>
   );
 }
+
+/* -------------------------------------------------------------------- */
+/* Admin variants                                                        */
+/* -------------------------------------------------------------------- */
+
+/**
+ * Skeleton for the admin record list (RecordList, ListeningManager, the
+ * Site-pages record section). Mirrors the `.admin-record-list` rows — a
+ * fixed rkey column beside a flexible preview line — so the placeholder
+ * lands on the same grid the real rows fill.
+ *
+ * Pass `toolbar` to prepend a `.admin-toolbar`-shaped bar, used when the
+ * whole page is still resolving (e.g. the session-restore gate) and the
+ * real toolbar hasn't rendered yet.
+ */
+export function AdminRecordListSkeleton({ rows = 6, toolbar = false, label = 'Loading records' }) {
+  return (
+    <SkeletonShell label={label}>
+      {toolbar && (
+        <div className="skeleton-admin-toolbar">
+          <Skeleton className="skeleton-admin-toolbar-back" />
+          <Skeleton className="skeleton-admin-toolbar-nsid" />
+          <Skeleton className="skeleton-admin-toolbar-btn" />
+        </div>
+      )}
+      <ul className="skeleton-admin-list">
+        {Array.from({ length: rows }, (_, i) => (
+          <li key={i} className="skeleton-admin-row">
+            <Skeleton className="skeleton-admin-rkey" />
+            <Skeleton
+              className="skeleton-admin-preview"
+              style={{ width: `${52 + ((i * 13) % 40)}%` }}
+            />
+          </li>
+        ))}
+      </ul>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for the Site-pages "Local vs PDS" grid. Mirrors the
+ * `.admin-page-panel` cards — bordered blocks with a label + status badge,
+ * a description line, and an actions row.
+ */
+export function AdminPagePanelsSkeleton({ panels = 4 }) {
+  return (
+    <SkeletonShell label="Loading pages">
+      <div className="skeleton-admin-panels">
+        {Array.from({ length: panels }, (_, i) => (
+          <div key={i} className="skeleton-admin-panel">
+            <div className="skeleton-admin-panel-head">
+              <Skeleton
+                className="skeleton-admin-panel-label"
+                style={{ width: `${8 + ((i * 3) % 6)}rem` }}
+              />
+              <Skeleton className="skeleton-admin-panel-badge" />
+            </div>
+            <Skeleton
+              className="skeleton-admin-panel-desc"
+              style={{ width: `${60 + ((i * 11) % 30)}%` }}
+            />
+            <div className="skeleton-admin-panel-actions">
+              <Skeleton className="skeleton-admin-panel-btn" />
+              {i % 2 === 0 && (
+                <Skeleton className="skeleton-admin-panel-btn" style={{ width: '6.5rem' }} />
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </SkeletonShell>
+  );
+}
+
+/**
+ * Skeleton for the record editor form (RecordEditor while it fetches an
+ * existing record). Mirrors the `.admin-form` stack — small-caps field
+ * labels above inputs, one tall block for the body textarea, and an
+ * actions row.
+ */
+export function AdminEditorSkeleton({ fields = 4 }) {
+  return (
+    <SkeletonShell label="Loading record" className="skeleton-admin-form">
+      {Array.from({ length: fields }, (_, i) => {
+        const tall = i === fields - 1;
+        return (
+          <div key={i} className="skeleton-admin-field">
+            <Skeleton
+              className="skeleton-admin-field-label"
+              style={{ width: `${4 + ((i * 5) % 5)}rem` }}
+            />
+            <Skeleton
+              className={`skeleton-admin-field-input${tall ? ' skeleton-admin-field-input-tall' : ''}`}
+            />
+          </div>
+        );
+      })}
+      <div className="skeleton-admin-actions">
+        <Skeleton className="skeleton-admin-action-btn" />
+        <Skeleton className="skeleton-admin-action-btn" style={{ width: '4.5rem' }} />
+      </div>
+    </SkeletonShell>
+  );
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
 import PageContentPanel from '../components/PageContentPanel.jsx';
+import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { ME_DID, COLLECTIONS, PORTFOLIO_PUBLICATION } from '../config.js';
@@ -36,7 +37,7 @@ export default function Admin() {
   if (loading) {
     return (
       <PageShell title="Admin" headTitle="Admin — dame.is">
-        <p className="placeholder-card">Restoring session…</p>
+        <AdminRecordListSkeleton toolbar rows={5} label="Restoring session" />
       </PageShell>
     );
   }
@@ -441,26 +442,28 @@ function RecordList({
 
       {error && <p className="admin-error">{error}</p>}
 
-      {visibleRecords.length === 0 && !loading && !error && (
+      {loading && records.length === 0 ? (
+        <AdminRecordListSkeleton rows={8} />
+      ) : visibleRecords.length === 0 && !error ? (
         <p className="placeholder-card">No records yet in this collection.</p>
+      ) : (
+        <ul className="admin-record-list reveal-stagger">
+          {visibleRecords.map((rec) => {
+            const r = rkeyFromUri(rec.uri);
+            return (
+              <li key={rec.uri} className="admin-record-row">
+                <Link
+                  to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(r)}`}
+                  className="admin-record-link"
+                >
+                  <code className="admin-record-rkey">{r}</code>
+                  <span className="admin-record-preview">{previewFor(rec.value, lex)}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
       )}
-
-      <ul className="admin-record-list">
-        {visibleRecords.map((rec) => {
-          const r = rkeyFromUri(rec.uri);
-          return (
-            <li key={rec.uri} className="admin-record-row">
-              <Link
-                to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(r)}`}
-                className="admin-record-link"
-              >
-                <code className="admin-record-rkey">{r}</code>
-                <span className="admin-record-preview">{previewFor(rec.value, lex)}</span>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
 
       {!done && records.length > 0 && (
         <button
@@ -472,7 +475,6 @@ function RecordList({
           {loading ? 'Loading…' : 'Load more'}
         </button>
       )}
-      {loading && records.length === 0 && <p className="placeholder-card">Loading records…</p>}
     </PageShell>
   );
 }
@@ -709,9 +711,9 @@ function PagesOverview({ agent, did }) {
           hardcoded defaults. Migrate or revert any of them.
         </p>
         {records === null ? (
-          <p className="placeholder-card">Loading pages…</p>
+          <AdminPagePanelsSkeleton panels={knownPageSlugs().length || 4} />
         ) : (
-          <div className="admin-page-panels">
+          <div className="admin-page-panels reveal">
             {knownPageSlugs().map((slug) => (
               <PageContentPanel
                 key={slug}
@@ -732,11 +734,11 @@ function PagesOverview({ agent, did }) {
           page slugs beyond the built-in surfaces above.
         </p>
         {records === null ? (
-          <p className="placeholder-card">Loading records…</p>
+          <AdminRecordListSkeleton rows={4} label="Loading page records" />
         ) : records.length === 0 ? (
           <p className="placeholder-card">No page records on your PDS yet.</p>
         ) : (
-          <ul className="admin-record-list">
+          <ul className="admin-record-list reveal-stagger">
             {records.map((rec) => {
               const r = rkeyFromUri(rec.uri);
               return (
@@ -1064,33 +1066,35 @@ function ListeningManager({ agent, did }) {
         </button>
       </div>
 
-      {records.length === 0 && !loading && !error && (
+      {loading && records.length === 0 ? (
+        <AdminRecordListSkeleton rows={8} label="Loading plays" />
+      ) : records.length === 0 && !error ? (
         <p className="placeholder-card">No plays yet.</p>
-      )}
-
-      <ul className="admin-record-list">
-        {records.map((rec) => {
-          const rkey = rkeyFromUri(rec.uri);
-          const checked = selected.has(rkey);
-          return (
-            <li
-              key={rec.uri}
-              className={`admin-record-row admin-multiselect-row${checked ? ' is-selected' : ''}`}
-            >
-              <label className="admin-checkbox admin-multiselect-check">
-                <input type="checkbox" checked={checked} onChange={() => toggle(rkey)} />
-                <span className="admin-record-preview">{playLabel(rec.value)}</span>
-              </label>
-              <Link
-                to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(rkey)}`}
-                className="admin-link-subtle admin-multiselect-edit"
+      ) : (
+        <ul className="admin-record-list reveal-stagger">
+          {records.map((rec) => {
+            const rkey = rkeyFromUri(rec.uri);
+            const checked = selected.has(rkey);
+            return (
+              <li
+                key={rec.uri}
+                className={`admin-record-row admin-multiselect-row${checked ? ' is-selected' : ''}`}
               >
-                Edit →
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
+                <label className="admin-checkbox admin-multiselect-check">
+                  <input type="checkbox" checked={checked} onChange={() => toggle(rkey)} />
+                  <span className="admin-record-preview">{playLabel(rec.value)}</span>
+                </label>
+                <Link
+                  to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(rkey)}`}
+                  className="admin-link-subtle admin-multiselect-edit"
+                >
+                  Edit →
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
 
       {!done && records.length > 0 && (
         <button
@@ -1102,7 +1106,6 @@ function ListeningManager({ agent, did }) {
           {loading ? 'Loading…' : 'Load more'}
         </button>
       )}
-      {loading && records.length === 0 && <p className="placeholder-card">Loading plays…</p>}
     </PageShell>
   );
 }


### PR DESCRIPTION
## Summary

Three UI improvements, all matching the app's serif / small-caps / hairline voice:

### 1. Nav sheet account view — overhauled
Rebuilds the signed-in `SignInPanel` from a bare handle + two-link list into a proper identity card:
- Avatar, display name, and @handle
- A hairline-framed **followers / following / posts** stat row
- A **did / pds** ledger rendered as clean mono values, echoing the atmosphere debug pane
- **Admin › / Sign out ×** as ruled action rows (also removes the stray underline the old Admin link carried)

The full profile (`getProfile`) and PDS (`resolvePds`) are fetched lazily; each block fades from a skeleton into its real value as it resolves.

### 2. Admin loading states — skeleton loaders
Every plain "Loading…" placeholder is replaced with a skeleton that mirrors the real layout, then reveal-animates the content in:
- New `AdminRecordListSkeleton`, `AdminPagePanelsSkeleton`, and `AdminEditorSkeleton` variants
- Wired into session restore, record lists, the listening manager, the site-pages overview, and the record editor
- `PageContentPanel`'s "checking" state now shows a pulsing badge + skeleton line instead of `…` / "Checking status…"

### 3. Debug pane empty-state polish
The "No backing record found for this route." message is now `--text-xs` (matching the other debug readouts) with a `--space-3` top margin for breathing room.

## Testing
- `vite build` passes clean
- New CSS verified against the real stylesheets in light and dark themes via a static render harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5wyvD1z7mmBoNmoC1buYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5wyvD1z7mmBoNmoC1buYu)_