### PR TITLE
Hide draft works/posts from the live-fetched public feeds

### DIFF
--- a/src/lib/publications.js
+++ b/src/lib/publications.js
@@ -33,6 +33,18 @@ export function isPortfolioDoc(value) {
 }
 
 /**
+ * True when a record value is marked a draft. Drafts are hidden from every
+ * public surface. The snapshot builder already drops them when it writes the
+ * world-readable JSON (see feedBuilder), but the live PDS fetch that pages run
+ * to confirm/refresh the snapshot returns *all* records — `listRecords` has no
+ * notion of drafts — so each public surface must re-apply this filter or a
+ * drafted work reappears the moment the live fetch overlays the snapshot.
+ */
+export function isDraft(value) {
+  return value?.draft === true;
+}
+
+/**
  * True when a standard-document value's home feed is the blog. Anything not
  * homed in the portfolio is a blog post — including, while
  * `PORTFOLIO_PUBLICATION` is unset, everything (legacy behavior).

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -10,7 +10,7 @@ import { formatDateFull, relativeDay } from '../lib/time.js';
 import { dayOfLife } from '../lib/dayOfLife.js';
 import { getPostThread } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
-import { showOnBlog } from '../lib/publications.js';
+import { showOnBlog, isDraft } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Blogging.css';
 
@@ -133,8 +133,11 @@ function resolveById(data, id) {
   // `data` is the `blogs` array of site.standard.document records.
   const blogs = Array.isArray(data) ? data : [];
   // Blog-homed docs, plus any portfolio doc cross-posted to the blog with a
-  // `blog` tag — so a dual-listed work resolves at /blogging/:rkey too.
-  const standard = blogs.find((r) => endsWithRkey(r?.uri, id) && showOnBlog(r?.value));
+  // `blog` tag — so a dual-listed work resolves at /blogging/:rkey too. Drafts
+  // stay hidden even by direct URL (the live fetch would otherwise find them).
+  const standard = blogs.find(
+    (r) => endsWithRkey(r?.uri, id) && !isDraft(r?.value) && showOnBlog(r?.value),
+  );
   return standard ? { kind: 'standard', record: standard } : null;
 }
 

--- a/src/pages/Blogging.jsx
+++ b/src/pages/Blogging.jsx
@@ -10,7 +10,7 @@ import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, formatDateFull, compareIsoDesc } from '../lib/time.js';
-import { showOnBlog } from '../lib/publications.js';
+import { showOnBlog, isDraft } from '../lib/publications.js';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
@@ -118,8 +118,9 @@ function mergeBlogEntries(data) {
   const blogs = Array.isArray(data) ? data : [];
   return blogs
     // Blog-homed docs plus any portfolio doc cross-posted with a `blog` tag.
-    // Portfolio-only docs live on /creating.
-    .filter((r) => r?.value && showOnBlog(r.value))
+    // Portfolio-only docs live on /creating. Drafts stay hidden — the live PDS
+    // fetch returns them, so filter here where snapshot and live both pass.
+    .filter((r) => r?.value && !isDraft(r.value) && showOnBlog(r.value))
     .map(normalizeStandard)
     .sort((a, b) => compareIsoDesc(a.createdAt, b.createdAt));
 }

--- a/src/pages/Creating.jsx
+++ b/src/pages/Creating.jsx
@@ -14,7 +14,7 @@ import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { relativeTime, compareIsoDesc } from '../lib/time.js';
 import { coverThumb } from '../lib/creatingHelpers.js';
-import { showOnCreating, workSlug, workCategory } from '../lib/publications.js';
+import { showOnCreating, isDraft, workSlug, workCategory } from '../lib/publications.js';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/FeedFilters.css';
@@ -89,8 +89,11 @@ export default function Creating() {
     fetchLive: loadWorks,
     mapItems: (snap) => {
       if (!Array.isArray(snap)) return [];
+      // Runs against both the snapshot and the live payload, so this is the
+      // single gate that keeps drafts off the feed regardless of source — the
+      // live PDS fetch (loadWorks) otherwise re-includes drafted works.
       return snap
-        .filter((r) => r?.value)
+        .filter((r) => r?.value && !isDraft(r.value))
         .sort((a, b) => compareIsoDesc(a.value?.createdAt, b.value?.createdAt));
     },
   });

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -9,7 +9,7 @@ import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { formatDateLong } from '../lib/time.js';
-import { showOnCreating, workSlug, workCategory } from '../lib/publications.js';
+import { showOnCreating, isDraft, workSlug, workCategory } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Blogging.css';
@@ -41,10 +41,13 @@ export default function CreatingWork() {
     },
     mapItems: (snap) => {
       if (!Array.isArray(snap)) return null;
+      // Drafts are hidden from public surfaces; a drafted work must not
+      // resolve by direct URL either (the live fetch would otherwise find it).
+      const visible = snap.filter((r) => r?.value && !isDraft(r.value));
       return (
-        snap.find((r) => r?.value && workSlug(r.value) === slug) ||
+        visible.find((r) => workSlug(r.value) === slug) ||
         // Fall back to the rkey so URI-derived links resolve too.
-        snap.find((r) => rkeyFromAtUri(r?.uri) === slug) ||
+        visible.find((r) => rkeyFromAtUri(r?.uri) === slug) ||
         null
       );
     },


### PR DESCRIPTION
## Problem

Marking a creating item (or blog post) as a **draft** did nothing on the public pages. The `draft` flag *is* respected in `feedBuilder.js`, which strips `draft === true` records when it writes the world-readable snapshot JSON. But the public pages don't only read the snapshot:

- They use the `snapshot-first` strategy: render the clean snapshot, then run a **live `listRecords` PDS fetch** and overlay the result.
- `listRecords` returns *all* records — it has no concept of drafts — and the live-fetch paths filtered only by cross-post classification (`showOnCreating` / `showOnBlog`), never by draft state.

So a drafted work briefly disappeared (clean snapshot), then **popped back into the feed** the moment the live fetch resolved.

## Fix

Re-apply the draft filter at each page's `mapItems` — the single choke point that runs against **both** the snapshot and the live payload — so drafts stay hidden regardless of source.

| File | Surface | Change |
|------|---------|--------|
| `src/lib/publications.js` | — | New shared `isDraft(value)` helper |
| `src/pages/Creating.jsx` | /creating index | Filter drafts in `mapItems` |
| `src/pages/CreatingWork.jsx` | /creating/:slug | Drafted work no longer resolves by direct URL |
| `src/pages/Blogging.jsx` | /blogging index | Same record type + same live-fetch bug |
| `src/pages/BlogPost.jsx` | /blogging/:id | Drafted post no longer resolves by direct URL |

The blog surfaces are fixed alongside `/creating` because they are the same `site.standard.document` record type going through the same live-fetch overlay, so a drafted blog post would leak identically.

Verified with `npm run build:offline` — compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4Hf8x5TLheTvyaS8MLU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4Hf8x5TLheTvyaS8MLU2)_