### PR TITLE
Blog breadcrumb: tighten gap above the stacked NSID on mobile

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -222,11 +222,22 @@
 @media (max-width: 700px) {
   .chrome-bar-tertiary.is-detail {
     flex-wrap: wrap;
+    /* Mobile chrome rows carry gap: var(--space-2); once the row wraps that
+       becomes a row-gap that stacks on top of the trail's own padding-bottom,
+       doubling the space above the NSID. Zero it so the NSID's small
+       padding-top is the only gap. */
+    row-gap: 0;
+  }
+  /* Drop the trail's bottom padding when the NSID stacks beneath it, so the
+     NSID sits close under the breadcrumb — reading as its caption rather than
+     a separate row. */
+  .chrome-bar-tertiary.is-detail .chrome-breadcrumb {
+    padding-bottom: 0;
   }
   .chrome-bar-tertiary.is-detail .chrome-crumb-nsid {
     flex-basis: 100%;
     margin-left: 0;
-    padding-top: 0;
+    padding-top: var(--space-1);
     text-align: left;
     white-space: normal;
     overflow: visible;


### PR DESCRIPTION
Follow-up to #190.

When the record NSID drops onto its own line beneath the breadcrumb on mobile detail pages, the gap above it was doubled: the wrapped tertiary row's `row-gap` (`var(--space-2)` = 8px on mobile chrome rows) stacked on top of the breadcrumb trail's own `padding-bottom` (8px), leaving ~16px above the NSID.

Zero the row-gap, drop the trail's bottom padding, and give the NSID a small `padding-top` (`var(--space-1)` = 4px) so it sits close under the breadcrumb — reading as its caption rather than a separate row.

Scope and behavior are unchanged otherwise: still `.is-detail` + `max-width: 700px` only, so feed pages and desktop are untouched.

## Verification
Drove the page in Chromium at 390px and 560px widths; the box-to-box gap between the breadcrumb and NSID is now 0 (only the NSID's 4px padding + line leading remains), matching the tighter caption look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz)_