### PR TITLE
Flat ledger: category in its own gerund-style column

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1744,6 +1744,14 @@ a.ledger-verb:focus-visible {
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
+/* When the rows carry a category (creating's works), it sits in its own fixed
+   left column — exactly like the gerund column in the home feed ledger — so
+   every title lines up down the page instead of being pushed right by a
+   variable-width inline tag. Rows without a category keep an empty cell. */
+.feed-ledger-flat-kinded .feed-item-ledger {
+  grid-template-columns: var(--ledger-verb-col) minmax(0, 1fr) auto;
+}
+
 /* Whole-row links read as calm ledger text (ink title, faint time) — the
    accent only comes up on hover — rather than a page full of green links. */
 .feed-ledger-flat .ledger-body a {
@@ -1762,14 +1770,12 @@ a.ledger-time:focus-visible {
   color: var(--accent);
 }
 
-/* A kind tag ahead of the title (e.g. a work's category), in the same quiet
-   mono small-caps as the verb column it stands in for. */
-.ledger-kind {
-  font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.9);
-  letter-spacing: 0.06em;
-  color: var(--ink-faint);
-  margin-right: 0.5em;
+/* The category cell reuses the verb column's own type (.ledger-verb); this
+   just guards against a long medium ("photography", "presentation") colliding
+   with the title — it wraps inside its column instead. */
+.ledger-kind-col {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .ledger-track a {

--- a/src/components/FlatLedger.jsx
+++ b/src/components/FlatLedger.jsx
@@ -17,17 +17,27 @@ import { Link } from 'react-router-dom';
  *                can read the record type at the top of the scroll
  */
 export default function FlatLedger({ rows }) {
+  // When any row carries a category, give it its own fixed left column — the
+  // way the home feed ledger columns its gerund — so every title lines up.
+  const kinded = rows.some((row) => row.kind);
   return (
-    <ol className="feed-list feed-ledger feed-ledger-flat reveal-stagger">
+    <ol
+      className={`feed-list feed-ledger feed-ledger-flat${kinded ? ' feed-ledger-flat-kinded' : ''} reveal-stagger`}
+    >
       {rows.map((row, i) => (
         <li
           key={row.key || i}
           className="feed-item feed-item-ledger"
           data-nsid={row.nsid || undefined}
         >
+          {kinded &&
+            (row.kind ? (
+              <span className="ledger-verb ledger-kind-col">{row.kind}</span>
+            ) : (
+              <span className="ledger-verb" aria-hidden="true" />
+            ))}
           <div className="ledger-body">
             <p className="ledger-text">
-              {row.kind && <span className="ledger-kind small-caps">{row.kind}</span>}
               <RowLink row={row}>
                 {row.title}
                 {row.secondary && <span className="ledger-count"> ({row.secondary})</span>}


### PR DESCRIPTION
## Summary

On the creating ledger, a work's category was an inline tag ahead of the title, so titles started at a different x on every row. Give it its own fixed left column — the same mono, faint, lowercase treatment as the gerund column in the home feed ledger — so every title lines up. Rows with no category keep an aligned empty cell.

Feeds whose rows carry no category (blogging, mothing, curating) stay two-column and unchanged.

## Testing
- `npm run build` passes.
- Rendered the creating ledger with the real stylesheets in a headless browser and screenshotted it to confirm the category columns align like the home feed's gerunds and every title lines up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_