### PR TITLE
Verb-page NSID fallback; footer strip timestamp in small caps

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-do
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Search, SwatchBook, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
-import { nsidFromAtUri } from '../lib/verbRegistry.js';
+import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { useAvatar } from '../hooks/useAvatar.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
@@ -60,11 +60,14 @@ export default function ChromeBar() {
 
   // Right edge of the strip: the AT Protocol collection you're looking
   // at. On feed pages it tracks the record at the top of the scroll
-  // position; elsewhere it's the page's own backing record (registered
-  // by PageShell).
+  // position. Verb routes (/listening, /blogging, …) fall back to their
+  // registry collection — the records the feed is OF — rather than the
+  // page's own is.dame.page record; only non-verb pages report their
+  // backing record (registered by PageShell).
   const { pageRecord } = useEditMode();
   const feedNsid = useTopFeedNsid();
-  const stripNsid = feedNsid || nsidFromAtUri(pageRecord?.atUri);
+  const routeVerbNsid = primaryNsid(location.pathname.split('/')[1] || '');
+  const stripNsid = feedNsid || routeVerbNsid || nsidFromAtUri(pageRecord?.atUri);
 
   // Publish the top chrome's live occupied bottom as `--chrome-top-h` on
   // <html> — the y-coordinate where the top chrome ends and the content

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -21,11 +21,3 @@
   font-size: var(--text-xs);
   color: var(--ink-faint);
 }
-
-/* "written … · updated …" — mono reads optically larger than the
-   surrounding chrome text at the same size, so it steps down to the
-   0.85× scale the ledger's time labels use, landing it visually level
-   with the breadcrumb strip's content. */
-.page-footer .record-timestamp {
-  font-size: calc(var(--text-xs) * 0.85);
-}

--- a/src/components/RecordTimestamp.jsx
+++ b/src/components/RecordTimestamp.jsx
@@ -17,7 +17,7 @@ export default function RecordTimestamp() {
   const { latestRecordAt } = useFeedFooter();
   if (latestRecordAt) {
     return (
-      <span className="record-timestamp gutter" title={`latest record: ${latestRecordAt}`}>
+      <span className="record-timestamp small-caps" title={`latest record: ${latestRecordAt}`}>
         latest record {relativeTime(latestRecordAt)}
       </span>
     );
@@ -37,7 +37,7 @@ function RouteRecordTimestamp() {
   const updatedAt = value?.updatedAt || createdAt;
 
   if (!createdAt) {
-    return <span className="record-timestamp gutter">written &mdash; · updated &mdash;</span>;
+    return <span className="record-timestamp small-caps">written &mdash; · updated &mdash;</span>;
   }
 
   const written = relativeTime(createdAt);
@@ -46,7 +46,7 @@ function RouteRecordTimestamp() {
 
   return (
     <span
-      className="record-timestamp gutter"
+      className="record-timestamp small-caps"
       title={`createdAt: ${createdAt}\nupdatedAt: ${updatedAt}`}
     >
       written {written}


### PR DESCRIPTION
## Summary

- **Verb pages report their records' collection** — on /listening, /blogging, and the other verb routes the strip's NSID falls back to the verb's registry collection (`fm.teal.alpha.feed.play`, `site.standard.document`, …) — the records the feed is *of* — instead of the page's own `is.dame.page` record. Top-visible-row tracking still wins when feed rows are on screen; non-verb pages keep reporting their backing record.
- **Footer strip in one voice** — "latest record …" / "written … · updated …" drop the mono treatment for the same all-small-caps register as the PUBLISHED ON THE AT PROTOCOL tag beside them (the mono-specific down-sizing rule from #171 goes with it).

## Verification

- Production build passes on top of the account-view work from #173
- Browser-verified: /listening → `fm.teal.alpha.feed.play`, /blogging → `site.standard.document`, /posting → `app.bsky.feed.post`, /themself → `is.dame.profile`; footer renders "LATEST RECORD 4H AGO" in small caps level with the tag beside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_