### PR TITLE
Home feed: use 1-hour gap for grouping song listen sessions

### DIFF
--- a/src/lib/listenSessions.js
+++ b/src/lib/listenSessions.js
@@ -13,7 +13,7 @@
  * newest song) plus a `count` and a `plays` array of the underlying
  * records for expand/collapse.
  */
-export const LISTEN_BATCH_GAP_MS = 2 * 60 * 60 * 1000; // 2 hours
+export const LISTEN_BATCH_GAP_MS = 60 * 60 * 1000; // 1 hour
 
 export function collapseListens(items) {
   const out = [];


### PR DESCRIPTION
Reduce `LISTEN_BATCH_GAP_MS` from 2 hours to 1 hour so listens separated by longer breaks form distinct session rows on the home feed (and Listening page, which shares the same constant).

Previously a gap like 9:34am → 11:07am (1h 33m) fell under the 2-hour threshold and merged into a single session. With a 1-hour window, any break longer than 60 minutes now starts a fresh group. The gap is still measured listen-to-listen, so interleaved non-listening items don't fragment a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHuYiA5t5KzseETsTXxtEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHuYiA5t5KzseETsTXxtEk)_