### PR TITLE
Home feed ledger: show the iNaturalist specimen photo on observation rows

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1676,6 +1676,61 @@ a.ledger-verb:focus-visible {
   font-size: var(--text-sm);
 }
 
+/* iNaturalist observation rows carry a specimen thumbnail beside the
+   common + scientific names (see ObservationLedgerBody), mirroring the
+   /mothing page's ledger row. A photoless observation keeps the same
+   footprint via an empty bordered box. */
+.ledger-obs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.ledger-obs-thumb {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  height: 2.25rem;
+  object-fit: cover;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  background: var(--page);
+}
+
+.ledger-obs-thumb-empty {
+  display: block;
+}
+
+.ledger-obs-names {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.ledger-obs-name {
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  line-height: 1.2;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.ledger-obs-sci {
+  font-style: italic;
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+/* The observation body is taller than a text line; center the verb and
+   time labels against the thumbnail instead of pinning them to the
+   baseline of the first name line. */
+.feed-ledger .feed-item-ledger:has(.ledger-obs) {
+  align-items: center;
+}
+
 /* Listening sessions: tapping the row (or its "N songs +" toggle, the
    keyboard-accessible affordance) expands the batch into one sub-row
    per track. */

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -4,6 +4,7 @@ import { renderPostText } from '../lib/postRichText.jsx';
 import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import { photoUrl } from '../lib/inaturalist.js';
 import PostEmbed from './PostEmbed.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
 import { ME_DID } from '../config.js';
@@ -58,7 +59,10 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
   // Reposts skip the inline "@handle: text" summary entirely — the
   // original post renders as a quote-style box instead (see RepostQuote).
   const isRepost = item.verb === 'reposting';
-  const summary = isRepost ? null : summarize(item, { expanded, onToggle });
+  // iNaturalist observations render a specimen thumbnail beside stacked
+  // common/scientific names (see ObservationLedgerBody), not a text summary.
+  const isObservation = item.verb === 'mothing' || item.verb === 'observing';
+  const summary = isRepost || isObservation ? null : summarize(item, { expanded, onToggle });
   const embed = isRepost ? null : ledgerEmbed(item);
   return (
     <>
@@ -75,6 +79,7 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
       )}
       <div className="ledger-body">
         {isRepost && <RepostQuote item={item} />}
+        {isObservation && <ObservationLedgerBody item={item} />}
         {summary && <p className="ledger-text">{summary}</p>}
         {embed && (
           <div className="ledger-embed">
@@ -215,9 +220,8 @@ function summarize(item, listenControls) {
       const title = payload.title || payload.name || payload.description || payload.caption;
       return plain(title, 'a gallery');
     }
-    case 'mothing':
-    case 'observing':
-      return summarizeObservation(item);
+    // 'mothing' / 'observing' are handled separately (ObservationLedgerBody
+    // renders a thumbnail + names), so they never reach this text summary.
     case 'liking':
       return summarizeSubject(item.subject, item.source);
     case 'following':
@@ -372,23 +376,46 @@ function uniqueArtistNames(plays) {
   return out;
 }
 
-function summarizeObservation(item) {
+/**
+ * An iNaturalist observation as a ledger body: a small square specimen
+ * thumbnail beside the common and scientific names stacked, mirroring the
+ * /mothing page's ledger row (MothLedgerRow). The verb cell already names
+ * the activity ("mothing" / "observing") and the row's own time column
+ * carries the timestamp, so this cell only owns the photo + names. Works
+ * for both mirrored records and live-fetched observations — same
+ * `photos: [{ id, url, … }]` / `taxon` payload shape.
+ */
+function ObservationLedgerBody({ item }) {
   const payload = item.payload || {};
+  const photo = Array.isArray(payload.photos) ? payload.photos[0] : null;
+  const thumb = photo ? photoUrl(photo, 'square') : null;
   const common = payload.taxon?.commonName;
   const sci = payload.taxon?.name;
-  const title = common || sci;
-  if (!title) {
-    return (
-      <Placeholder>
-        {item.verb === 'mothing' ? 'an unidentified moth' : 'an unidentified organism'}
-      </Placeholder>
-    );
-  }
+  const name = common || sci;
+  const showSci = sci && sci !== name;
+  const fallback = item.verb === 'mothing' ? 'an unidentified moth' : 'an unidentified organism';
   return (
-    <>
-      {title}
-      {sci && sci !== title && <span className="ledger-count"> ({sci})</span>}
-    </>
+    <div className="ledger-obs">
+      {thumb ? (
+        <img
+          className="ledger-obs-thumb"
+          src={thumb}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          width={36}
+          height={36}
+        />
+      ) : (
+        <span className="ledger-obs-thumb ledger-obs-thumb-empty" aria-hidden="true" />
+      )}
+      <span className="ledger-obs-names">
+        <span className="ledger-obs-name">
+          {name || <Placeholder>{fallback}</Placeholder>}
+        </span>
+        {showSci && <span className="ledger-obs-sci">{sci}</span>}
+      </span>
+    </div>
   );
 }
 


### PR DESCRIPTION
Mothing/observing rows in the home feed's **ledger** layout now lead with a small square specimen thumbnail beside the common and scientific names stacked — mirroring the `/mothing` page's ledger row.

## Changes
- **`src/components/FeedLedgerRow.jsx`** — observation rows (`mothing` / `observing`) render a new `ObservationLedgerBody`: a square iNat thumbnail (`photoUrl(photo, 'square')`) + the common name in serif with the scientific name italic beneath, instead of the old one-line text summary. Removed the now-dead `summarizeObservation` text path.
- **`src/components/Feed.css`** — added `.ledger-obs*` classes and a `:has(.ledger-obs)` rule so the verb and time columns center against the thumbnail rather than pinning to the first text line.

## Notes
- Works for both mirrored records and live-fetched observations (identical `photos` / `taxon` payload shape).
- A photoless observation keeps the same footprint via an empty bordered box; when only a scientific name exists it shows once (no duplication).
- Square edges (`--radius-2: 0`) and semantic color tokens only, so it's correct across every theme × mode.

Verified with a production build and a headless-Chromium render of real `FeedLedgerRow` output against the actual stylesheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_