### PR TITLE
Ledger view for the mothing and curating feeds

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1739,7 +1739,9 @@ a.ledger-verb:focus-visible {
 }
 
 .feed-ledger-flat .feed-item-ledger {
-  grid-template-columns: minmax(0, 1fr) var(--ledger-time-col);
+  /* The right cell auto-sizes so it fits either a short relative time
+     ("3mo") or a small count ("42 blocks"). */
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 /* Whole-row links read as calm ledger text (ink title, faint time) — the

--- a/src/components/FlatLedger.jsx
+++ b/src/components/FlatLedger.jsx
@@ -2,17 +2,19 @@ import { Link } from 'react-router-dom';
 
 /**
  * A flat, day-group-less ledger table for single-type feed pages (blogging,
- * creating, …). Reuses the home feed's ledger type + rules (the `.feed-ledger`
- * / `.ledger-*` styles in Feed.css) but drops the redundant verb column —
- * every row on these pages is the same kind — and reads as one continuous
- * compact table of "title · when" instead of the day-grouped activity ledger.
+ * creating, curating, mothing, …). Reuses the home feed's ledger type + rules
+ * (the `.feed-ledger` / `.ledger-*` styles in Feed.css) but drops the
+ * redundant verb column — every row on these pages is the same kind — and
+ * reads as one continuous compact table of "title · meta".
  *
- * Each row is `{ key, href, title, kind?, time?, nsid? }`:
- *   - href   destination for the whole row (title + time both link to it)
- *   - kind   optional small-caps tag ahead of the title (e.g. a work category)
- *   - time   optional short/relative timestamp, flush right
- *   - nsid   optional collection, stamped as data-nsid so the chrome strip can
- *            read the record type at the top of the scroll (like FeedItem does)
+ * Each row is `{ key, href, title, kind?, secondary?, time?, external?, nsid? }`:
+ *   - href       destination for the whole row (title + right cell both link)
+ *   - kind       optional small-caps tag ahead of the title (e.g. a category)
+ *   - secondary  optional muted suffix after the title (e.g. a scientific name)
+ *   - time       optional right-column string (a relative time, a count, …)
+ *   - external   render an external <a target=_blank> instead of a router Link
+ *   - nsid       optional collection, stamped as data-nsid so the chrome strip
+ *                can read the record type at the top of the scroll
  */
 export default function FlatLedger({ rows }) {
   return (
@@ -26,18 +28,37 @@ export default function FlatLedger({ rows }) {
           <div className="ledger-body">
             <p className="ledger-text">
               {row.kind && <span className="ledger-kind small-caps">{row.kind}</span>}
-              <Link to={row.href}>{row.title}</Link>
+              <RowLink row={row}>
+                {row.title}
+                {row.secondary && <span className="ledger-count"> ({row.secondary})</span>}
+              </RowLink>
             </p>
           </div>
           {row.time ? (
-            <Link className="ledger-time" to={row.href}>
+            <RowLink row={row} className="ledger-time">
               {row.time}
-            </Link>
+            </RowLink>
           ) : (
             <span className="ledger-time" />
           )}
         </li>
       ))}
     </ol>
+  );
+}
+
+/** A row's link — an external <a> (iNaturalist, are.na, …) or a router Link. */
+function RowLink({ row, className, children }) {
+  if (row.external) {
+    return (
+      <a className={className} href={row.href} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link className={className} to={row.href}>
+      {children}
+    </Link>
   );
 }

--- a/src/pages/Curating.jsx
+++ b/src/pages/Curating.jsx
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import MasonryGrid from '../components/MasonryGrid.jsx';
-import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
+import FlatLedger from '../components/FlatLedger.jsx';
+import { CreatingGridSkeleton, FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { useImagesReady } from '../hooks/useImagesReady.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { fetchChannelMeta, fetchChannelPage, normalizeBlock, pickCoverThumb, arenaText } from '../lib/arena.js';
@@ -80,12 +82,15 @@ export default function Curating() {
     mapItems: (d) => (Array.isArray(d?.galleries) ? d.galleries : null),
   });
 
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger';
   const loading = status === 'loading';
   const list = galleries || [];
 
   // Hold the skeleton until the first rows' gallery covers are ready, so
   // the grid doesn't swap in with blank cells that pop as they download.
-  // Once revealed we stay revealed.
+  // Once revealed we stay revealed. The ledger shows no covers, so it needn't
+  // wait on them.
   const coverUrls = useMemo(
     () => list.slice(0, COVER_WAIT).map((g) => g.cover?.src).filter(Boolean),
     [list],
@@ -95,7 +100,7 @@ export default function Curating() {
   useEffect(() => {
     if (!loading && coversReady) setRevealed(true);
   }, [loading, coversReady]);
-  const showSkeleton = loading || (list.length > 0 && !revealed);
+  const showSkeleton = ledger ? loading : loading || (list.length > 0 && !revealed);
 
   return (
     <PageShell
@@ -105,9 +110,26 @@ export default function Curating() {
       headTitle="dame.is curating"
     >
       {showSkeleton ? (
-        <CreatingGridSkeleton cells={6} />
+        ledger ? (
+          <FeedSkeleton rows={6} label="Loading galleries" />
+        ) : (
+          <CreatingGridSkeleton cells={6} />
+        )
       ) : list.length === 0 ? (
         <p className="feed-empty">No galleries yet.</p>
+      ) : ledger ? (
+        <FlatLedger
+          rows={list.map((g) => ({
+            key: g.slug,
+            href: `/curating/${g.slug}`,
+            title: g.title,
+            time:
+              g.blockCount != null
+                ? `${g.blockCount} ${g.blockCount === 1 ? 'block' : 'blocks'}`
+                : null,
+            nsid: COLLECTIONS.arenaChannel,
+          }))}
+        />
       ) : (
         <MasonryGrid
           items={list}

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import PageShell from '../components/PageShell.jsx';
-import { MothingSkeleton } from '../components/Skeleton.jsx';
+import FlatLedger from '../components/FlatLedger.jsx';
+import { MothingSkeleton, FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { fetchMothData, fetchMothSignature, photoUrl, buildSessions } from '../lib/inaturalist.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
-import { ME_DID, INATURALIST_USER } from '../config.js';
+import { ME_DID, INATURALIST_USER, MOTHING_OBSERVATION_NSID } from '../config.js';
+import '../components/Feed.css';
 import './Mothing.css';
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -87,8 +90,32 @@ function SessionHeader({ session }) {
   );
 }
 
+/** Compact per-session summary for the ledger day-header (count · species). */
+function sessionLedgerMeta(session) {
+  const parts = [`${session.observationCount} moth${session.observationCount === 1 ? '' : 's'}`];
+  if (session.speciesCount) parts.push(`${session.speciesCount} species`);
+  return parts.join(' · ');
+}
+
+/** One iNaturalist observation as a flat-ledger row (external link out). */
+function mothLedgerRow(obs) {
+  const name = obs.taxon?.commonName || obs.taxon?.name || 'Unidentified moth';
+  const sci = obs.taxon?.name;
+  return {
+    key: obs.id,
+    href: obs.url,
+    external: true,
+    title: name,
+    secondary: sci && sci !== name ? sci : null,
+    time: obs.observedTime ? formatTime(obs.observedTime) : formatDate(obs.observedDate),
+    nsid: MOTHING_OBSERVATION_NSID,
+  };
+}
+
 export default function Mothing() {
   const { title, intro } = usePageContent('mothing');
+  const { layout } = useFeedLayout();
+  const ledger = layout === 'ledger';
 
   const { items, status } = useLiveFeed({
     name: 'mothing',
@@ -162,9 +189,36 @@ export default function Mothing() {
       )}
 
       {loading && observations.length === 0 ? (
-        <MothingSkeleton sessions={2} cells={4} />
+        ledger ? (
+          <FeedSkeleton rows={6} label="Loading observations" />
+        ) : (
+          <MothingSkeleton sessions={2} cells={4} />
+        )
       ) : observations.length === 0 ? (
         <p className="feed-empty">No moth observations yet.</p>
+      ) : ledger ? (
+        <div className="feed-ledger">
+          {sessions.map((session) => (
+            <section key={session.date} className="feed-day-group">
+              <header className="day-section-header">
+                <h3 className="day-header">Night of {formatDate(session.date)}</h3>
+                <p className="day-header-meta">{sessionLedgerMeta(session)}</p>
+              </header>
+              <FlatLedger rows={session.observations.map(mothLedgerRow)} />
+            </section>
+          ))}
+          {orphans.length > 0 && (
+            <section className="feed-day-group">
+              <header className="day-section-header">
+                <h3 className="day-header">Daytime &amp; untimed</h3>
+                <p className="day-header-meta">
+                  {orphans.length} observation{orphans.length === 1 ? '' : 's'}
+                </p>
+              </header>
+              <FlatLedger rows={orphans.map(mothLedgerRow)} />
+            </section>
+          )}
+        </div>
       ) : (
         <div className="mothing-sessions">
           {sessions.map((session) => (


### PR DESCRIPTION
## Summary

Extends the compact table (ledger) layout to the last two feed pages, honoring the same global layout toggle as the rest.

- **Mothing** — in the ledger, each night's session becomes a ledger day-group: a "Night of \<date\>" header with its moth / species count, then one compact row per observation (common name, faint scientific name, observed time) linking out to iNaturalist. The photo grid stays for the cards view.
- **Curating** — a flat ledger table of galleries (title · block count). The cover-thumbnail grid stays for the cards view.
- `FlatLedger` gains optional external links (iNaturalist / are.na) and a muted secondary suffix (the scientific name), and its right cell auto-sizes so it fits either a relative time or an "N blocks" count. Existing blogging / creating callers are unchanged.

## Testing
- `npm run build` passes.
- Rendered both the mothing (session-grouped) and curating (flat, block counts) ledgers with the real stylesheets in a headless browser and screenshotted them to confirm they match the home feed ledger aesthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_