### PR TITLE
Surface new iNaturalist observations promptly: 6h mirror + live fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ only observations changed since the last sync (via iNaturalist's
 `updated_since`), writes just those to the right collection plus the two
 refreshed summaries, and deletes records for observations removed upstream (or
 moved across the moth boundary by a re-identification). `--dry-run` plans without
-writing; `--full` ignores the freshness marker. A daily Vercel cron
-(`/api/mirror-mothing`, see `vercel.json`) runs the same sync using
-`BSKY_APP_PASSWORD` (+ optional `BSKY_IDENTIFIER`); set `CRON_SECRET` to lock the
-endpoint down.
+writing; `--full` ignores the freshness marker. A Vercel cron runs the same
+sync every 6 hours (`/api/mirror-mothing`, see `vercel.json`), just before each
+`/api/rebuild`, so new observations reach the PDS — and the home feed — within
+hours instead of a day. It uses `BSKY_APP_PASSWORD` (+ optional
+`BSKY_IDENTIFIER`); set `CRON_SECRET` to lock the endpoint down. The freshness
+check makes the extra runs cheap: they no-op when nothing changed upstream.
 
 The `/mothing` page applies the same freshness check in the browser: it paints
 from the snapshot and only re-pulls the full observation set from iNaturalist

--- a/api/mirror-mothing.js
+++ b/api/mirror-mothing.js
@@ -1,6 +1,6 @@
 // Vercel serverless function: mirror every iNaturalist observation onto the
 // PDS, split by taxonomy into the mothing (moths) and observing (everything
-// else) collections. Wired into vercel.json as a daily cron; the same work
+// else) collections. Wired into vercel.json as a 6-hourly cron; the same work
 // can be run locally with `node scripts/mirror-inaturalist.mjs`.
 //
 // Incremental: a cheap freshness check skips the run when nothing changed;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -73,6 +73,10 @@ function postingReplyVerbLabel(reply) {
  * to the generic `/{nsid}/{rkey}` form that Record.jsx handles.
  */
 function hrefFor(item) {
+  // A live iNaturalist observation isn't mirrored to the PDS yet, so it has no
+  // record page — its card links out to iNaturalist instead. Skip the row's
+  // internal link so a stray tap can't land on a "record not found" page.
+  if (item._live) return null;
   return recordHrefFor(item.verb, {
     atUri: item.atUri,
     rkey: rkeyFromAtUri(item.atUri),

--- a/src/lib/feedBuilder.js
+++ b/src/lib/feedBuilder.js
@@ -12,7 +12,14 @@
 // pure function that the prefetch script calls when it needs to write a
 // per-collection JSON snapshot or a combined per-verb file.
 
-import { ME_DID, APPVIEW, COLLECTIONS } from '../config.js';
+import {
+  ME_DID,
+  APPVIEW,
+  COLLECTIONS,
+  INATURALIST_USER,
+  MOTHING_OBSERVATION_NSID,
+  OBSERVING_OBSERVATION_NSID,
+} from '../config.js';
 import {
   getAuthorFeed,
   listRecords,
@@ -20,6 +27,7 @@ import {
 import { VERB_REGISTRY } from './verbRegistry.js';
 import { isPortfolioDoc } from './publications.js';
 import { createSubjectResolver } from './subjectResolver.js';
+import { fetchLiveObservationItems } from './liveObservations.js';
 import { compareIsoDesc } from './time.js';
 
 /**
@@ -455,6 +463,24 @@ export function applyAgeCutoff(records, maxAgeDays) {
 }
 
 /**
+ * The highest iNaturalist id already mirrored, across both observation
+ * collections' fetched records (each keyed by its iNat id). Observation
+ * records list newest-first, so even a capped first-paint fetch still holds
+ * the true maximum. Returns null when no observations were fetched.
+ */
+function newestMirroredObservationId(perCollection) {
+  let max = 0;
+  for (const nsid of [MOTHING_OBSERVATION_NSID, OBSERVING_OBSERVATION_NSID]) {
+    const records = perCollection[nsid.replace(/\./g, '-')] || [];
+    for (const r of records) {
+      const n = Number(String(r?.uri || '').split('/').pop());
+      if (Number.isFinite(n) && n > max) max = n;
+    }
+  }
+  return max || null;
+}
+
+/**
  * Fetch every `app.bsky.graph.listitem` record and bucket them under their
  * parent list URI. Each list record gets a `_members` array of `{ did }`
  * entries (later resolved to handles via the bsky AppView).
@@ -650,6 +676,37 @@ export async function buildUnifiedFeed({
       (perVerb[item.verb] ||= []).push(item);
       unified.push(item);
     }
+  }
+
+  // Live-augment observations from iNaturalist: surface sightings newer than
+  // the newest mirrored record so they appear before the mirror cron writes
+  // them. Opt-in (`options.liveObservations`) — the browser turns it on; the
+  // static snapshot build leaves it off since the cron keeps that fresh. Each
+  // item borrows the deterministic at:// URI the mirror will assign (keyed by
+  // the iNat id), so it merges with — never duplicates — the record once
+  // mirrored.
+  if (options.liveObservations && (includeVerb('mothing') || includeVerb('observing'))) {
+    await safe('liveObservations', async () => {
+      const newestId = newestMirroredObservationId(perCollection);
+      const live = await fetchLiveObservationItems({
+        me,
+        newestMirroredId: newestId,
+        user: options.inaturalistUser || INATURALIST_USER,
+        wantMothing: includeVerb('mothing'),
+        wantObserving: includeVerb('observing'),
+        warn,
+      });
+      const seen = new Set(unified.map((i) => i.atUri));
+      let added = 0;
+      for (const item of live) {
+        if (!item.atUri || seen.has(item.atUri)) continue;
+        seen.add(item.atUri);
+        unified.push(item);
+        (perVerb[item.verb] ||= []).push(item);
+        added += 1;
+      }
+      counts.liveObservations = added;
+    }, null);
   }
 
   sortUnifiedFeed(unified);

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -289,6 +289,43 @@ export async function fetchObservations({ user = INATURALIST_USER, max = 1000, s
 }
 
 /**
+ * Fetch observations with an iNaturalist id greater than `sinceId` — the ones
+ * logged after the newest already mirrored to the PDS. Ordered by id ascending
+ * and paginated via `id_above`; `scope` defaults to ALL (moths + everything
+ * else) so the caller can split by each result's `isMoth` flag. Location is
+ * stripped by `normalizeObservation`. Returns [] when `sinceId` is falsy.
+ */
+export async function fetchObservationsNewerThanId({
+  user = INATURALIST_USER,
+  sinceId,
+  max = 200,
+  scope = ALL_SCOPE,
+} = {}) {
+  if (!sinceId) return [];
+  const out = [];
+  let above = String(sinceId);
+  while (out.length < max) {
+    const params = new URLSearchParams({
+      ...scopeParams(user, scope),
+      per_page: String(Math.min(PER_PAGE, max - out.length)),
+      order: 'asc',
+      order_by: 'id',
+      id_above: above,
+    });
+    const data = await fetchJson(`${INATURALIST_API}/observations?${params}`);
+    const batch = Array.isArray(data?.results) ? data.results : [];
+    if (batch.length === 0) break;
+    for (const o of batch) {
+      const n = normalizeObservation(o);
+      if (n) out.push(n);
+    }
+    above = String(batch[batch.length - 1].id);
+    if (batch.length < PER_PAGE) break;
+  }
+  return out;
+}
+
+/**
  * A cheap freshness signature for a scope: one tiny request that returns the
  * total count plus the most-recent edit instant (in UTC). Comparing this
  * against a stored signature tells us whether a full pull is even needed —

--- a/src/lib/liveObservations.js
+++ b/src/lib/liveObservations.js
@@ -1,0 +1,77 @@
+// Surface brand-new iNaturalist observations on the home feed before the
+// mirror cron has written them to the PDS.
+//
+// The home feed reads observations from mirrored `is.dame.{mothing,observing}.
+// observation` records, which the cron refreshes every few hours. This module
+// closes the remaining gap: it asks iNaturalist directly for anything logged
+// after the newest mirrored observation and shapes those into feed items.
+//
+// Each item is built from the SAME record value the mirror writes
+// (`mothingObservationValue` / `observingObservationValue`) and borrows the
+// deterministic `at://…/<iNat id>` URI the mirror will assign, so once the
+// observation IS mirrored the two are one and the same feed entry — the feed
+// dedupes on at:// URI, so there's never a duplicate. Location is stripped
+// upstream in `normalizeObservation`; it never reaches here.
+
+import { ME_DID, INATURALIST_USER, MOTHING_OBSERVATION_NSID, OBSERVING_OBSERVATION_NSID } from '../config.js';
+import {
+  fetchObservationsNewerThanId,
+  mothingObservationValue,
+  observingObservationValue,
+} from './inaturalist.js';
+
+// A short in-memory cache so the home feed's 30s background polls don't hit
+// iNaturalist every tick — a fresh observation still shows within the TTL.
+// Keyed by the inputs that change the result (newest mirrored id, user, which
+// verbs are wanted). Node one-shot runs never hit the second call.
+const TTL_MS = 120_000;
+let cache = null;
+
+/**
+ * @returns {Promise<object[]>} feed items for observations newer than the
+ *   newest mirrored one, shaped like the mirrored observation feed items.
+ */
+export async function fetchLiveObservationItems({
+  me = ME_DID,
+  newestMirroredId,
+  user = INATURALIST_USER,
+  wantMothing = true,
+  wantObserving = true,
+  warn = () => {},
+} = {}) {
+  if (!newestMirroredId || (!wantMothing && !wantObserving)) return [];
+
+  const key = `${me}|${newestMirroredId}|${user}|${wantMothing ? 1 : 0}${wantObserving ? 1 : 0}`;
+  if (cache && cache.key === key && Date.now() - cache.at < TTL_MS) return cache.items;
+
+  let observations;
+  try {
+    observations = await fetchObservationsNewerThanId({ user, sinceId: newestMirroredId });
+  } catch (err) {
+    warn('liveObservations: iNaturalist fetch failed:', err?.message || err);
+    return cache && cache.key === key ? cache.items : [];
+  }
+
+  const items = [];
+  for (const obs of observations) {
+    if (obs?.id == null) continue;
+    const isMoth = Boolean(obs.isMoth);
+    if (isMoth ? !wantMothing : !wantObserving) continue;
+    const nsid = isMoth ? MOTHING_OBSERVATION_NSID : OBSERVING_OBSERVATION_NSID;
+    const value = isMoth ? mothingObservationValue(obs) : observingObservationValue(obs);
+    items.push({
+      verb: isMoth ? 'mothing' : 'observing',
+      source: 'inaturalist',
+      createdAt: value.createdAt || null,
+      atUri: `at://${me}/${nsid}/${obs.id}`,
+      cid: null,
+      payload: value,
+      // Not yet on the PDS — the row links out to iNaturalist (ObservationCard
+      // already does), so a click never lands on a missing record page.
+      _live: true,
+    });
+  }
+
+  cache = { key, at: Date.now(), items };
+  return items;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -250,6 +250,9 @@ export default function Home() {
           authorFeedMax: INITIAL_FETCH_MAX,
           skipListMembers: true,
           verbs,
+          // Pull iNaturalist observations newer than the newest mirrored one
+          // so brand-new sightings show without waiting for the mirror cron.
+          liveObservations: true,
         },
       });
       live = Array.isArray(result?.unified) ? result.unified : null;

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "trailingSlash": false,
   "crons": [
     { "path": "/api/rebuild", "schedule": "0 */6 * * *" },
-    { "path": "/api/mirror-mothing", "schedule": "30 5 * * *" }
+    { "path": "/api/mirror-mothing", "schedule": "50 5,11,17,23 * * *" }
   ],
   "rewrites": [
     { "source": "/oauth-client-metadata.json", "destination": "/api/client-metadata" },


### PR DESCRIPTION
## Summary

New iNaturalist observations were taking up to a day to appear on the home feed. The pipeline was otherwise healthy — observations mirror correctly and the feed shows everything on the PDS — but the mirror ran only once a day, so anything logged after 05:30 UTC waited until the next morning. Two changes close the gap:

### 1. Mirror every 6 hours (was daily)
`/api/mirror-mothing` now runs at 05:50 / 11:50 / 17:50 / 23:50 UTC — every 6 hours, 10 minutes before each `/api/rebuild` so the regenerated snapshot picks up new observations too. The mirror is incremental with a cheap freshness check, so the extra runs no-op when nothing changed upstream.

### 2. Home feed live-fetches observations newer than the mirror
In addition to the cron, `buildUnifiedFeed` now queries iNaturalist directly (via `id_above`) for any observation logged after the newest one already mirrored, so brand-new sightings show immediately:

- New `fetchObservationsNewerThanId` + `src/lib/liveObservations.js` shape those observations into feed items using the exact record value the mirror writes and the deterministic `at://…/<iNat id>` URI it will assign (keyed by the iNat id) — so once mirrored the two are one entry and the feed dedupes them; no duplicate. Location is stripped upstream in `normalizeObservation`, as always.
- Opt-in via `options.liveObservations` (the browser turns it on; the static snapshot build leaves it off since the cron keeps that fresh). Each result is split into mothing vs observing by taxonomy and merged newest-first. A 2-minute cache keeps the 30s background polls from hitting iNaturalist every tick; failures fall back to the mirrored records.
- A live (not-yet-mirrored) observation row skips its internal record link (no PDS record yet); its card still links out to iNaturalist.

## Testing
- `npm run build` passes.
- Against live data: the live fetch returned exactly the two observations still missing from the PDS (logged today, correctly routed to `observing`), and the full `buildUnifiedFeed` merged them at the top of the feed newest-first (`counts.liveObservations = 2`) with no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_