### PR TITLE
Moth ledger: thumbnail + stacked names, tap opens the lightbox

### DIFF
--- a/src/pages/Mothing.css
+++ b/src/pages/Mothing.css
@@ -168,6 +168,95 @@
   color: var(--ink-soft, var(--ink));
 }
 
+/* Mothing ledger — one compact row per observation: a small square thumb, the
+   common + scientific name stacked, and the observed time flush right. The
+   whole row opens the same lightbox the tile grid uses. */
+.mothing-ledger {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mothing-ledger-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-2) 0;
+  text-align: left;
+  font: inherit;
+  color: var(--ink);
+  background: none;
+  border: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--rule-soft) 55%, transparent);
+  cursor: zoom-in;
+  transition: background 120ms ease;
+}
+
+.mothing-ledger-item:last-child .mothing-ledger-row {
+  border-bottom: none;
+}
+
+.mothing-ledger-row:hover {
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.mothing-ledger-row-static {
+  cursor: default;
+}
+
+.mothing-ledger-row-static:hover {
+  background: none;
+}
+
+.mothing-ledger-thumb {
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  object-fit: cover;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  background: var(--page);
+}
+
+.mothing-ledger-thumb-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.mothing-ledger-names {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.mothing-ledger-name {
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.mothing-ledger-sci {
+  font-style: italic;
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  line-height: 1.3;
+}
+
+.mothing-ledger-time {
+  flex: 0 0 auto;
+  font-family: var(--mono);
+  font-size: calc(var(--text-xs) * 0.85);
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
 .mothing-source {
   margin-top: var(--space-6);
   font-size: var(--text-xs);

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 import PageShell from '../components/PageShell.jsx';
-import FlatLedger from '../components/FlatLedger.jsx';
 import Lightbox from '../components/Lightbox.jsx';
 import { MothingSkeleton, FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
@@ -118,19 +117,51 @@ function sessionLedgerMeta(session) {
   return parts.join(' · ');
 }
 
-/** One iNaturalist observation as a flat-ledger row (external link out). */
-function mothLedgerRow(obs) {
-  const name = obs.taxon?.commonName || obs.taxon?.name || 'Unidentified moth';
+/**
+ * One observation as a ledger row: a small square thumbnail, the common and
+ * scientific names stacked, and the observed time flush right. Tapping a row
+ * with a photo opens the in-page lightbox (the same one the tile grid uses);
+ * a photoless observation is a static row with a placeholder thumb.
+ */
+function MothLedgerRow({ obs, onOpen }) {
+  const photo = obs.photos?.[0];
+  const thumb = photo ? photoUrl(photo, 'square') : null;
+  const name = mothName(obs);
   const sci = obs.taxon?.name;
-  return {
-    key: obs.id,
-    href: obs.url,
-    external: true,
-    title: name,
-    secondary: sci && sci !== name ? sci : null,
-    time: obs.observedTime ? formatTime(obs.observedTime) : formatDate(obs.observedDate),
-    nsid: MOTHING_OBSERVATION_NSID,
-  };
+  const showSci = sci && sci !== name;
+  const time = obs.observedTime ? formatTime(obs.observedTime) : formatDate(obs.observedDate);
+  const inner = (
+    <>
+      {thumb ? (
+        <img className="mothing-ledger-thumb" src={thumb} alt="" loading="lazy" decoding="async" />
+      ) : (
+        <span className="mothing-ledger-thumb mothing-ledger-thumb-empty" aria-hidden="true">
+          &#x1F98B;
+        </span>
+      )}
+      <span className="mothing-ledger-names">
+        <span className="mothing-ledger-name">{name}</span>
+        {showSci && <span className="mothing-ledger-sci">{sci}</span>}
+      </span>
+      <span className="mothing-ledger-time">{time}</span>
+    </>
+  );
+  return (
+    <li className="mothing-ledger-item" data-nsid={MOTHING_OBSERVATION_NSID}>
+      {photo ? (
+        <button
+          type="button"
+          className="mothing-ledger-row"
+          onClick={() => onOpen(obs)}
+          aria-label={`View photo: ${name}`}
+        >
+          {inner}
+        </button>
+      ) : (
+        <div className="mothing-ledger-row mothing-ledger-row-static">{inner}</div>
+      )}
+    </li>
+  );
 }
 
 export default function Mothing() {
@@ -257,7 +288,11 @@ export default function Mothing() {
                 <h3 className="day-header">Night of {formatDate(session.date)}</h3>
                 <p className="day-header-meta">{sessionLedgerMeta(session)}</p>
               </header>
-              <FlatLedger rows={session.observations.map(mothLedgerRow)} />
+              <ol className="mothing-ledger reveal-stagger">
+                {session.observations.map((obs) => (
+                  <MothLedgerRow key={obs.id} obs={obs} onOpen={openLightbox} />
+                ))}
+              </ol>
             </section>
           ))}
           {orphans.length > 0 && (
@@ -268,7 +303,11 @@ export default function Mothing() {
                   {orphans.length} observation{orphans.length === 1 ? '' : 's'}
                 </p>
               </header>
-              <FlatLedger rows={orphans.map(mothLedgerRow)} />
+              <ol className="mothing-ledger reveal-stagger">
+                {orphans.map((obs) => (
+                  <MothLedgerRow key={obs.id} obs={obs} onOpen={openLightbox} />
+                ))}
+              </ol>
             </section>
           )}
         </div>


### PR DESCRIPTION
## Summary

Replace the moth ledger's generic flat rows with bespoke ones:

- Each row leads with a small square thumbnail, then the common name over the scientific name (stacked), with the observed time flush right.
- Tapping a row now opens the same in-page lightbox the tile grid uses (walking every photographed observation) instead of bouncing out to iNaturalist — the iNaturalist link lives in the lightbox's "source" control, alongside reverse-image search.
- Photoless observations stay as a static row with a placeholder thumb. Session grouping and the day-headers are unchanged.

## Testing
- `npm run build` passes.
- Rendered the ledger with the real stylesheets in a headless browser (placeholder squares standing in for the iNaturalist thumbnails, which aren't reachable offline) to confirm the thumbnail + stacked-names layout. Tap-to-open reuses the lightbox state already wired for the tile grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_