### PR TITLE
Sky chip steps the avatar too; fix 1px scroll creep per tap

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -5,6 +5,7 @@ import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { useAvatar } from '../hooks/useAvatar.js';
+import { skyAvatarUrl } from '../lib/skyAvatars.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useChromePanel } from '../hooks/useChromePanel.jsx';
@@ -35,7 +36,15 @@ export default function ChromeBar() {
   // Brand mark: Dame's live Bluesky avatar (regenerated hourly to track the
   // sun). While it's loading — or if it ever fails — the mark simply isn't
   // rendered rather than falling back to a glyph.
-  const avatar = useAvatar();
+  //
+  // TEMPORARY (sky-theme testing): while the bottom-bar hour chip is
+  // overriding the sky clock, the mark swaps to the bundled sky-avatar
+  // frame for the overridden hour, so the avatar steps through the day
+  // in lockstep with the palette. Remove alongside the chip.
+  const liveAvatar = useAvatar();
+  const { theme, skyHour, skyOverridden } = useTheme();
+  const avatar =
+    (theme === 'sky' && skyOverridden ? skyAvatarUrl(skyHour) : null) || liveAvatar;
   const [avatarBroken, setAvatarBroken] = useState(false);
   const showAvatar = avatar && !avatarBroken;
   // A new hourly avatar URL gets a fresh chance to load — clear any prior

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -56,6 +56,15 @@ function applyTheme(theme, skyHour) {
   applyThemeColor(color);
 }
 
+// State for the iOS re-tint scroll nudge below. Module-level so
+// overlapping nudges (rapid theme/hour changes — e.g. mashing the sky
+// hour chip) share one TRUE baseline: a later nudge must not read the
+// 1px-displaced position left by an earlier one as its "original"
+// scroll position, or each overlap leaks a permanent 1px downward
+// creep when the racing restores land out of order.
+let nudgeBaseY = null;
+let nudgeRestoreRaf = 0;
+
 function applyThemeColor(color) {
   if (typeof document === 'undefined') return;
   const head = document.head;
@@ -69,12 +78,17 @@ function applyThemeColor(color) {
   // iOS Safari re-evaluates its status bar / URL bar tint at the END
   // of a user gesture (touchend). Nudging a 1px scroll provokes the
   // re-tint pass; without this, the chrome stays on the previous
-  // theme's color until the next scroll/tap.
+  // theme's color until the next scroll/tap. Re-entrant: the baseline
+  // is captured once per settled position and the pending restore is
+  // cancelled, so back-to-back nudges always restore to where the page
+  // actually started.
   try {
-    const y = window.scrollY || window.pageYOffset || 0;
-    window.scrollTo(0, y + 1);
-    requestAnimationFrame(() => {
-      window.scrollTo(0, y);
+    if (nudgeBaseY == null) nudgeBaseY = window.scrollY || window.pageYOffset || 0;
+    window.scrollTo(0, nudgeBaseY + 1);
+    cancelAnimationFrame(nudgeRestoreRaf);
+    nudgeRestoreRaf = requestAnimationFrame(() => {
+      window.scrollTo(0, nudgeBaseY);
+      nudgeBaseY = null;
     });
   } catch {}
 }
@@ -96,8 +110,19 @@ export function ThemeProvider({ children }) {
   const skyHourRef = useRef(skyHour);
   skyHourRef.current = skyHour;
 
+  // What applyTheme last painted. The click handlers below apply
+  // synchronously (for the iOS same-gesture theme-color) and then set
+  // state; without this guard the state-driven effect would re-apply the
+  // identical theme+hour right after — a second scroll nudge per tap.
+  const appliedRef = useRef(null);
+  const applySig = (t, h) => (t === 'sky' ? `sky:${h}` : t);
+
   useEffect(() => {
-    applyTheme(theme, skyHour);
+    const sig = applySig(theme, skyHour);
+    if (appliedRef.current !== sig) {
+      applyTheme(theme, skyHour);
+      appliedRef.current = sig;
+    }
     try {
       localStorage.setItem(STORAGE_KEY, theme);
     } catch {}
@@ -134,6 +159,7 @@ export function ThemeProvider({ children }) {
     // Apply synchronously inside the click handler so iOS Safari sees
     // the updated theme-color meta during the same user gesture.
     applyTheme(next, skyHourRef.current);
+    appliedRef.current = applySig(next, skyHourRef.current);
     setThemeState(next);
     if (next !== 'sky') setSkyOverride(null);
   }, []);
@@ -143,6 +169,7 @@ export function ThemeProvider({ children }) {
       const idx = VALID.indexOf(prev);
       const next = VALID[(idx + 1) % VALID.length];
       applyTheme(next, skyHourRef.current);
+      appliedRef.current = applySig(next, skyHourRef.current);
       if (next !== 'sky') setSkyOverride(null);
       return next;
     });
@@ -155,6 +182,7 @@ export function ThemeProvider({ children }) {
     const next = (skyHourRef.current + 1) % 24;
     // Sync apply for the same iOS theme-color gesture reason as setTheme.
     applyTheme('sky', next);
+    appliedRef.current = applySig('sky', next);
     setSkyOverride(next);
   }, []);
 

--- a/src/lib/skyAvatars.js
+++ b/src/lib/skyAvatars.js
@@ -1,0 +1,28 @@
+// The 24 hourly sky-avatar frames (the same art the live Bluesky avatar
+// cycles through — see the "automated dynamic avatar" blog post), keyed
+// by Eastern hour. Bundled through Vite as hashed assets because bare
+// /images paths aren't reliably served in production (the SPA catch-all
+// rewrite swallows them — same reason api/favicon.js embeds its art).
+// Only the frame actually displayed is ever fetched.
+//
+// Used by the chrome-bar brand mark while the TEMPORARY sky-theme hour
+// chip is overriding the clock: the mark swaps from the live Bluesky
+// avatar to the frame matching the overridden hour, so avatar + palette
+// step through the day together. Remove alongside the chip.
+
+import { avatarKeys } from '../../og/time.js';
+
+const KEYS = avatarKeys();
+
+const FRAMES = import.meta.glob('../../images/sky-avatars/*.jpg', {
+  eager: true,
+  query: '?url',
+  import: 'default',
+});
+
+/** Bundled asset URL for the sky-avatar frame of an hour 0–23 (null if
+ *  the frame is missing, so callers can fall back to the live avatar). */
+export function skyAvatarUrl(hour) {
+  const key = KEYS[((hour % 24) + 24) % 24];
+  return FRAMES[`../../images/sky-avatars/${key}.jpg`] || null;
+}


### PR DESCRIPTION
Two changes to the TEMPORARY sky-theme test chip:

- **The chip now steps the top-chrome avatar along with the palette.** While the chip is overriding the clock, the brand mark swaps from the live Bluesky avatar to the bundled sky-avatar frame for the overridden hour (`images/sky-avatars`, piped through Vite as hashed assets since bare `/images` paths get swallowed by the SPA rewrite in production — only the displayed frame downloads). Leaving sky mode or the natural hourly tick restores the live avatar.
- **Fixes the page scrolling down ~1px per chip tap.** The iOS re-tint hack in `applyThemeColor` (scroll 1px, restore next frame) ran twice per tap — sync gesture apply + state effect — and overlapping nudges adopted the still-displaced position as their restore baseline, leaking 1px per overlap. The nudge now captures one true baseline across overlaps (cancelling the pending restore), and the effect skips re-applying a theme+hour the gesture path already painted.

Verified: avatar src steps in lockstep with the chip label, and 20 rapid taps at scrollY 800 produce zero drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS)_