### PR TITLE
Footer resolves the page-registered record (/for-hire resume timestamps)

### DIFF
--- a/src/components/RecordTimestamp.jsx
+++ b/src/components/RecordTimestamp.jsx
@@ -1,4 +1,6 @@
+import { useLocation } from 'react-router-dom';
 import { useAtUri } from '../hooks/useAtUri.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useFeedFooter } from '../hooks/useFeedFooter.jsx';
 import { relativeTime } from '../lib/time.js';
 
@@ -26,7 +28,18 @@ export default function RecordTimestamp() {
 }
 
 function RouteRecordTimestamp() {
-  const { record } = useAtUri();
+  const location = useLocation();
+  const { pageRecord } = useEditMode();
+  // Prefer the record the page registered via PageShell over pure route
+  // derivation — routes whose backing record is picked dynamically
+  // (/for-hire's active is.dame.resume) can't be derived from the URL
+  // alone. Path-guarded so a stale registration from the previous page
+  // never leaks in mid-navigation.
+  const registered =
+    pageRecord?.atUri && pageRecord.path === location.pathname
+      ? { atUri: pageRecord.atUri, cid: pageRecord.cid }
+      : undefined;
+  const { record } = useAtUri(registered);
   const value = record?.value || record;
   // Different lexicons name their primary timestamp differently —
   // site.standard.document / leaflet use `publishedAt`, teal.fm uses

--- a/src/hooks/useAtUri.js
+++ b/src/hooks/useAtUri.js
@@ -117,6 +117,11 @@ function deriveFromRoute(pathname, override) {
       atUri: override.atUri,
       cid: override.cid || null,
       lexicon: override.lexicon || lexiconFromAtUri(override.atUri),
+      // Carry the rkey so the generic by-rkey snapshot/PDS lookups can
+      // resolve override-driven records (e.g. /for-hire's dynamically
+      // selected is.dame.resume) — collections without a bespoke branch
+      // below would otherwise never fetch.
+      rkey: override.rkey || rkeyFromAtUri(override.atUri) || null,
       record: override.record || null,
       route: pathname,
     };


### PR DESCRIPTION
## Summary

The footer's "written … · updated …" line derived its backing record purely from the route, so /for-hire — whose backing `is.dame.resume` record is picked dynamically in admin — resolved to nothing and showed dashes.

- `RecordTimestamp` now prefers the record the page registered via PageShell (the override pattern `AtUriHead` already used), path-guarded so a stale registration from the previous page can't leak in mid-navigation
- `useAtUri`'s override branch carries the rkey derived from the at-uri, so generic collections without a bespoke lookup branch (like `is.dame.resume`) can fetch from the PDS

## Verification

- Production build passes on top of #181
- Browser-verified: /for-hire now shows "written 1d ago"; home still shows "latest record …", blog posts still show "written 7mo ago", and /themself is unchanged (its profile record carries no timestamps — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYBMShzWCdNtwqc7ZJBiyQ)_