### PR TITLE
Admin editor actions in the bottom-chrome bar; fix pinned breadcrumb overlap

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -137,6 +137,17 @@ export default function ChromeBar() {
           ? crumb.getBoundingClientRect().bottom
           : el.getBoundingClientRect().bottom;
       document.documentElement.style.setProperty('--chrome-top-h', `${Math.max(0, Math.floor(bottom))}px`);
+      // On individual pages the breadcrumb is pinned open (not just revealed on
+      // scroll), so unlike the feed pages — where it slides over already-
+      // scrolled content — it would otherwise hang over the top of the page's
+      // own content (the title). Publish its height as `--chrome-crumb-pin-h`
+      // so the content column can reserve that much extra top padding; 0 on
+      // pages where the strip only rides over on scroll.
+      const pinnedH = isDetailPage && crumb ? crumb.getBoundingClientRect().height : 0;
+      document.documentElement.style.setProperty(
+        '--chrome-crumb-pin-h',
+        `${Math.max(0, Math.ceil(pinnedH))}px`,
+      );
     };
     apply();
     let raf = 0;
@@ -156,7 +167,7 @@ export default function ChromeBar() {
       window.removeEventListener('resize', schedule);
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [showBreadcrumb]);
+  }, [showBreadcrumb, isDetailPage]);
 
   return (
     <>

--- a/src/components/EditModeBar.jsx
+++ b/src/components/EditModeBar.jsx
@@ -58,6 +58,7 @@ export default function EditModeBar() {
     editSheet,
     sheetEditor,
     closeEditSheet,
+    pageEditor,
   } = useEditMode();
   const { agent, did } = useAtprotoSession();
   const { closeDock } = useActionDock();
@@ -87,12 +88,19 @@ export default function EditModeBar() {
     openEditSheet(atUri);
   }
 
-  // While the quick-edit sheet is open, the bar hosts its Save / Delete
-  // controls (the sheet's own editor buttons are hidden) so editing the
-  // record's fields or JSON is committed straight from the action bar. The
-  // Save/Delete controls appear once the editor controller is published.
-  const editing = !!editSheet;
-  const busyEditor = sheetEditor?.saving || sheetEditor?.deleting;
+  // The bar hosts a record editor's Save / Delete / Close controls (the
+  // editor's own buttons are hidden) whenever one publishes a controller: the
+  // quick-edit sheet (`sheetEditor`) or the full admin editor page
+  // (`pageEditor`). The sheet wins if both are somehow present.
+  const onSheet = !!editSheet;
+  const ctl = onSheet ? sheetEditor : pageEditor;
+  const editing = onSheet || !!pageEditor;
+  const busyEditor = ctl?.saving || ctl?.deleting;
+
+  function closeEditor() {
+    if (onSheet) closeEditSheet();
+    else pageEditor?.close?.();
+  }
 
   // Publish the bar's live height on <html> as `--edit-bar-h`. The nav dock
   // reads it to lift its sheet so it expands from on top of this bar rather
@@ -101,7 +109,7 @@ export default function EditModeBar() {
   // whenever edit mode is off so the dock falls back to the bar.
   useEffect(() => {
     const root = document.documentElement;
-    if (!active) {
+    if (!active && !editing) {
       root.style.setProperty('--edit-bar-h', '0px');
       return undefined;
     }
@@ -119,7 +127,7 @@ export default function EditModeBar() {
       window.removeEventListener('resize', apply);
       root.style.setProperty('--edit-bar-h', '0px');
     };
-  }, [active]);
+  }, [active, editing]);
 
   async function handleDelete() {
     if (!agent || !isOwner || selectedCount === 0) return;
@@ -160,7 +168,7 @@ export default function EditModeBar() {
 
   return (
     <AnimatePresence initial={false}>
-      {active && (
+      {(active || editing) && (
         <motion.div
           className="edit-mode-bar-wrap"
           initial={{ height: 0 }}
@@ -192,32 +200,40 @@ export default function EditModeBar() {
                   <button
                     type="button"
                     className="edit-mode-bar-btn edit-mode-bar-clear"
-                    onClick={closeEditSheet}
+                    onClick={closeEditor}
                     disabled={busyEditor}
                   >
                     <X size={15} strokeWidth={1.75} aria-hidden="true" />
                     <span>Close</span>
                   </button>
-                  {sheetEditor?.canDelete && (
+                  {ctl?.canDelete && (
                     <button
                       type="button"
                       className="edit-mode-bar-btn edit-mode-bar-delete"
-                      onClick={() => sheetEditor.remove()}
-                      disabled={busyEditor || sheetEditor.loading}
+                      onClick={() => ctl.remove()}
+                      disabled={busyEditor || ctl.loading}
                     >
                       <Trash2 size={15} strokeWidth={1.75} aria-hidden="true" />
-                      <span>{sheetEditor.deleting ? 'Deleting…' : 'Delete'}</span>
+                      <span>{ctl.deleting ? 'Deleting…' : 'Delete'}</span>
                     </button>
                   )}
-                  {sheetEditor && (
+                  {ctl && (
                     <button
                       type="button"
                       className="edit-mode-bar-btn edit-mode-bar-save"
-                      onClick={() => sheetEditor.save()}
-                      disabled={busyEditor || sheetEditor.loading}
+                      onClick={() => ctl.save()}
+                      disabled={busyEditor || ctl.loading}
                     >
                       <Save size={15} strokeWidth={1.75} aria-hidden="true" />
-                      <span>{sheetEditor.saving ? 'Saving…' : 'Save'}</span>
+                      <span>
+                        {ctl.saving
+                          ? ctl.isNew
+                            ? 'Creating…'
+                            : 'Saving…'
+                          : ctl.isNew
+                            ? 'Create'
+                            : 'Save'}
+                      </span>
                     </button>
                   )}
                 </>

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -46,6 +46,11 @@ export function EditModeProvider({ children }) {
   // action bar can drive save/delete: { save, remove, saving, deleting,
   // loading, canDelete } or null.
   const [sheetEditor, setSheetEditor] = useState(null);
+  // The same shape, published by the full admin record editor page so its
+  // Save / Delete / Close live in the bottom-chrome action bar instead of at
+  // the foot of the page. Independent of `sheetEditor` (different source, so
+  // the two never race to null each other). Also carries `close` + `isNew`.
+  const [pageEditor, setPageEditor] = useState(null);
   const location = useLocation();
   const { open: dockOpen } = useActionDock();
 
@@ -169,6 +174,8 @@ export function EditModeProvider({ children }) {
       closeEditSheet,
       sheetEditor,
       setSheetEditor,
+      pageEditor,
+      setPageEditor,
     }),
     [
       active,
@@ -190,6 +197,8 @@ export function EditModeProvider({ children }) {
       closeEditSheet,
       sheetEditor,
       setSheetEditor,
+      pageEditor,
+      setPageEditor,
     ],
   );
 

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -110,16 +110,16 @@ export const LEXICONS = {
         key: 'coverImage', label: 'Cover image', type: 'image',
         hint: 'Optional thumbnail / hero shown on cards and at the top of the work.',
       },
-      { key: 'content',     label: 'Body',         type: 'blocks' },
-      {
-        key: 'links', label: 'Links', type: 'json',
-        hint: 'Optional external links (standard.site union — raw JSON).',
-      },
       {
         key: 'draft', label: 'Draft — hidden from public feeds (admin still sees it)',
         type: 'boolean',
       },
       { key: 'publishedAt', label: 'Published at', type: 'datetime', default: 'now', required: true },
+      { key: 'content',     label: 'Body',         type: 'blocks' },
+      {
+        key: 'links', label: 'Links', type: 'json',
+        hint: 'Optional external links (standard.site union — raw JSON).',
+      },
     ],
     // Keep a user-entered path; otherwise derive one from the record key.
     derive: (record, { rkey }) => (rkey ? { ...record, path: record.path || `/${rkey}` } : record),

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
 import PageContentPanel from '../components/PageContentPanel.jsx';
 import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import { ME_DID, COLLECTIONS, PORTFOLIO_PUBLICATION } from '../config.js';
 import { LEXICONS, lexiconFor, knownCollections } from '../lib/lexicons.js';
 
@@ -1131,11 +1132,41 @@ function RecordEditorPage({ agent, did, collection, rkey, preset = null }) {
       : lex?.label || collection;
   const title = isNew ? `New ${newLabel}` : `${lex?.label || collection}`;
   const headTitle = `${title} — Admin — dame.is`;
+  const listHref = `/admin?c=${encodeURIComponent(collection)}`;
+  const navigate = useNavigate();
+
+  // The editor's Save / Delete / Close ride in the bottom-chrome edit action
+  // bar (EditModeBar) rather than at the foot of the page — mirroring the
+  // quick-edit sheet. Drive the editor imperatively via a ref and publish its
+  // live status so the bar can label + disable its controls.
+  const editorRef = useRef(null);
+  const { setPageEditor } = useEditMode();
+  const [status, setStatus] = useState({
+    saving: false,
+    deleting: false,
+    loading: !isNew,
+    isNew,
+  });
+  const handleStatus = useCallback((s) => setStatus(s), []);
+
+  useEffect(() => {
+    setPageEditor({
+      save: () => editorRef.current?.save(),
+      remove: () => editorRef.current?.remove(),
+      close: () => navigate(listHref),
+      saving: status.saving,
+      deleting: status.deleting,
+      loading: status.loading,
+      canDelete: !status.isNew,
+      isNew: status.isNew,
+    });
+    return () => setPageEditor(null);
+  }, [setPageEditor, status, listHref, navigate]);
 
   return (
     <PageShell title={title} headTitle={headTitle}>
       <div className="admin-toolbar">
-        <Link to={`/admin?c=${encodeURIComponent(collection)}`} className="admin-link-subtle">
+        <Link to={listHref} className="admin-link-subtle">
           ← Back to list
         </Link>
         <code className="admin-collection-nsid">{collection}</code>
@@ -1148,18 +1179,21 @@ function RecordEditorPage({ agent, did, collection, rkey, preset = null }) {
         </p>
       )}
       <RecordEditor
+        ref={editorRef}
         agent={agent}
         did={did}
         collection={collection}
         rkey={rkey}
         initialValue={initialValue}
+        hideActions
+        onStatus={handleStatus}
         onCreated={({ rkey: newRkey }) => {
           window.location.assign(
             `/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(newRkey)}`,
           );
         }}
         onDeleted={() => {
-          window.location.assign(`/admin?c=${encodeURIComponent(collection)}`);
+          window.location.assign(listHref);
         }}
       />
     </PageShell>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8,9 +8,12 @@
      rides just above the bar and slides up out of it near the page's end
      (--chrome-bottom-footer-h, measured live) — reserve its height too so
      the revealed strip lands in its own band instead of over the last line
-     of content (which, unlike the top, can't scroll out from under it). */
+     of content (which, unlike the top, can't scroll out from under it). The
+     owner edit-mode action bar (--edit-bar-h, 0 when off) rides above the bar
+     too — reserve it so the admin editor's last field clears it. */
   padding-bottom: calc(
-    var(--chrome-h) + var(--chrome-bottom-footer-h, 0px) + env(safe-area-inset-bottom, 0px)
+    var(--chrome-h) + var(--edit-bar-h, 0px) + var(--chrome-bottom-footer-h, 0px) +
+      env(safe-area-inset-bottom, 0px)
   );
 }
 
@@ -47,7 +50,14 @@
   width: 100%;
   max-width: 72rem;
   margin: 0 auto;
-  padding: var(--space-8) clamp(var(--space-5), 6vw, var(--space-9));
+  /* `--chrome-crumb-pin-h` is the height of the top breadcrumb strip when it's
+     pinned open (individual/detail pages); it's an absolutely-positioned
+     overlay that would otherwise hang over the page title, so reserve that
+     much extra top padding. 0 on feed/index pages, where the strip only rides
+     over content on scroll. */
+  padding: calc(var(--space-8) + var(--chrome-crumb-pin-h, 0px))
+    clamp(var(--space-5), 6vw, var(--space-9))
+    var(--space-8);
 }
 
 /* Route-level crossfade wrapper. Stretches the full content width so
@@ -294,7 +304,7 @@
 
 @media (max-width: 700px) {
   .main {
-    padding: var(--space-6) var(--space-4);
+    padding: calc(var(--space-6) + var(--chrome-crumb-pin-h, 0px)) var(--space-4) var(--space-6);
   }
   .page-title {
     font-size: var(--text-3xl);


### PR DESCRIPTION
## Summary

Three editor / chrome changes:

### Admin editor actions → bottom-chrome edit bar
The full record editor (`/admin?c=…&r=…`) no longer renders Save/Delete at the foot of the page. It drives **Save · Delete · Close** from the same expanded bottom-chrome action bar the quick-edit sheet already uses.

- `useEditMode`: add a `pageEditor` controller channel, independent of `sheetEditor` so the two sources never race to null each other.
- `RecordEditorPage`: render the editor with `hideActions`, drive it via a ref, and publish a controller (save / remove / close / live status). Close returns to the record list; Save reads "Create" for new records; Delete only shows for existing ones.
- `EditModeBar`: host the editor controls whenever either source publishes a controller; render on `active || editing`; reserve `--edit-bar-h` in the app-shell so the editor's last field clears the bar.

### Reorder publishing metadata
In the `site.standard.document` editor (blogs + creative works), `draft` and `publishedAt` now sit directly under the cover image (before the body), with the rest of the publishing metadata, rather than at the very bottom.

### Fix pinned-breadcrumb overlap
The always-on breadcrumb (added in #184) is absolutely positioned (`top: 100%`), so on individual pages — where it's pinned open rather than revealed on scroll — it hung over the page title. It now publishes its height as `--chrome-crumb-pin-h` when pinned, and `.main` reserves that much extra top padding; 0 on feed/index pages, which keep the scroll-over behavior.

## Testing
- `npm run build` passes.
- Breadcrumb fix verified in a mobile browser: 38px reserved on a detail route (title clears the strip), 0px on `/creating` and `/` (no extra gap; strip still hidden until scroll).
- The admin action bar mirrors the working quick-edit-sheet controller pattern and compiles; it couldn't be driven end-to-end in the sandbox since `/admin` requires owner OAuth sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P81KybXzJr8jbFfFM21B1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01P81KybXzJr8jbFfFM21B1Q)_