### PR TITLE
Square account avatar; move resume print button to the bottom chrome

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -674,3 +674,14 @@
     min-width: 0;
   }
 }
+
+/* Print: the fixed chrome bars (and their expanding sheets) are screen
+   navigation — never part of a printed page. Hiding them here also keeps
+   the resume's bottom-bar print button out of the printout it triggers. */
+@media print {
+  .chrome-bar,
+  .dock-sheet-wrap,
+  .dock-backdrop {
+    display: none !important;
+  }
+}

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Search, SwatchBook, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, SwatchBook, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { useAvatar } from '../hooks/useAvatar.js';
@@ -313,6 +313,11 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const searchActive = !!params.get('q');
   const filterCustomized = params.has('verbs');
   const onHomePage = location.pathname === '/';
+  // The resume (/for-hire) page exposes a print / save-as-PDF control in the
+  // bottom bar's page-level cluster — it replaces the old in-page print button
+  // and only shows while a resume is on screen.
+  const onResumePage =
+    location.pathname === '/for-hire' || location.pathname.startsWith('/for-hire/');
 
   // If the route stops exposing filters while the filter panel is open
   // (e.g. navigating away from a feed), fold it away — the trigger button
@@ -498,6 +503,17 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 >
                   <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
+                {onResumePage && (
+                  <button
+                    type="button"
+                    className="chrome-nav chrome-print-btn"
+                    onClick={() => window.print()}
+                    aria-label="Print or save this resume as PDF"
+                    title="Print / save as PDF"
+                  >
+                    <Printer className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  </button>
+                )}
                 {isOwner && (
                   <button
                     type="button"

--- a/src/components/SignInPanel.css
+++ b/src/components/SignInPanel.css
@@ -116,7 +116,7 @@
   height: 3rem;
   overflow: hidden;
   border: 1px solid var(--rule-soft);
-  border-radius: 50%;
+  border-radius: var(--radius-2);
   background: var(--page-edge);
 }
 

--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -12,13 +12,6 @@
   gap: var(--space-3);
 }
 
-.resume-headline-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-4);
-}
-
 .resume-title {
   font-family: var(--serif);
   font-size: var(--text-3xl);
@@ -31,27 +24,6 @@
   font-size: var(--text-lg);
   color: var(--accent);
   margin: var(--space-1) 0 0;
-}
-
-.resume-print-btn {
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  font-family: var(--sans);
-  font-size: var(--text-sm);
-  color: var(--ink-soft);
-  background: var(--page-edge);
-  border: 1px solid var(--rule-soft);
-  border-radius: 0;
-  cursor: pointer;
-  transition: border-color 200ms ease, color 200ms ease;
-}
-
-.resume-print-btn:hover {
-  border-color: var(--accent-soft);
-  color: var(--ink);
 }
 
 .resume-contact {
@@ -292,7 +264,6 @@
 
 /* --- Print: a clean one-document resume ----------------------------- */
 @media print {
-  .resume-print-btn,
   .resume-record-link,
   .resume-footnote {
     display: none !important;

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { Printer } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
@@ -87,21 +86,9 @@ export default function Resume() {
     >
       <article className="resume reveal">
         <header className="resume-header">
-          <div className="resume-headline-row">
-            <div>
-              <h1 className="resume-title">{pageTitle || 'For hire'}</h1>
-              {v.headline && <p className="resume-headline">{v.headline}</p>}
-            </div>
-            <button
-              type="button"
-              className="resume-print-btn"
-              onClick={() => window.print()}
-              aria-label="Print this resume"
-              title="Print / save as PDF"
-            >
-              <Printer size={16} strokeWidth={1.75} aria-hidden="true" />
-              <span>Print</span>
-            </button>
+          <div>
+            <h1 className="resume-title">{pageTitle || 'For hire'}</h1>
+            {v.headline && <p className="resume-headline">{v.headline}</p>}
           </div>
 
           {contact && (


### PR DESCRIPTION
## Summary

Two small UI follow-ups:

### 1. Account avatar → square
The avatar in the nav sheet's account card is now a square (`--radius-2`, i.e. no rounding) instead of a circle, matching the app's flat, no-radius surfaces.

### 2. Resume print button → bottom chrome
- Removes the in-page "Print" button from the resume page (plus its CSS, the unused `Printer` import, and the headline-row flex wrapper).
- Adds a **printer icon button** to the bottom chrome bar's left cluster, beside the owner edit button. It only appears on `/for-hire` (and `/for-hire/:slug`) and is available to everyone, not just the owner.
- Adds an `@media print` rule that hides the fixed chrome bars, so the printout stays a clean one-document resume and the new print button never prints itself.

## Testing
- `vite build` passes clean
- Dev server: printer shows on `/for-hire`, absent on `/blogging`; under print emulation both chrome bars are hidden (0 of 2 visible)
- Square avatar verified in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5wyvD1z7mmBoNmoC1buYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5wyvD1z7mmBoNmoC1buYu)_