### PR TITLE
Cross-post standard docs to both feeds; pin breadcrumb on detail pages

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -88,7 +88,15 @@ export default function ChromeBar() {
   const crumbs = buildCrumbs(location.pathname);
   const scrolledDown = useScrolledDown();
   const dayLabel = useCurrentDayLabel();
-  const showBreadcrumb = scrolledDown && (crumbs.length > 0 || !!dayLabel);
+  // Individual (detail) pages — anything two or more segments deep, e.g.
+  // /blogging/:slug, /creating/:slug, /curating/:slug, or a generic record —
+  // pin the breadcrumb open as their standing back-affordance (it replaces
+  // the old per-page "← Section" eyebrow), so the trail is always there and a
+  // dual-listed doc keeps whichever feed it was opened from as its parent
+  // crumb. Feed/index pages keep the scroll-triggered reveal.
+  const isDetailPage = crumbs.length >= 2;
+  const showBreadcrumb =
+    isDetailPage || (scrolledDown && (crumbs.length > 0 || !!dayLabel));
 
   // Right edge of the strip: the AT Protocol collection you're looking
   // at. On feed pages it tracks the record at the top of the scroll

--- a/src/components/PageShell.jsx
+++ b/src/components/PageShell.jsx
@@ -6,7 +6,7 @@ import { useEditMode } from '../hooks/useEditMode.jsx';
  * Shared page container — optional title + intro (each only renders when
  * provided), plus the AT URI <head> hints for the route's backing record.
  */
-export default function PageShell({ title, intro, atUri, cid, children, headTitle, eyebrow }) {
+export default function PageShell({ title, intro, atUri, cid, children, headTitle }) {
   // Publish the route's backing record to edit mode so the owner's quick-edit
   // sheet can target "this page" (a blog post, the home page record, etc.).
   const { registerPageRecord } = useEditMode();
@@ -17,7 +17,6 @@ export default function PageShell({ title, intro, atUri, cid, children, headTitl
   return (
     <article className="page">
       <AtUriHead atUri={atUri} cid={cid} title={headTitle} />
-      {eyebrow && <div className="page-eyebrow">{eyebrow}</div>}
       {title && (
         <h1 className="page-title">
           {title}

--- a/src/hooks/useAtUri.js
+++ b/src/hooks/useAtUri.js
@@ -4,7 +4,7 @@ import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, getRecord, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import { VERB_TO_COLLECTION, RECORD_ROUTE_SEGMENTS } from '../lib/recordRoutes.js';
-import { isPortfolioDoc, workSlug } from '../lib/publications.js';
+import { showOnCreating, workSlug } from '../lib/publications.js';
 
 const STANDARD_DOC = 'site.standard.document';
 
@@ -238,11 +238,16 @@ async function loadFromSnapshots(info) {
       : null;
   }
   if (info.lexicon === COLLECTIONS.creating && info.slug) {
-    // Portfolio works are site.standard.document records (in `blogs`, matched
-    // by path) plus any legacy is.dame.creating.work (in `creations`).
+    // Creative works are site.standard.document records (in `blogs`, matched
+    // by path — or rkey for a blog-homed doc cross-posted here without one)
+    // plus any legacy is.dame.creating.work (in `creations`).
     const blogs = await fetchSnapshot('blogs');
     const std = Array.isArray(blogs)
-      ? blogs.find((r) => isPortfolioDoc(r?.value) && workSlug(r.value) === info.slug)
+      ? blogs.find(
+          (r) =>
+            showOnCreating(r?.value) &&
+            (workSlug(r.value) === info.slug || rkeyFromAtUri(r?.uri) === info.slug),
+        )
       : null;
     if (std) return mirrorLeafletTimestamps(std);
     const works = await fetchSnapshot('creations');
@@ -312,7 +317,12 @@ async function fetchRecordFromPds(pds, info) {
   }
   if (info.lexicon === COLLECTIONS.creating && info.slug) {
     const std = await listRecords(pds, { repo: ME_DID, collection: STANDARD_DOC, max: 200 }).catch(() => []);
-    const byStd = std.find((r) => isPortfolioDoc(r?.value) && workSlug(r.value) === info.slug) || null;
+    const byStd =
+      std.find(
+        (r) =>
+          showOnCreating(r?.value) &&
+          (workSlug(r.value) === info.slug || rkeyFromAtUri(r?.uri) === info.slug),
+      ) || null;
     if (byStd) return mirrorLeafletTimestamps(byStd);
     const recs = await listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.creating, max: 200 }).catch(() => []);
     return recs.find((r) => workSlug(r?.value) === info.slug) || null;

--- a/src/lib/publications.js
+++ b/src/lib/publications.js
@@ -1,23 +1,62 @@
 // Classify `site.standard.document` records by the publication they belong
 // to. Creative works and blog posts share the same record type; their `site`
 // field (an `at://` URI pointing at a `site.standard.publication`) is what
-// decides where they surface. See `PORTFOLIO_PUBLICATION` in config.js.
+// decides their *home* feed. See `PORTFOLIO_PUBLICATION` in config.js.
+//
+// A doc can also be cross-posted so it's a first-class member of *both*
+// /creating and /blogging. That's opt-in via a reserved, directional tag on
+// the record: `blog` (or `blogging`) additionally surfaces a portfolio-homed
+// doc on the blog; `creating` (or `portfolio`) additionally surfaces a
+// blog-homed doc on /creating. The `site` field stays the doc's canonical
+// home either way — the tag is purely additive.
 
 import { PORTFOLIO_PUBLICATION } from '../config.js';
 
-/** True when a standard-document value belongs to the portfolio publication. */
+// Reserved cross-post tags, matched case-insensitively and kept out of the
+// visible category (see `workCategory`) so they never render as a medium chip.
+const BLOG_TAGS = new Set(['blog', 'blogging']);
+const CREATING_TAGS = new Set(['creating', 'portfolio']);
+const RESERVED_TAGS = new Set([...BLOG_TAGS, ...CREATING_TAGS]);
+
+function tagList(value) {
+  return Array.isArray(value?.tags) ? value.tags : [];
+}
+
+function hasAnyTag(value, set) {
+  return tagList(value).some((t) => set.has(String(t).trim().toLowerCase()));
+}
+
+/** True when a standard-document value's home publication is the portfolio. */
 export function isPortfolioDoc(value) {
   if (!PORTFOLIO_PUBLICATION) return false;
   return value?.site === PORTFOLIO_PUBLICATION;
 }
 
 /**
- * True when a standard-document value should render on the blog. Anything
- * that isn't a portfolio doc is a blog post — including, while
+ * True when a standard-document value's home feed is the blog. Anything not
+ * homed in the portfolio is a blog post — including, while
  * `PORTFOLIO_PUBLICATION` is unset, everything (legacy behavior).
  */
 export function isBlogDoc(value) {
   return !isPortfolioDoc(value);
+}
+
+/**
+ * True when a standard-document value should surface on /creating — either
+ * the portfolio is its home publication, or a blog-homed doc opts in with a
+ * directional `creating`/`portfolio` tag.
+ */
+export function showOnCreating(value) {
+  return isPortfolioDoc(value) || hasAnyTag(value, CREATING_TAGS);
+}
+
+/**
+ * True when a standard-document value should surface on /blogging — either
+ * the blog is its home feed, or a portfolio-homed doc opts in with a
+ * directional `blog` tag.
+ */
+export function showOnBlog(value) {
+  return isBlogDoc(value) || hasAnyTag(value, BLOG_TAGS);
 }
 
 /**
@@ -39,6 +78,9 @@ export function workSlug(value) {
 export function workCategory(value) {
   if (value?.category) return value.category;
   if (value?.kind) return value.kind;
-  const tags = Array.isArray(value?.tags) ? value.tags : [];
-  return tags[0] || '';
+  // Skip reserved cross-post tags so a `blog`/`creating` marker never shows
+  // up as the work's medium; the first real tag stands in as the category.
+  return (
+    tagList(value).find((t) => !RESERVED_TAGS.has(String(t).trim().toLowerCase())) || ''
+  );
 }

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -10,7 +10,7 @@ import { formatDateLong, relativeTime } from '../lib/time.js';
 import { dayOfLife } from '../lib/dayOfLife.js';
 import { getPostThread } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
-import { isPortfolioDoc } from '../lib/publications.js';
+import { showOnBlog } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Blogging.css';
 
@@ -132,8 +132,9 @@ export default function BlogPost() {
 function resolveById(data, id) {
   // `data` is the `blogs` array of site.standard.document records.
   const blogs = Array.isArray(data) ? data : [];
-  // Portfolio standard-docs are creative works, not blog posts.
-  const standard = blogs.find((r) => endsWithRkey(r?.uri, id) && !isPortfolioDoc(r?.value));
+  // Blog-homed docs, plus any portfolio doc cross-posted to the blog with a
+  // `blog` tag — so a dual-listed work resolves at /blogging/:rkey too.
+  const standard = blogs.find((r) => endsWithRkey(r?.uri, id) && showOnBlog(r?.value));
   return standard ? { kind: 'standard', record: standard } : null;
 }
 
@@ -149,11 +150,6 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
       atUri={record?.uri}
       cid={record?.cid}
       headTitle={`${title} — dame.is`}
-      eyebrow={
-        <Link to="/blogging" className="page-back small-caps">
-          ← Blog
-        </Link>
-      }
     >
       <article className="blog-article reveal">
         <div className="blog-article-meta">

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -8,7 +8,7 @@ import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, formatDateFull, compareIsoDesc } from '../lib/time.js';
-import { isPortfolioDoc } from '../lib/publications.js';
+import { showOnBlog } from '../lib/publications.js';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
@@ -16,9 +16,10 @@ import './Blogging.css';
 
 /**
  * The blog index. Backed by `site.standard.document` records (in the
- * `blogs` snapshot), addressed by rkey. Portfolio standard-docs are filtered
- * out — they live on /creating. (pub.leaflet.document is deprecated and no
- * longer fetched.)
+ * `blogs` snapshot), addressed by rkey. Portfolio-homed standard-docs are
+ * filtered out — they live on /creating — unless one opts back in with a
+ * `blog` cross-post tag (see `showOnBlog`). (pub.leaflet.document is
+ * deprecated and no longer fetched.)
  */
 export default function Blogging() {
   const [params] = useSearchParams();
@@ -102,8 +103,9 @@ function mergeBlogEntries(data) {
   // records. (pub.leaflet.document is deprecated and no longer fetched.)
   const blogs = Array.isArray(data) ? data : [];
   return blogs
-    // Portfolio standard-docs live on /creating, not the blog.
-    .filter((r) => r?.value && !isPortfolioDoc(r.value))
+    // Blog-homed docs plus any portfolio doc cross-posted with a `blog` tag.
+    // Portfolio-only docs live on /creating.
+    .filter((r) => r?.value && showOnBlog(r.value))
     .map(normalizeStandard)
     .sort((a, b) => compareIsoDesc(a.createdAt, b.createdAt));
 }

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -8,11 +8,11 @@ import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
-import { resolvePds, listRecords } from '../lib/atproto.js';
+import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
 import { coverThumb } from '../lib/creatingHelpers.js';
-import { isPortfolioDoc, workSlug, workCategory } from '../lib/publications.js';
+import { showOnCreating, workSlug, workCategory } from '../lib/publications.js';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/FeedFilters.css';
@@ -22,7 +22,9 @@ const STANDARD_DOC = 'site.standard.document';
 
 function WorkCard({ record }) {
   const v = record.value || {};
-  const slug = workSlug(v);
+  // Blog-homed docs cross-posted here may lack a `path`; fall back to the
+  // rkey so the link still resolves at /creating/:slug.
+  const slug = workSlug(v) || rkeyFromAtUri(record.uri);
   const thumb = coverThumb(v);
   const category = workCategory(v);
   return (
@@ -52,8 +54,9 @@ const COVER_WAIT = 12;
  * Creative works now live as `site.standard.document` records in the
  * portfolio publication; legacy `is.dame.creating.work` records are read
  * alongside them so nothing is orphaned during the migration. Standard docs
- * arrive via the `blogs` snapshot (filtered to the portfolio publication);
- * legacy works via `creations`.
+ * arrive via the `blogs` snapshot, filtered by `showOnCreating` (portfolio-
+ * homed docs, plus any blog-homed doc cross-posted here with a `creating`
+ * tag); legacy works via `creations`.
  */
 async function loadWorks() {
   const pds = await resolvePds(ME_DID);
@@ -63,7 +66,7 @@ async function loadWorks() {
   ]);
   transformRecords(stdDocs, STANDARD_DOC, pds, ME_DID);
   transformRecords(legacy, COLLECTIONS.creating, pds, ME_DID);
-  return [...stdDocs.filter((r) => isPortfolioDoc(r?.value)), ...legacy];
+  return [...stdDocs.filter((r) => showOnCreating(r?.value)), ...legacy];
 }
 
 export default function Creating() {
@@ -78,7 +81,7 @@ export default function Creating() {
         fetchSnapshot('creations'),
         fetchSnapshot('blogs'),
       ]);
-      const std = Array.isArray(blogs) ? blogs.filter((r) => isPortfolioDoc(r?.value)) : [];
+      const std = Array.isArray(blogs) ? blogs.filter((r) => showOnCreating(r?.value)) : [];
       return [...std, ...(Array.isArray(creations) ? creations : [])];
     },
     fetchLive: loadWorks,

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -9,7 +9,7 @@ import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { formatDateLong } from '../lib/time.js';
-import { isPortfolioDoc, workSlug, workCategory } from '../lib/publications.js';
+import { showOnCreating, workSlug, workCategory } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Blogging.css';
@@ -26,7 +26,7 @@ export default function CreatingWork() {
         fetchSnapshot('creations'),
         fetchSnapshot('blogs'),
       ]);
-      const std = Array.isArray(blogs) ? blogs.filter((r) => isPortfolioDoc(r?.value)) : [];
+      const std = Array.isArray(blogs) ? blogs.filter((r) => showOnCreating(r?.value)) : [];
       return [...std, ...(Array.isArray(creations) ? creations : [])];
     },
     fetchLive: async () => {
@@ -37,7 +37,7 @@ export default function CreatingWork() {
       ]);
       transformRecords(stdDocs, STANDARD_DOC, pds, ME_DID);
       transformRecords(legacy, COLLECTIONS.creating, pds, ME_DID);
-      return [...stdDocs.filter((r) => isPortfolioDoc(r?.value)), ...legacy];
+      return [...stdDocs.filter((r) => showOnCreating(r?.value)), ...legacy];
     },
     mapItems: (snap) => {
       if (!Array.isArray(snap)) return null;
@@ -89,11 +89,6 @@ export default function CreatingWork() {
       atUri={record?.uri}
       cid={record?.cid}
       headTitle={v?.title ? `${v.title} — dame.is` : `${slug} — dame.is`}
-      eyebrow={
-        <Link to="/creating" className="page-back small-caps">
-          ← Portfolio
-        </Link>
-      }
     >
       <article className="creating-work-page reveal">
         <div className="blog-article-meta">

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -122,11 +122,6 @@ export default function CuratingChannel() {
       title={arenaText(gallery.title) || undefined}
       intro={arenaText(gallery.description) || undefined}
       headTitle={`${gallery.title} — dame.is`}
-      eyebrow={
-        <Link to="/curating" className="page-back small-caps">
-          ← Curating
-        </Link>
-      }
     >
       <div className="curating-channel-meta gutter">
         <span>{gallery.blockCount} {gallery.blockCount === 1 ? 'block' : 'blocks'}</span>

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -195,11 +195,6 @@ export default function Record({ verb, nsid, source }) {
       atUri={atUri}
       cid={cid}
       headTitle={headTitleFor(verb, item)}
-      eyebrow={
-        <Link to={`/${verb}`} className="page-back small-caps">
-          ← {verb}
-        </Link>
-      }
     >
       <article className="record-page">
         {(verb === 'posting' || verb === 'reposting') && parents.length > 0 && (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -66,22 +66,6 @@
   gap: var(--space-5);
 }
 
-/* Eyebrow: a small back/breadcrumb link above the page title. */
-.page-eyebrow {
-  margin-bottom: var(--space-3);
-}
-
-.page-back {
-  color: var(--ink-muted);
-  text-decoration: none;
-  transition: color 120ms ease;
-}
-
-.page-back:hover,
-.page-back:focus-visible {
-  color: var(--accent);
-}
-
 .page-title {
   font-family: var(--serif);
   font-weight: 600;


### PR DESCRIPTION
## Summary

Lets a single `site.standard.document` be a first-class member of **both** `/creating` and `/blogging`, and replaces the per-page back-link eyebrow with the always-on top-chrome breadcrumb on individual pages.

### Dual-feed membership
A doc's `site` field stays its canonical home ("default main"). A reserved, directional tag opts it into the other feed:

- `blog` / `blogging` → also surface a portfolio-homed doc on `/blogging`
- `creating` / `portfolio` → also surface a blog-homed doc on `/creating`

Implementation:
- `publications.js`: adds non-exclusive `showOnCreating` / `showOnBlog` alongside the home-publication predicates; reserved cross-post tags are kept out of the visible category chip.
- Both feed indexes, both detail resolvers, and the `useAtUri` head/URI lookup route through the new predicates, with an rkey fallback for a cross-posted doc that lacks a slug.
- The **home-feed verb** still keys off the home publication (`feedBuilder`), so a doc appears once in the home feed but in both section indexes — no duplication.

### Breadcrumb replaces the eyebrow
The breadcrumb is derived from the URL path, so a dual-listed doc keeps whichever feed it was opened from as its parent crumb (back to `/creating` from `/creating/:slug`, back to `/blogging` from `/blogging/:rkey`) — something the fixed single-destination eyebrow couldn't express.

- `ChromeBar`: pins the breadcrumb open on detail routes (`crumbs.length >= 2`); feed/index pages keep the scroll-triggered reveal.
- Removes the `eyebrow` prop from `PageShell` and its four call sites, plus the now-dead `.page-eyebrow` / `.page-back` styles.

## Testing
- `npm run build` passes.
- Classifier truth table verified for all four cases (portfolio, portfolio + `blog`, blog, blog + `creating`).
- Browser check: breadcrumb is pinned (opacity 1, no transform) on a detail route with the eyebrow gone, and stays hidden at the top of `/creating` and `/` (opacity 0, translated up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P81KybXzJr8jbFfFM21B1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01P81KybXzJr8jbFfFM21B1Q)_