### PR TITLE
Fix leaked Bluesky embed HTML in migrated blog posts

### DIFF
--- a/src/lib/legacyBlogMarkdown.js
+++ b/src/lib/legacyBlogMarkdown.js
@@ -112,7 +112,8 @@ export function markdownToContent(body) {
 
 function blocksFromTokens(tokens) {
   const out = [];
-  for (const t of tokens) {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const t = tokens[i];
     switch (t.type) {
       case 'heading':
         out.push(headerBlock(t));
@@ -132,9 +133,14 @@ function blocksFromTokens(tokens) {
       case 'hr':
         out.push({ $type: 'pub.leaflet.blocks.text', plaintext: '', facets: [] });
         break;
-      case 'html':
-        out.push(...htmlBlocks(t));
+      case 'html': {
+        const { blocks, consumed } = htmlBlocks(tokens, i);
+        out.push(...blocks);
+        // `consumed` sibling tokens were swallowed by an unterminated embed
+        // (see htmlBlocks); skip past them so they don't re-emit as text.
+        i += consumed;
         break;
+      }
       case 'space':
       default:
         break;
@@ -241,10 +247,32 @@ function listItem(item, ordered) {
 // The Eleventy posts embed Bluesky posts as raw <blockquote data-bluesky-uri>
 // HTML (from the official embed snippet). Recover the AT URI and turn it into a
 // first-class bskyPost block; drop any other raw HTML.
-function htmlBlocks(t) {
-  const uri = /data-bluesky-uri="(at:\/\/[^"]+)"/.exec(t.text || t.raw || '');
-  if (uri) return [{ $type: 'pub.leaflet.blocks.bskyPost', postRef: { uri: uri[1] } }];
-  return [];
+//
+// The embed snippet holds the quoted post's body as blank-line-separated
+// paragraphs *inside* the <blockquote>. marked ends an HTML block at the first
+// blank line, so only the opening tag lands in this `html` token — the post's
+// own lines and the closing `</blockquote><script>` tail spill out as the
+// following sibling tokens (paragraphs). Left alone they render as stray text
+// blocks, one carrying literal `</blockquote>`/`<script>` markup (visible on
+// the live post). Since the rendered bskyPost already shows that text, swallow
+// those siblings up to and including the one that closes the blockquote.
+//
+// Takes the full `tokens` list and this token's `index`; returns the recovered
+// block(s) plus how many *following* tokens to skip. `consumed` is 0 when the
+// embed is self-contained (single line) or its close can't be found — in the
+// latter case we leave siblings untouched rather than risk eating real content.
+function htmlBlocks(tokens, index) {
+  const t = tokens[index];
+  const raw = t.text || t.raw || '';
+  const uri = /data-bluesky-uri="(at:\/\/[^"]+)"/.exec(raw);
+  if (!uri) return { blocks: [], consumed: 0 };
+  const blocks = [{ $type: 'pub.leaflet.blocks.bskyPost', postRef: { uri: uri[1] } }];
+  if (/<\/blockquote>/i.test(raw)) return { blocks, consumed: 0 };
+  for (let j = index + 1; j < tokens.length; j += 1) {
+    const sibRaw = tokens[j].raw || tokens[j].text || '';
+    if (/<\/blockquote>/i.test(sibRaw)) return { blocks, consumed: j - index };
+  }
+  return { blocks, consumed: 0 };
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## What & why

On the "decentralized bathroom" blog post, raw `<br>`, `<a href>`, `</blockquote>` and `<script>` markup was rendering as literal text right below an embedded Bluesky post.

The cause is a bug in the legacy-markdown → leaflet converter (`src/lib/legacyBlogMarkdown.js`), not the renderer. The Bluesky embed snippet holds the quoted post's body as blank-line-separated paragraphs *inside* the `<blockquote>`. `marked` ends an HTML block at the first blank line, so only the opening tag reached `htmlBlocks` — the post's own lines plus the closing `</blockquote><script>` tail spilled out as sibling paragraph tokens and became stray text blocks (the last one carrying the literal markup). The post's text was already shown by the recovered `bskyPost` embed just above it, so those blocks were pure noise.

## Change

`htmlBlocks` now receives the token list + index. For an embed whose `<blockquote>` isn't closed within its own token, it swallows the following sibling tokens up to and including the one carrying `</blockquote>`. Self-contained embeds (and any where the close can't be found) consume nothing, so unrelated content is never eaten.

## Verification

- Converting the real markdown drops the post from 38 → 35 blocks: the three leaked blocks are gone, the `bskyPost` embed and surrounding content are intact, and no block contains leaked HTML/embed text.
- All 6 legacy posts still convert cleanly (no regressions).
- Offline `vite build` passes.

## Follow-up (manual)

The runtime source of truth is the live PDS record, so re-run the migration for this post from **Admin → Legacy blog migration** to overwrite it with the cleaned content (`migratePost` is idempotent — `rkey = slug`). This is the only legacy post with a Bluesky embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpqztJKNHGvbb3wg2iyUU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpqztJKNHGvbb3wg2iyUU5)_