### PR TITLE
Ledger reposts render as quote boxes; day stats at label scale

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1422,9 +1422,10 @@ a.reference-card-profile:focus-visible {
   font-size: var(--text-lg);
 }
 
+/* Day stats sit at the same scale as the rows' gerund/time labels. */
 .feed-ledger .day-header-meta {
   font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.95);
+  font-size: calc(var(--text-xs) * 0.85);
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-align: right;
@@ -1678,6 +1679,28 @@ a.ledger-verb:focus-visible {
   display: none;
 }
 
+/* Reposts render as a quote-style box (FeedLedgerRow's RepostQuote).
+   The original post IS the row's content, so unlike a quote nested
+   inside a post its text stays unclamped and its own media renders —
+   still height-capped by the rules above. Quotes nested inside the
+   reposted post stay dropped. */
+.ledger-repost .post-embed-quote-text {
+  display: block;
+  overflow: visible;
+}
+
+.ledger-repost .post-embed-quote > .post-embed-images {
+  display: grid;
+}
+
+.ledger-repost .post-embed-quote > .post-embed-video {
+  display: block;
+}
+
+.ledger-repost .post-embed-quote > .post-embed-link-card {
+  display: grid;
+}
+
 /* Text-less posts: the embed is the row's only content. Baseline row
    alignment would sink the verb/time labels to the embed's bottom
    edge, so those rows top-align instead, with a nudge that sits the
@@ -1706,7 +1729,8 @@ a.ledger-verb:focus-visible {
   }
 
   .feed-ledger .ledger-verb,
-  .feed-ledger .ledger-time {
+  .feed-ledger .ledger-time,
+  .feed-ledger .day-header-meta {
     font-size: calc(var(--text-xs) * 0.8);
   }
 

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -6,6 +6,7 @@ import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import PostEmbed from './PostEmbed.jsx';
+import RelativeTimeText from './RelativeTimeText.jsx';
 import { ME_DID } from '../config.js';
 
 /**
@@ -55,8 +56,11 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
       : LEDGER_VERB_LABELS[item.verb] || item.verb;
   const ts =
     item.createdAt || item.payload?.createdAt || item.payload?.indexedAt || null;
-  const summary = summarize(item, { expanded, onToggle });
-  const embed = ledgerEmbed(item);
+  // Reposts skip the inline "@handle: text" summary entirely — the
+  // original post renders as a quote-style box instead (see RepostQuote).
+  const isRepost = item.verb === 'reposting';
+  const summary = isRepost ? null : summarize(item, { expanded, onToggle });
+  const embed = isRepost ? null : ledgerEmbed(item);
   return (
     <>
       {/* Label-less rows (thread continuations) keep an empty verb cell
@@ -71,6 +75,7 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
         <span className="ledger-verb">{label}</span>
       )}
       <div className="ledger-body">
+        {isRepost && <RepostQuote item={item} />}
         {summary && <p className="ledger-text">{summary}</p>}
         {embed && (
           <div className="ledger-embed">
@@ -101,15 +106,86 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
 /**
  * Post embeds (images / video / link card / quote) ride along under the
  * summary line in a condensed, height-capped form (see the .ledger-embed
- * rules in Feed.css). Only posting/reposting rows carry one.
+ * rules in Feed.css). Only posting rows carry one — reposts render their
+ * whole payload as a quote box instead (RepostQuote below).
  */
 function ledgerEmbed(item) {
-  if (item.verb !== 'posting' && item.verb !== 'reposting') return null;
+  if (item.verb !== 'posting') return null;
   const payload = item.payload || {};
-  if (payload.subjectMissing) return null;
   const embed = payload.embed || payload.embedRecord || null;
   if (!embed) return null;
   return { embed, did: payload.author?.did };
+}
+
+/**
+ * A repost's body: the original post styled like a quote embed —
+ * mirrors PostEmbed's QuoteRecord markup so it inherits the condensed
+ * quote treatment wholesale. The head's timestamp links out to the
+ * original on bsky.app; unlike a quote nested inside a post, the box
+ * IS the row's content, so its text stays unclamped and its own media
+ * renders (see the .ledger-repost overrides in Feed.css).
+ */
+function RepostQuote({ item }) {
+  const payload = item.payload || {};
+  if (payload.subjectMissing) {
+    return (
+      <p className="ledger-text">
+        <Placeholder>an unavailable post</Placeholder>
+      </p>
+    );
+  }
+  const author = payload.author || {};
+  const ts = payload.indexedAt || null;
+  const externalHref =
+    author.handle && payload.subjectUri
+      ? `https://bsky.app/profile/${author.handle}/post/${String(payload.subjectUri).split('/').pop()}`
+      : author.handle
+        ? `https://bsky.app/profile/${author.handle}`
+        : null;
+  const embed = payload.embed || payload.embedRecord || null;
+  return (
+    <div className="ledger-embed ledger-repost">
+      <article className="post-embed-quote">
+        <header className="post-embed-quote-head">
+          {author.avatar && (
+            <img
+              className="post-embed-quote-avatar"
+              src={author.avatar}
+              alt=""
+              width={20}
+              height={20}
+              loading="lazy"
+            />
+          )}
+          <span className="post-embed-quote-author">
+            {author.displayName && (
+              <span className="post-embed-quote-name">{author.displayName}</span>
+            )}
+            {author.handle && (
+              <span className="post-embed-quote-handle">@{author.handle}</span>
+            )}
+          </span>
+          {ts && (
+            <span className="post-embed-quote-time gutter">
+              {externalHref ? (
+                <a href={externalHref} target="_blank" rel="noreferrer noopener">
+                  <RelativeTimeText value={ts} />
+                </a>
+              ) : (
+                <RelativeTimeText value={ts} />
+              )}
+            </span>
+          )}
+        </header>
+        {payload.text && (
+          <p className="post-embed-quote-text">
+            {renderPostText(payload.text, payload.facets || null)}
+          </p>
+        )}
+        {embed && <PostEmbed embed={embed} did={author.did} />}
+      </article>
+    </div>
+  );
 }
 
 function summarize(item, listenControls) {


### PR DESCRIPTION
## Summary

- **Reposts as quote boxes** — repost rows drop the inline "@handle: text" summary for a quote-style box mirroring PostEmbed's QuoteRecord markup: the original author's chip (avatar, name, @handle) with a relative timestamp linking out to the post on bsky.app. Because the box IS the row's content (unlike a quote nested inside a post), its text stays unclamped and its own media renders inside — still height-capped; quotes nested inside the reposted post stay dropped, and unavailable reposts keep their muted placeholder.
- **Day stats at label scale** — the "N items, N interactions" line beside each date steps down to the same 0.85×/0.8× mono scale as the rows' gerund and time labels.

## Verification

- Production build passes on top of the sky-chip work from #177
- Browser-verified against live data: a text+image repost and an image-only repost both render as quote boxes with media inside (`display: grid` confirmed against the nested-media hide rule); day stats measure 10.2px, identical to the row timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_