### PR TITLE
Strip NSID tracks per-record collections on /creating and /blogging

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -759,11 +759,12 @@ function useCurrentDayLabel() {
   return label;
 }
 
-/** NSID of the feed record at the top of the scroll position — the first
- *  feed row still (partly) visible below the chrome — or null on pages
- *  without feed rows. Same DOM-driven, rAF-throttled sweep as
- *  useCurrentDayLabel above; rows publish their collection via the
- *  `data-nsid` attribute FeedItem stamps on each <li>. */
+/** NSID of the record at the top of the scroll position — the first
+ *  record entry still (partly) visible below the chrome — or null on
+ *  pages without record lists. Same DOM-driven, rAF-throttled sweep as
+ *  useCurrentDayLabel above; entries publish their collection via a
+ *  `data-nsid` attribute (FeedItem rows, the /creating grid, the
+ *  /blogging table of contents). */
 function useTopFeedNsid() {
   const [nsid, setNsid] = useState(null);
   const location = useLocation();
@@ -775,7 +776,7 @@ function useTopFeedNsid() {
           getComputedStyle(document.documentElement).getPropertyValue('--chrome-top-h'),
         ) || 0;
       let current = null;
-      for (const el of document.querySelectorAll('.feed-item[data-nsid]')) {
+      for (const el of document.querySelectorAll('[data-nsid]')) {
         const rect = el.getBoundingClientRect();
         if (rect.height > 0 && rect.bottom > chromeBottom + 12) {
           current = el.dataset.nsid;

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -9,6 +9,7 @@ import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, formatDateFull, compareIsoDesc } from '../lib/time.js';
 import { isPortfolioDoc } from '../lib/publications.js';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
 import './Blogging.css';
@@ -68,7 +69,11 @@ export default function Blogging() {
       ) : (
         <ol className="blogging-toc reveal-stagger">
           {filtered.map((e, i) => (
-            <li key={e.uri || i} className="blogging-toc-entry">
+            <li
+              key={e.uri || i}
+              className="blogging-toc-entry"
+              data-nsid={nsidFromAtUri(e.uri) || undefined}
+            >
               <Link to={e.href} className="blogging-toc-link">
                 <span className="blogging-toc-num gutter">{String(i + 1).padStart(2, '0')}</span>
                 <span className="blogging-toc-body">

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -13,6 +13,7 @@ import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
 import { coverThumb } from '../lib/creatingHelpers.js';
 import { isPortfolioDoc, workSlug, workCategory } from '../lib/publications.js';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/FeedFilters.css';
 import './Creating.css';
@@ -25,7 +26,7 @@ function WorkCard({ record }) {
   const thumb = coverThumb(v);
   const category = workCategory(v);
   return (
-    <li className="creating-grid-cell">
+    <li className="creating-grid-cell" data-nsid={nsidFromAtUri(record.uri) || undefined}>
       <Link to={`/creating/${slug}`} className="creating-grid-link">
         {thumb ? (
           <img src={thumb.url} alt={thumb.alt || ''} loading="lazy" />


### PR DESCRIPTION
## Summary

The /creating grid cells and /blogging table-of-contents entries now stamp their record's collection via the same `data-nsid` attribute the feed rows use, and the chrome's top-visible sweep reads any `[data-nsid]` element instead of only feed rows. The breadcrumb strip's NSID therefore reflects the record actually at the top of the scroll position on those pages — `site.standard.document` for standard-site works rather than the registry's `is.dame.creating.work` default — switching as you scroll across mixed collections.

## Verification

- Production build passes on top of the sky-avatar work from #178
- Browser-verified: /blogging entries all stamp `site.standard.document` and the chip tracks them while scrolling; /creating (portfolio standard-docs) shows `site.standard.document` instead of `is.dame.creating.work`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_