### PR TITLE
Blog page: reorder title metadata and stack breadcrumb NSID on mobile

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -212,6 +212,29 @@
   text-align: right;
 }
 
+/* On mobile, an individual (detail) page's breadcrumb trail and its NSID can
+   each run long — the slug wraps to a second line and the NSID would otherwise
+   be squeezed against the right edge and ellipsized ("SITE.STANDARD.DOC…").
+   Let the strip wrap and drop the NSID onto its own line beneath the trail,
+   left-aligned and shown in full, instead of clipping it. Scoped to detail
+   pages (`.is-detail`); feed pages keep the compact right-aligned NSID that
+   tracks the scrolled record. */
+@media (max-width: 700px) {
+  .chrome-bar-tertiary.is-detail {
+    flex-wrap: wrap;
+  }
+  .chrome-bar-tertiary.is-detail .chrome-crumb-nsid {
+    flex-basis: 100%;
+    margin-left: 0;
+    padding-top: 0;
+    text-align: left;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+  }
+}
+
 .chrome-crumb-sep {
   color: var(--ink-faint);
   user-select: none;

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -285,7 +285,7 @@ export default function ChromeBar() {
           style={{ pointerEvents: showBreadcrumb ? 'auto' : 'none' }}
         >
           <motion.div
-            className="chrome-bar-row chrome-bar-tertiary"
+            className={`chrome-bar-row chrome-bar-tertiary ${isDetailPage ? 'is-detail' : ''}`}
             initial={false}
             animate={{ y: showBreadcrumb ? '0%' : '-100%', opacity: showBreadcrumb ? 1 : 0 }}
             transition={{ duration: reduce ? 0 : 0.32, ease: [0.32, 0.72, 0, 1] }}

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -6,7 +6,7 @@ import Comments from '../components/Comments.jsx';
 import { BlogPostSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
-import { formatDateLong, relativeTime } from '../lib/time.js';
+import { formatDateFull, relativeDay } from '../lib/time.js';
 import { dayOfLife } from '../lib/dayOfLife.js';
 import { getPostThread } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
@@ -153,10 +153,9 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
     >
       <article className="blog-article reveal">
         <div className="blog-article-meta">
-          {created && <span>{formatDateLong(created)}</span>}
-          {dayNum && <span>· Day {dayNum.toLocaleString()}</span>}
-          {created && <span>· {relativeTime(created)}</span>}
-          <span className="blog-article-tag">standard.site</span>
+          {created && <span>{relativeDay(created)}</span>}
+          {created && <span>{formatDateFull(created)}</span>}
+          {dayNum && <span>Day {dayNum.toLocaleString()}</span>}
         </div>
         {/* The `description` field is intentionally not rendered here — it's the
             open-graph / feed-summary blurb, and on the post itself it just

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -102,12 +102,24 @@
 
 .blog-article-meta {
   display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
   gap: var(--space-3);
   font-family: var(--sans);
   font-size: var(--text-xs);
   color: var(--ink-muted);
   letter-spacing: 0.04em;
   margin: var(--space-2) 0 var(--space-6);
+}
+
+/* Bullet separators between the meta atoms — relative time • date • day —
+   matching the "Xago • date" separator on the blog index. The flex gap sits
+   before each bullet and the bullet's own margin after it, so the dot stays
+   evenly spaced on both sides even when the line wraps. */
+.blog-article-meta > span + span::before {
+  content: '•';
+  margin-right: var(--space-3);
+  color: var(--ink-faint);
 }
 
 .blog-article-tags {


### PR DESCRIPTION
Reworks the individual blog page's presentation in two ways.

## Title metadata
The line under the title now reads **`1 year ago • March 8, 2025 • Day 11,629`** — long-form relative time first, then the US-style full date, then the day-of-life number, separated by `•` bullets (matching the blog index's existing separator). The trailing `standard.site` lexicon tag is removed.

- `formatDateLong` → `formatDateFull` ("March 8, 2025")
- `relativeTime` → `relativeDay` ("1 year ago" instead of the terse "1y ago")
- Separators moved from inline `·` prefixes to a CSS `::before` bullet, so the line also wraps gracefully on narrow screens.

## Mobile breadcrumb NSID
On an individual (detail) page at mobile widths, the breadcrumb strip now wraps and drops the record's NSID onto its own line beneath the trail, left-aligned and shown in full — instead of squeezing it against the right edge and ellipsizing it (`SITE.STANDARD.DOC…`).

- Scoped with a new `.is-detail` class (added only when `isDetailPage` is true), so feed/index pages keep the compact right-aligned NSID that tracks the scrolled record, and desktop is unchanged.
- The existing pinned-strip height measurement already re-measures the taller two-line strip, so the title still sits cleanly below it with no overlap.

## Verification
Drove the real page in Chromium at desktop (1200px) and mobile (390px) widths against a synthetic snapshot, and confirmed both behaviors render as intended. Offline build (`npm run build:offline`) passes. Only the four source files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz)_