### PR TITLE
Compact ledger table for the dedicated feeds; dashed song separators

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1702,17 +1702,72 @@ a.ledger-verb:focus-visible {
   margin-left: 0.35em;
 }
 
-/* Expanded tracks reuse the row's grid: each play's "track — artist"
-   line lands in the summary column and its time in the right-aligned
-   time column, with the verb column left empty. Auto-placement makes
-   one implicit grid row per track. */
+/* Expanded tracks: one compact sub-row per play, spanning the summary +
+   time columns (the verb column stays empty on the left). A thin dashed
+   rule tops each one so the songs read as a tight ruled list rather than a
+   loose run of lines. Flex keeps "track — artist" at the left and the time
+   flush right, aligned to the session row's own time column. */
+.ledger-track-row {
+  grid-column: 2 / 4;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--ledger-col-gap);
+  padding-top: 0.3em;
+  margin-top: 0.3em;
+  border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 55%, transparent);
+}
+
 .ledger-track {
-  grid-column: 2;
   font-size: var(--text-sm);
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .ledger-track-time {
-  grid-column: 3;
+  flex: 0 0 auto;
+}
+
+/* Flat ledger — the single-type feed pages (blogging, creating, …) reuse the
+   ledger's type + rules but drop the redundant verb column (every row is the
+   same kind) and don't day-group, so the rows read as one continuous compact
+   table of "title · when". Two columns: the title stretches, a short relative
+   time sits flush right. */
+.feed-ledger-flat {
+  gap: 0;
+}
+
+.feed-ledger-flat .feed-item-ledger {
+  grid-template-columns: minmax(0, 1fr) var(--ledger-time-col);
+}
+
+/* Whole-row links read as calm ledger text (ink title, faint time) — the
+   accent only comes up on hover — rather than a page full of green links. */
+.feed-ledger-flat .ledger-body a {
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.feed-ledger-flat .ledger-time {
+  text-decoration: none;
+}
+
+.feed-ledger-flat .ledger-body a:hover,
+.feed-ledger-flat .ledger-body a:focus-visible,
+a.ledger-time:hover,
+a.ledger-time:focus-visible {
+  color: var(--accent);
+}
+
+/* A kind tag ahead of the title (e.g. a work's category), in the same quiet
+   mono small-caps as the verb column it stands in for. */
+.ledger-kind {
+  font-family: var(--mono);
+  font-size: calc(var(--text-xs) * 0.9);
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  margin-right: 0.5em;
 }
 
 .ledger-track a {

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { formatTime } from '../lib/time.js';
 import { renderPostText } from '../lib/postRichText.jsx';
@@ -88,15 +87,18 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
         const playTs = play?.createdAt || play?.payload?.playedTime || null;
         const playHref = recordPathFromAtUri(play?.atUri);
         const line = trackLine(play?.payload);
+        // Each play is its own compact sub-row spanning the summary + time
+        // columns, split from the one above by a thin dashed rule (see
+        // .ledger-track-row in Feed.css) so the song list reads tight.
         return (
-          <Fragment key={play?.atUri || playTs}>
+          <div className="ledger-track-row" key={play?.atUri || playTs}>
             <p className="ledger-text ledger-track">
               {playHref ? <Link to={playHref}>{line || <em>—</em>}</Link> : line || <em>—</em>}
             </p>
             <span className="ledger-time ledger-track-time">
               {playTs ? formatTime(playTs) : ''}
             </span>
-          </Fragment>
+          </div>
         );
       })}
     </>

--- a/src/components/FlatLedger.jsx
+++ b/src/components/FlatLedger.jsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+
+/**
+ * A flat, day-group-less ledger table for single-type feed pages (blogging,
+ * creating, …). Reuses the home feed's ledger type + rules (the `.feed-ledger`
+ * / `.ledger-*` styles in Feed.css) but drops the redundant verb column —
+ * every row on these pages is the same kind — and reads as one continuous
+ * compact table of "title · when" instead of the day-grouped activity ledger.
+ *
+ * Each row is `{ key, href, title, kind?, time?, nsid? }`:
+ *   - href   destination for the whole row (title + time both link to it)
+ *   - kind   optional small-caps tag ahead of the title (e.g. a work category)
+ *   - time   optional short/relative timestamp, flush right
+ *   - nsid   optional collection, stamped as data-nsid so the chrome strip can
+ *            read the record type at the top of the scroll (like FeedItem does)
+ */
+export default function FlatLedger({ rows }) {
+  return (
+    <ol className="feed-list feed-ledger feed-ledger-flat reveal-stagger">
+      {rows.map((row, i) => (
+        <li
+          key={row.key || i}
+          className="feed-item feed-item-ledger"
+          data-nsid={row.nsid || undefined}
+        >
+          <div className="ledger-body">
+            <p className="ledger-text">
+              {row.kind && <span className="ledger-kind small-caps">{row.kind}</span>}
+              <Link to={row.href}>{row.title}</Link>
+            </p>
+          </div>
+          {row.time ? (
+            <Link className="ledger-time" to={row.href}>
+              {row.time}
+            </Link>
+          ) : (
+            <span className="ledger-time" />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import FlatLedger from '../components/FlatLedger.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { BloggingTocSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
@@ -44,6 +46,8 @@ export default function Blogging() {
     mapItems: mergeBlogEntries,
   });
 
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger';
   const loading = status === 'loading';
   const safeEntries = entries || [];
   const filtered = useMemo(
@@ -67,6 +71,16 @@ export default function Blogging() {
         <p className="feed-empty">
           {q ? 'No blog posts match that search.' : 'No blog posts yet.'}
         </p>
+      ) : ledger ? (
+        <FlatLedger
+          rows={filtered.map((e, i) => ({
+            key: e.uri || i,
+            href: e.href,
+            title: e.title,
+            time: e.createdAt ? relativeTime(e.createdAt) : null,
+            nsid: nsidFromAtUri(e.uri),
+          }))}
+        />
       ) : (
         <ol className="blogging-toc reveal-stagger">
           {filtered.map((e, i) => (

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import MasonryGrid from '../components/MasonryGrid.jsx';
+import FlatLedger from '../components/FlatLedger.jsx';
 import CreatingFilters, { filterCreatingItems } from '../components/CreatingFilters.jsx';
-import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
+import { CreatingGridSkeleton, FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
@@ -93,6 +95,8 @@ export default function Creating() {
     },
   });
 
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger';
   const loading = status === 'loading';
   const safeWorks = works || [];
   const kinds = useMemo(
@@ -126,7 +130,9 @@ export default function Creating() {
   useEffect(() => {
     if (!loading && coversReady) setRevealed(true);
   }, [loading, coversReady]);
-  const showSkeleton = loading || (filtered.length > 0 && !revealed);
+  // The ledger table shows no cover art, so it needn't wait on cover preloads
+  // the way the grid does — it paints as soon as the works are loaded.
+  const showSkeleton = ledger ? loading : loading || (filtered.length > 0 && !revealed);
 
   return (
     <PageShell
@@ -137,11 +143,30 @@ export default function Creating() {
     >
       <CreatingFilters kinds={kinds} counts={counts} />
       {showSkeleton ? (
-        <CreatingGridSkeleton cells={6} />
+        ledger ? (
+          <FeedSkeleton rows={6} label="Loading works" />
+        ) : (
+          <CreatingGridSkeleton cells={6} />
+        )
       ) : filtered.length === 0 ? (
         <p className="feed-empty">
           {q ? 'No works match that search.' : 'No works yet.'}
         </p>
+      ) : ledger ? (
+        <FlatLedger
+          rows={filtered.map((r, i) => {
+            const v = r.value || {};
+            const slug = workSlug(v) || rkeyFromAtUri(r.uri);
+            return {
+              key: r.uri || i,
+              href: `/creating/${slug}`,
+              title: v.title || slug,
+              kind: workCategory(v),
+              time: v.createdAt ? relativeTime(v.createdAt) : null,
+              nsid: nsidFromAtUri(r.uri),
+            };
+          })}
+        />
       ) : (
         <MasonryGrid
           items={filtered}

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -9,6 +9,7 @@ import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
 import { collapseListens } from '../lib/listenSessions.js';
@@ -31,7 +32,12 @@ export default function Listening() {
     mapItems: toListeningItems,
   });
 
-  const { removedUris } = useEditMode();
+  const { removedUris, active: editActive } = useEditMode();
+  const { layout } = useFeedLayout();
+  // Match the home feed: the compact ledger is the default, but owner edit
+  // mode steps aside to the full cards (their selection UI isn't wired into
+  // the ledger rows).
+  const ledger = layout === 'ledger' && !editActive;
   const loading = status === 'loading';
   const safeItems = items || [];
   // Stats reflect all listening (minus any owner-removed plays), independent
@@ -90,18 +96,25 @@ export default function Listening() {
           {q ? 'No songs match that search.' : 'No plays yet.'}
         </p>
       ) : (
-        <ol className="feed-list reveal-stagger">
-          {groups.map((group) => (
-            <li key={group.dateKey} className="feed-day-group">
-              <DayOfLifeHeader date={group.date} />
-              <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
-                {group.items.map((item) => (
-                  <FeedItem key={item.atUri} item={item} showVerb={false} />
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ol>
+        <div className={ledger ? 'feed-ledger' : undefined}>
+          <ol className="feed-list reveal-stagger">
+            {groups.map((group) => (
+              <li key={group.dateKey} className="feed-day-group">
+                <DayOfLifeHeader date={group.date} variant={ledger ? 'ledger' : 'default'} />
+                <ul className="feed-list" style={ledger ? undefined : { marginTop: 'var(--space-3)' }}>
+                  {group.items.map((item) => (
+                    <FeedItem
+                      key={item.atUri}
+                      item={item}
+                      showVerb={false}
+                      layout={ledger ? 'ledger' : 'cards'}
+                    />
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        </div>
       )}
       {!loading && refreshedAt && (
         <p className="gutter feed-loaded-at" style={{ marginTop: 'var(--space-7)', textAlign: 'center' }}>

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -7,6 +7,8 @@ import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
@@ -28,6 +30,9 @@ export default function Logging() {
     mapItems: toLoggingItems,
   });
 
+  const { active: editActive } = useEditMode();
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger' && !editActive;
   const loading = status === 'loading';
   const safeItems = items || [];
   const filtered = useMemo(
@@ -59,18 +64,20 @@ export default function Logging() {
           {q ? 'No status records match that search.' : 'No status records yet.'}
         </p>
       ) : (
-        <ol className="feed-list reveal-stagger">
-          {groups.map((group) => (
-            <li key={group.dateKey} className="feed-day-group">
-              <DayOfLifeHeader date={group.date} />
-              <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
-                {group.items.map((item) => (
-                  <FeedItem key={item.atUri} item={item} />
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ol>
+        <div className={ledger ? 'feed-ledger' : undefined}>
+          <ol className="feed-list reveal-stagger">
+            {groups.map((group) => (
+              <li key={group.dateKey} className="feed-day-group">
+                <DayOfLifeHeader date={group.date} variant={ledger ? 'ledger' : 'default'} />
+                <ul className="feed-list" style={ledger ? undefined : { marginTop: 'var(--space-3)' }}>
+                  {group.items.map((item) => (
+                    <FeedItem key={item.atUri} item={item} layout={ledger ? 'ledger' : 'cards'} />
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        </div>
       )}
       {!loading && refreshedAt && (
         <p className="gutter feed-loaded-at" style={{ marginTop: 'var(--space-7)', textAlign: 'center' }}>

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -7,6 +7,8 @@ import PostingFilters, { filterPostingItems, postingCategories } from '../compon
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
 import { getAuthorFeed } from '../lib/atproto.js';
@@ -26,6 +28,9 @@ export default function Posting() {
     mapItems: toPostingItems,
   });
 
+  const { active: editActive } = useEditMode();
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger' && !editActive;
   const loading = status === 'loading';
   const safeItems = items || [];
   const filtered = useMemo(
@@ -65,18 +70,25 @@ export default function Posting() {
       ) : groups.length === 0 ? (
         <p className="feed-empty">{params.get('q') ? 'No posts match that search.' : 'No posts match these filters.'}</p>
       ) : (
-        <ol className="feed-list reveal-stagger">
-          {groups.map((group) => (
-            <li key={group.dateKey} className="feed-day-group">
-              <DayOfLifeHeader date={group.date} />
-              <ul className="feed-list" style={{ marginTop: 'var(--space-3)' }}>
-                {group.items.map((item) => (
-                  <FeedItem key={item.atUri} item={item} showVerb={false} />
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ol>
+        <div className={ledger ? 'feed-ledger' : undefined}>
+          <ol className="feed-list reveal-stagger">
+            {groups.map((group) => (
+              <li key={group.dateKey} className="feed-day-group">
+                <DayOfLifeHeader date={group.date} variant={ledger ? 'ledger' : 'default'} />
+                <ul className="feed-list" style={ledger ? undefined : { marginTop: 'var(--space-3)' }}>
+                  {group.items.map((item) => (
+                    <FeedItem
+                      key={item.atUri}
+                      item={item}
+                      showVerb={false}
+                      layout={ledger ? 'ledger' : 'cards'}
+                    />
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        </div>
       )}
       {!loading && refreshedAt && (
         <p className="gutter feed-loaded-at" style={{ marginTop: 'var(--space-7)', textAlign: 'center' }}>


### PR DESCRIPTION
## Summary

Gives the dedicated feed pages the home feed's compact table (ledger) layout, honoring the same global layout toggle, and tightens the expanded listening session.

### Compact table on the dedicated feeds
- **Listening, logging, posting** now read the `useFeedLayout` preference and render the day-grouped ledger (verb · summary · time) exactly like the home feed when the table layout is active — falling back to their cards, and to cards during owner edit mode, otherwise.
- **Blogging and creating** get a flat, day-group-less variant of the ledger (new `FlatLedger` component + `.feed-ledger-flat`): the redundant verb column is dropped and each row reads "title · when" (with an optional category tag), in the ledger's own type and rules. Their card / grid layouts stay for the cards view.

### Expanded listening sessions
- Each song is now its own compact sub-row spanning the summary + time columns, split by a thin dashed rule, so a long run of tracks reads as a tight ruled list instead of a loose block (home feed + listening page).

## Testing
- `npm run build` passes.
- SSR-checked the new markup (3 dashed sub-rows when a session is expanded, 0 when collapsed; the flat table's two-column rows with the category tag + relative time).
- Rendered the real stylesheets in a headless browser and screenshotted the result to confirm the dashed separators and the flat table match the ledger aesthetic.

Note: these pages share the one global layout toggle (which defaults to the ledger/table), so switching it now switches every feed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_