### PR TITLE
Sky hour chip: render the label in caps (4PM, 11AM)

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -479,6 +479,9 @@
   font-size: 0.72rem;
   letter-spacing: 0.05em;
   font-variant-numeric: tabular-nums;
+  /* Hour keys are lowercase in data ("4pm"); the chip reads as a label,
+     so render it in caps: 4PM, 11AM. */
+  text-transform: uppercase;
 }
 
 /* The compass nav button is the menu trigger — promote it to a filled,


### PR DESCRIPTION
The temporary sky-theme hour chip now renders its label uppercase (4PM, 5PM, 11AM) via `text-transform: uppercase` on its CSS rule — the underlying hour keys stay lowercase in the data; only the display changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUxUhkqd5KkKY8kaQFHYnS)_