### PR TITLE
Blog breadcrumb: keep the trail's bottom padding when no NSID is present

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -228,10 +228,12 @@
        padding-top is the only gap. */
     row-gap: 0;
   }
-  /* Drop the trail's bottom padding when the NSID stacks beneath it, so the
-     NSID sits close under the breadcrumb — reading as its caption rather than
-     a separate row. */
-  .chrome-bar-tertiary.is-detail .chrome-breadcrumb {
+  /* Drop the trail's bottom padding ONLY when an NSID stacks beneath it, so
+     the NSID sits close under the breadcrumb — reading as its caption rather
+     than a separate row. When there's no NSID (some detail pages don't report
+     one), the trail keeps its own bottom padding so it isn't jammed against
+     the strip's bottom edge. */
+  .chrome-bar-tertiary.is-detail:has(.chrome-crumb-nsid) .chrome-breadcrumb {
     padding-bottom: 0;
   }
   .chrome-bar-tertiary.is-detail .chrome-crumb-nsid {


### PR DESCRIPTION
Follow-up to #192.

That change zeroed the breadcrumb trail's `padding-bottom` on every mobile detail page so the stacked NSID would sit tight beneath it. But detail pages that don't report an NSID (e.g. some `/curating` channels) then had the trail jammed against the strip's bottom edge.

Gate the `padding-bottom: 0` behind `:has(.chrome-crumb-nsid)` so it only applies when the NSID actually stacks beneath the trail; otherwise the trail keeps its own `var(--space-2)` bottom padding. (`:has()` is already used elsewhere in this codebase.)

## Verification
Drove the page in Chromium at 390px and toggled the NSID node live to exercise both branches of `:has()`:
- With NSID → breadcrumb `padding-bottom: 0px` (tight caption).
- Without NSID → breadcrumb `padding-bottom: 8px` (restored, not cramped).

One file changed (`src/components/ChromeBar.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9MFZhyKBBLpB5ozGFeerz)_