### PR TITLE
Lab records: faithful renders + link to the Anisota piece page

### DIFF
--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -225,7 +225,10 @@ async function main() {
     pds,
     me: ME_DID,
     appview: APPVIEW,
-    options: { log, warn },
+    // leanMedia: keep the big inline PNG/SVG data-URLs out of the static
+    // snapshot JSON (the live in-memory feed and the record page still show
+    // the real media).
+    options: { log, warn, leanMedia: true },
   });
 
   await writeJson('posts', authorFeed);

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1416,6 +1416,106 @@ a.reference-card-profile:focus-visible {
   padding: var(--space-3);
 }
 
+/* Word Magnets poem — cream tiles re-laid faithfully from the saved board
+   (see src/lib/anisotaLab.js). The field is a container so the tile font,
+   emitted in cqw, scales with the field width; overflow hides anything the
+   6% padding pushes past the frame. */
+.lab-poem-field {
+  position: relative;
+  width: 100%;
+  max-width: 24rem;
+  margin: 0;
+  container-type: inline-size;
+  overflow: hidden;
+  border: 1px solid var(--rule-soft);
+  background: var(--page);
+}
+
+.lab-poem-tile {
+  position: absolute;
+  font-size: var(--tile-font);
+  transform: translate(-50%, -50%) rotate(var(--rot, 0deg));
+  transform-origin: center;
+  padding: 0.28em 0.5em;
+  line-height: 1;
+  white-space: nowrap;
+  font-family: var(--serif);
+  /* Cream paper magnets — their own physical object, so they read the same in
+     every dame.is theme rather than tracking the page palette. */
+  background: linear-gradient(#fbf7ee, #efe7d6);
+  color: #1a1714;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.14);
+}
+
+.lab-poem-tile.is-fragment {
+  background: linear-gradient(#efe7d6, #e4d9c2);
+  color: #4a3f30;
+  font-style: italic;
+}
+
+/* Erasure poem — the source post's original text with redacted words blacked
+   out by an ink bar, the surviving found poem beneath. */
+.lab-redaction {
+  margin: 0;
+  font-family: var(--serif);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-width: var(--measure);
+  line-height: 1.85;
+}
+
+.lab-redaction-word.is-redacted {
+  position: relative;
+  color: transparent;
+}
+
+.lab-redaction-word.is-redacted::after {
+  content: '';
+  position: absolute;
+  top: 0.06em;
+  bottom: 0.06em;
+  left: -0.04em;
+  right: -0.04em;
+  background: var(--ink);
+  pointer-events: none;
+}
+
+.lab-redaction-found {
+  margin: var(--space-3) 0 0;
+  font-style: italic;
+  color: var(--ink-soft);
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+/* "view on anisota" link on the single-record page. */
+.lab-card-source {
+  align-self: flex-start;
+  color: var(--accent);
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.lab-card-source:hover {
+  border-bottom-color: var(--accent-soft);
+}
+
+/* The single-record page gives each piece more room than the feed card. */
+.lab-card-record .lab-poem-field {
+  max-width: 34rem;
+}
+
+.lab-card-record .lab-card-figure img {
+  max-width: 30rem;
+}
+
+.lab-card-record .lab-card-figure-sigil img {
+  max-width: 22rem;
+}
+
 /* BlogCard source tag ------------------------------------------------- */
 
 .blog-card-source {

--- a/src/components/cards/AnisotaLabCard.jsx
+++ b/src/components/cards/AnisotaLabCard.jsx
@@ -1,23 +1,31 @@
 /**
  * Renders a creative piece made in the Anisota Lab — the `crafting` verb.
  * One card handles every studio's output plus authored spells, branching on
- * the record's collection (derived from its at:// URI):
+ * the record's collection (derived from its at:// URI). Each type is rendered
+ * faithfully to how Anisota itself displays it (the layout / tokenise math is
+ * ported in src/lib/anisotaLab.js):
  *
- *   net.anisota.lab.poetry     — a Word Magnets poem (assembled text)
- *   net.anisota.lab.redaction  — an erasure/found poem (surviving words)
- *   net.anisota.lab.sigil      — a sigil, drawn as a standalone SVG
- *   net.anisota.lab.carving    — a relief print (PNG data-URL thumbnail)
+ *   net.anisota.lab.poetry     — Word Magnets poem, re-laid from tiles + board
+ *   net.anisota.lab.redaction  — erasure poem, original text with words blacked out
+ *   net.anisota.lab.sigil      — a sigil, its standalone SVG (sandboxed <img>)
+ *   net.anisota.lab.carving    — a relief print (PNG data-URL)
  *   net.anisota.lab.inkblot    — a symmetric inkblot (PNG data-URL)
  *   net.anisota.lab.petri      — a petri culture (PNG data-URL)
  *   net.anisota.lab.synth      — a multitrack synth loop (tempo/steps meta)
  *   net.anisota.spell.custom   — an authored spell (name + description)
  *
- * The bulky reproduction data (tile layouts, gouge paths, event grids…) is
- * stripped upstream in feedBuilder.transformRecords — only the finished
- * text / figure / print reaches this card.
+ * `variant="record"` is the larger treatment used on the single-record page,
+ * which also surfaces a "view on anisota" link to the piece's page there.
  */
 import { renderPlainTextWithTruncatedUrls } from '../../lib/feedUrlFormat.jsx';
 import { nsidFromAtUri } from '../../lib/verbRegistry.js';
+import {
+  computePoemLayout,
+  tokenizePost,
+  isRedactable,
+  sigilSvgDataUrl,
+  anisotaWorkUrl,
+} from '../../lib/anisotaLab.js';
 
 /** Short, lowercase label for each Lab collection — shown in small caps. */
 const KIND_LABEL = {
@@ -31,21 +39,37 @@ const KIND_LABEL = {
   'net.anisota.spell.custom': 'spell',
 };
 
-export default function AnisotaLabCard({ payload, atUri }) {
+export default function AnisotaLabCard({ payload, atUri, variant = 'feed' }) {
   const v = payload || {};
   const nsid = nsidFromAtUri(atUri);
   const kind = KIND_LABEL[nsid] || 'lab piece';
   // Inkblots carry no user name (their rkey is their identity), so only the
   // kind label leads them; every other piece can front its title.
   const title = nsid === 'net.anisota.lab.inkblot' ? null : v.name || null;
+  const isRecord = variant === 'record';
+  const anisotaUrl = isRecord ? anisotaWorkUrl(atUri) : null;
 
   return (
-    <article className="lab-card feed-card" data-at-uri={atUri} data-nsid={nsid || undefined}>
+    <article
+      className={`lab-card feed-card lab-card-${isRecord ? 'record' : 'feed'}`}
+      data-at-uri={atUri}
+      data-nsid={nsid || undefined}
+    >
       <header className="lab-card-head">
         <span className="small-caps lab-card-kind">{kind}</span>
         {title && <h3 className="lab-card-title">{title}</h3>}
       </header>
       <LabBody nsid={nsid} value={v} />
+      {anisotaUrl && (
+        <a
+          className="lab-card-source small-caps"
+          href={anisotaUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          view on anisota →
+        </a>
+      )}
     </article>
   );
 }
@@ -53,8 +77,10 @@ export default function AnisotaLabCard({ payload, atUri }) {
 function LabBody({ nsid, value: v }) {
   switch (nsid) {
     case 'net.anisota.lab.poetry':
+      return <PoemBody value={v} />;
+
     case 'net.anisota.lab.redaction':
-      return v.text ? <p className="lab-card-text">{v.text}</p> : null;
+      return <RedactionBody value={v} />;
 
     case 'net.anisota.spell.custom':
       return v.description ? (
@@ -72,7 +98,7 @@ function LabBody({ nsid, value: v }) {
     }
 
     case 'net.anisota.lab.sigil': {
-      const src = sigilSvgSrc(v.svg);
+      const src = sigilSvgDataUrl(v.svg);
       return src ? (
         <div className="lab-card-figure lab-card-figure-sigil">
           <img src={src} alt={v.name ? `Sigil: ${v.name}` : 'A sigil'} loading="lazy" />
@@ -95,14 +121,64 @@ function LabBody({ nsid, value: v }) {
 }
 
 /**
- * A sigil is stored as a standalone SVG document. Render it through an
- * `<img>` data URL rather than inlining the markup, so the figure can't run
- * scripts even though it's the owner's own record. Returns null for anything
- * that isn't actually an SVG.
+ * A Word Magnets poem, re-laid from its saved tile layout. Poems that carry a
+ * `board` snapshot render as positioned cream tiles exactly as arranged; older
+ * poems (no board) fall back to the assembled `text`.
  */
-function sigilSvgSrc(svg) {
-  if (typeof svg !== 'string' || !svg.includes('<svg')) return null;
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+function PoemBody({ value: v }) {
+  const layout = computePoemLayout(v.tiles, v.board);
+  if (!layout) {
+    return v.text ? <p className="lab-card-text">{v.text}</p> : null;
+  }
+  return (
+    <div
+      className="lab-poem-field"
+      style={{ aspectRatio: String(layout.fieldAspect), '--tile-font': `${layout.fontCqw}cqw` }}
+      role="img"
+      aria-label={v.text ? `Poem: ${v.text}` : 'A poem'}
+    >
+      {layout.tiles.map((tile, i) => (
+        <span
+          key={i}
+          className={`lab-poem-tile${tile.fragment ? ' is-fragment' : ''}`}
+          style={{ left: `${tile.left}%`, top: `${tile.top}%`, '--rot': `${tile.rot}deg` }}
+          aria-hidden="true"
+        >
+          {tile.word}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * An erasure poem: the source post's original text with the redacted words
+ * blacked out, and the surviving found poem beneath. Falls back to the
+ * surviving `text` alone when no `original` snapshot was saved.
+ */
+function RedactionBody({ value: v }) {
+  const original = typeof v.original === 'string' ? v.original : '';
+  const redacted = Array.isArray(v.redacted) ? new Set(v.redacted) : new Set();
+  if (!original) {
+    return v.text ? <p className="lab-card-text">{v.text}</p> : null;
+  }
+  const tokens = tokenizePost(original);
+  return (
+    <div className="lab-redaction-wrap">
+      <p className="lab-redaction" aria-label={v.text ? `Erasure poem: ${v.text}` : 'An erasure poem'}>
+        {tokens.map((t, i) =>
+          isRedactable(t) && redacted.has(t.index) ? (
+            <span key={i} className="lab-redaction-word is-redacted" aria-hidden="true">
+              {t.text}
+            </span>
+          ) : (
+            <span key={i}>{t.text}</span>
+          ),
+        )}
+      </p>
+      {v.text && <p className="lab-redaction-found">{v.text}</p>}
+    </div>
+  );
 }
 
 /** Only render `image` fields that are self-contained data URLs. */

--- a/src/lib/anisotaLab.js
+++ b/src/lib/anisotaLab.js
@@ -1,0 +1,187 @@
+// Helpers for rendering Anisota Lab creations (the `crafting` verb) faithfully
+// on dame.is. The layout / tokenisation math is ported verbatim from the
+// Anisota app so a poem, erasure, or sigil re-lays here exactly as it does on
+// anisota.net:
+//   - computePoemLayout  ← anisota src/utils/poemLayout.js
+//   - tokenizePost        ← anisota src/utils/redaction.js
+//   - sigilSvgDataUrl     ← anisota src/components/sigil/sigilGeometry.js
+// Keeping the numbers identical is the whole point — see the comments there.
+
+const ANISOTA_ORIGIN = 'https://anisota.net';
+
+/**
+ * Lab collections that have a dedicated, designed viewer page on anisota.net
+ * (`/profile/{who}/{nsid}/{rkey}`). The rest (carving, petri, synth) have no
+ * per-piece page, so we fall back to the maker's profile.
+ */
+const ANISOTA_WORK_PAGE_COLLECTIONS = new Set([
+  'net.anisota.lab.poetry',
+  'net.anisota.lab.redaction',
+  'net.anisota.lab.sigil',
+  'net.anisota.lab.inkblot',
+  'net.anisota.spell.custom',
+]);
+
+/**
+ * Build the canonical anisota.net URL for a Lab record from its at:// URI.
+ * The `/profile/{who}/…` route accepts a DID in the `who` slot, which is
+ * exactly what the URI gives us. Pieces without a designed page link to the
+ * maker's Anisota profile instead.
+ */
+export function anisotaWorkUrl(atUri) {
+  const m = String(atUri || '').match(/^at:\/\/([^/]+)\/([^/]+)\/([^/?#]+)/);
+  if (!m) return null;
+  const [, did, collection, rkey] = m;
+  if (ANISOTA_WORK_PAGE_COLLECTIONS.has(collection)) {
+    return `${ANISOTA_ORIGIN}/profile/${did}/${collection}/${encodeURIComponent(rkey)}`;
+  }
+  return `${ANISOTA_ORIGIN}/profile/${did}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Poetry (Word Magnets) — poemLayout.js                               */
+/* ------------------------------------------------------------------ */
+
+// ATProto has no float type, so the board's ratios are stored as scaled
+// integers and divided back when read (bx/by/bw/bh are already whole units).
+export const BOARD_ASPECT_SCALE = 1000;
+export const BOARD_FONT_SCALE = 100000;
+
+/**
+ * Re-lay a saved poem's tiles from its `board` snapshot. Returns the field
+ * aspect ratio, the tile font size in `cqw` (percent of the field's own
+ * width, resolved via a container query), and every tile placed by its
+ * centre as a percent of the field. Returns null for poems saved before
+ * board capture, so the caller can fall back to plain text.
+ */
+export function computePoemLayout(tiles, board, opts = {}) {
+  const { pad = 0.06, minAspect = 0.6, maxAspect = 2, fieldAspect: forced } = opts;
+  if (!board || !Array.isArray(tiles) || tiles.length === 0) return null;
+
+  const aspect = Number(board.aspect) / BOARD_ASPECT_SCALE;
+  const font = Number(board.font) / BOARD_FONT_SCALE;
+  const bx = Number(board.bx);
+  const by = Number(board.by);
+  const bw = Number(board.bw);
+  const bh = Number(board.bh);
+  if (
+    ![aspect, font, bx, by, bw, bh].every(Number.isFinite) ||
+    aspect <= 0 || font <= 0 || bw <= 0 || bh <= 0
+  ) {
+    return null;
+  }
+
+  const fieldAspect = forced && forced > 0
+    ? forced
+    : Math.max(minAspect, Math.min(maxAspect, aspect));
+  const avail = 1 - 2 * pad;
+
+  let contentW;
+  let contentH;
+  if (aspect >= fieldAspect) {
+    contentW = avail;
+    contentH = (avail * fieldAspect) / aspect;
+  } else {
+    contentH = avail;
+    contentW = (avail * aspect) / fieldAspect;
+  }
+  const leftBase = (1 - contentW) / 2;
+  const topBase = (1 - contentH) / 2;
+
+  const placed = tiles.map((t) => {
+    const rx = ((Number(t.x) || 0) - bx) / bw;
+    const ry = ((Number(t.y) || 0) - by) / bh;
+    return {
+      word: t.word,
+      fragment: !!t.fragment,
+      rot: Number(t.rot) || 0,
+      left: (leftBase + rx * contentW) * 100,
+      top: (topBase + ry * contentH) * 100,
+    };
+  });
+
+  return {
+    fieldAspect,
+    fontCqw: font * contentW * 100,
+    tiles: placed,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Redaction (erasure poetry) — redaction.js                           */
+/* ------------------------------------------------------------------ */
+
+// One token at a time: a word, or a whitespace run. Anything between matches
+// is a "mark" run (punctuation/symbols/emoji).
+const TOKEN_RE = /([\p{L}\p{N}][\p{L}\p{N}'’]*)|(\s+)/gu;
+
+// Marks are redactable too, but must never collide with the word indices a
+// saved piece already stores, so they live in their own high numbering.
+export const PUNCT_BASE = 100000;
+
+/** True for any token that can be blacked out — a word or a punctuation mark. */
+export function isRedactable(token) {
+  return !!token && token.index >= 0;
+}
+
+/**
+ * Break post text into an ordered list of tokens
+ * `[{ text, isWord, isMark, index }]`. Words carry a zero-based word index;
+ * marks carry a PUNCT_BASE-offset index; whitespace gets index -1. A saved
+ * redaction stores the indices, so the same tokenisation reopens the same
+ * arrangement over the same original text.
+ */
+export function tokenizePost(text) {
+  const src = String(text || '');
+  const tokens = [];
+  let last = 0;
+  let wordIndex = 0;
+  let markIndex = 0;
+
+  const pushMarks = (from, to) => {
+    if (to > from) {
+      tokens.push({ text: src.slice(from, to), isWord: false, isMark: true, index: PUNCT_BASE + markIndex++ });
+    }
+  };
+
+  let m;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(src))) {
+    if (m.index > last) pushMarks(last, m.index);
+    if (m[1] != null) {
+      tokens.push({ text: m[1], isWord: true, isMark: false, index: wordIndex++ });
+    } else {
+      tokens.push({ text: m[0], isWord: false, isMark: false, index: -1 });
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < src.length) pushMarks(last, src.length);
+  return tokens;
+}
+
+/* ------------------------------------------------------------------ */
+/* Sigil — sigilGeometry.js                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Make a stored sigil SVG safe to render. Older records were truncated at the
+ * PDS size cap mid-path; keep the paths that completed and close the document
+ * so the figure still shows. Returns '' when nothing renderable survives.
+ */
+export function sanitizeSvgDocument(svg) {
+  if (typeof svg !== 'string' || !svg) return '';
+  if (svg.includes('</svg>')) return svg;
+  const lastClose = svg.lastIndexOf('/>');
+  if (lastClose === -1) return '';
+  return svg.slice(0, lastClose + 2) + '\n</svg>';
+}
+
+/**
+ * A sigil SVG as an <img>-ready data URL (sanitised first). Rendering the SVG
+ * through an <img> rather than inline markup keeps it sandboxed — a record
+ * can't run script. Returns '' if unrenderable.
+ */
+export function sigilSvgDataUrl(svg) {
+  const safe = sanitizeSvgDocument(svg);
+  return safe ? 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(safe) : '';
+}

--- a/src/lib/feedBuilder.js
+++ b/src/lib/feedBuilder.js
@@ -293,7 +293,7 @@ export function leafletSynopsis(docValue) {
  * place. Anything we can do in one pass to make rendering easier — slug
  * mirrors, blob URL bake-ins, etc. — lives here.
  */
-export function transformRecords(records, nsid, pds, did = ME_DID) {
+export function transformRecords(records, nsid, pds, did = ME_DID, opts = {}) {
   if (!records?.length) return records;
   for (const r of records) {
     const v = r?.value;
@@ -337,18 +337,26 @@ export function transformRecords(records, nsid, pds, did = ME_DID) {
     }
   }
 
-  // Anisota Lab pieces carry bulky reproduction data (tile layouts, gouge
-  // paths, synth event grids, reaction-diffusion recipes, redaction masks…)
-  // that the feed never renders — only the finished text / figure / print is
-  // shown. Drop those fields so they don't bloat the unified snapshot or the
-  // browser's localStorage feed cache. The record page fetches the full
-  // record live, so nothing is lost there.
+  // Anisota Lab pieces carry bulky reproduction data (gouge paths, synth event
+  // grids, reaction-diffusion recipes, sigil core paths…) that never renders —
+  // AnisotaLabCard only needs the finished text / tiles / figure / print. Drop
+  // the reopen-the-studio payloads so they don't bloat the unified feed. What
+  // the card renders (name, text, tiles+board, redacted+original, image, svg,
+  // description, tempo/steps/scale) is kept.
   if (ANISOTA_LAB_HEAVY_FIELDS[nsid]) {
-    const heavy = ANISOTA_LAB_HEAVY_FIELDS[nsid];
     for (const r of records) {
       const v = r?.value;
       if (!v) continue;
-      for (const key of heavy) delete v[key];
+      for (const key of ANISOTA_LAB_HEAVY_FIELDS[nsid]) delete v[key];
+      // For the static build-time snapshot, also drop the big inline media
+      // data-URLs (a rendered PNG is ≤200 KB; a sigil SVG ≤60 KB) so the
+      // snapshot JSON stays small. The in-memory live feed keeps them (it
+      // never touches storage), and the record page re-fetches the full
+      // record, so the piece still renders everywhere it's shown.
+      if (opts.leanMedia) {
+        delete v.image;
+        delete v.svg;
+      }
     }
   }
 
@@ -356,17 +364,16 @@ export function transformRecords(records, nsid, pds, did = ME_DID) {
 }
 
 /**
- * Per-collection lists of reproduction-only fields stripped from Anisota Lab
- * records before they enter the feed (see transformRecords). Everything the
- * card actually renders — name, text, image, svg, method, description — is
- * kept; only the reopen-the-studio payloads are dropped.
+ * Per-collection lists of reproduction-only fields stripped from every Anisota
+ * Lab record before it enters the feed (see transformRecords). Redaction keeps
+ * `original` + `redacted` (the erasure render needs them); poetry keeps
+ * `tiles` + `board` (the tile re-lay needs them).
  */
 const ANISOTA_LAB_HEAVY_FIELDS = {
-  'net.anisota.lab.poetry': ['tiles', 'board', 'sources'],
+  'net.anisota.lab.poetry': ['sources'],
   'net.anisota.lab.sigil': ['points', 'meta'],
   'net.anisota.lab.carving': ['strokes'],
   'net.anisota.lab.inkblot': ['params'],
-  'net.anisota.lab.redaction': ['redacted', 'original'],
   'net.anisota.lab.synth': ['tracks', 'fx'],
   'net.anisota.lab.petri': ['drops', 'params'],
   'net.anisota.spell.custom': ['conditions', 'effects', 'source', 'trigger'],
@@ -515,6 +522,10 @@ export async function buildUnifiedFeed({
   // script keeps its full caps for the static snapshot.
   const initialMax = options.initialMax ?? null;
   const capFor = (c) => (initialMax ? Math.min(c.max || 200, initialMax) : c.max || 200);
+  // Snapshot builds (the prefetch script) drop the big inline media data-URLs
+  // from Anisota Lab records to keep public/data JSON small; the browser's
+  // in-memory live feed leaves `leanMedia` off so it renders the real media.
+  const leanMedia = options.leanMedia === true;
   // Skipping list-item aggregation on the first fetch shaves a 1000-row
   // listRecords call; lists still render, just without `_members`.
   const skipListMembers = options.skipListMembers === true;
@@ -571,7 +582,7 @@ export async function buildUnifiedFeed({
             () => listRecords(pds, { repo: me, collection: c.nsid, max: capFor(c) }),
             [],
           );
-          transformRecords(fetched, c.nsid, pds, me);
+          transformRecords(fetched, c.nsid, pds, me, { leanMedia });
           // Drafts must never reach public surfaces — the snapshots written
           // from these records are world-readable. The admin reads the PDS
           // live (authenticated), so it still sees drafts.

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -266,7 +266,7 @@ function RecordBody({ verb, item, collection }) {
     case 'observing':
       return <ObservationCard {...item} />;
     case 'crafting':
-      return <AnisotaLabCard {...item} />;
+      return <AnisotaLabCard {...item} variant="record" />;
     default:
       return <GenericRecordBody verb={verb} item={item} collection={collection} />;
   }


### PR DESCRIPTION
## Summary

Follow-up to #183. Renders each Anisota Lab creation (the `crafting` verb) the way Anisota itself displays it — in the home feed **and** on the single-record page — and links the record page out to the piece's page on anisota.net.

### Faithful renders
- New `src/lib/anisotaLab.js` ports the exact math from the Anisota app: `computePoemLayout` (poemLayout.js), `tokenizePost` (redaction.js), and `sigilSvgDataUrl` (sigilGeometry.js), plus `anisotaWorkUrl`.
- **Poems** re-lay as the actual Word Magnets tile arrangement (positioned cream tiles from `tiles`+`board`); legacy poems without a board fall back to text.
- **Erasure poems** render the original post with the redacted words blacked out (found poem beneath), using Anisota's exact word-indexing.
- **Sigils** render as a sandboxed SVG `<img>` (with the truncated-SVG repair); **inkblot / carving / petri** render their PNG; **synth** shows tempo/steps/scale; **spell** shows name + description.
- A `variant="record"` treatment enlarges the piece on the record page and adds a **"view on anisota"** link (`/profile/{did}/{nsid}/{rkey}` for poetry/redaction/sigil/inkblot/spell; maker profile for carving/petri/synth, which have no per-piece page).

### Feed data / snapshot balance
- `feedBuilder` keeps exactly what the renders need (poem `tiles`+`board`, redaction `original`+`redacted`, `image`, `svg`) and strips only never-rendered reproduction data.
- A new `leanMedia` option (set by the prefetch snapshot build) drops the big inline PNG/SVG data-URLs from the static `public/data` snapshot JSON; the in-memory live feed and the record page keep them, so pieces still render everywhere.

## Testing
- `npm run build` passes.
- Ported math verified directly (`computePoemLayout`, `tokenizePost`, `anisotaWorkUrl`).
- Server-side rendered poems (positioned tiles), redactions (correct words blacked out), sigils, and image kinds, plus the record-vs-feed variant (link only on the record page) and the strip / `leanMedia` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_