### PR TITLE
Fix iNaturalist observation timestamps in the home feed

### DIFF
--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { formatTime } from '../lib/time.js';
+import { formatTime, formatWallClockTime } from '../lib/time.js';
 import { renderPostText } from '../lib/postRichText.jsx';
 import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
@@ -64,6 +64,16 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
   const isObservation = item.verb === 'mothing' || item.verb === 'observing';
   const summary = isRepost || isObservation ? null : summarize(item, { expanded, onToggle });
   const embed = isRepost ? null : ledgerEmbed(item);
+  // Observations show their stored local wall-clock time-of-day directly, never
+  // localized — the record's timestamp is that wall-clock pinned to `Z`, so
+  // running it through `formatTime` (which localizes) would re-shift the clock
+  // (a 2:59pm sighting reading 10:59am). Falls back to the localized time only
+  // for the rare observation with no recorded time.
+  const timeText = isObservation
+    ? formatWallClockTime(item.payload?.observedTime) || (ts ? formatTime(ts) : '')
+    : ts
+      ? formatTime(ts)
+      : '';
   return (
     <>
       {/* Label-less rows (thread continuations) keep an empty verb cell
@@ -87,7 +97,7 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
           </div>
         )}
       </div>
-      <span className="ledger-time">{ts ? formatTime(ts) : ''}</span>
+      <span className="ledger-time">{timeText}</span>
       {expanded && isListenBatch(item) && item.plays.map((play) => {
         const playTs = play?.createdAt || play?.payload?.playedTime || null;
         const playHref = recordPathFromAtUri(play?.atUri);

--- a/src/lib/feedBuilder.js
+++ b/src/lib/feedBuilder.js
@@ -28,6 +28,7 @@ import { VERB_REGISTRY } from './verbRegistry.js';
 import { isPortfolioDoc } from './publications.js';
 import { createSubjectResolver } from './subjectResolver.js';
 import { fetchLiveObservationItems } from './liveObservations.js';
+import { observationFeedInstant } from './inaturalist.js';
 import { compareIsoDesc } from './time.js';
 
 /**
@@ -707,6 +708,19 @@ export async function buildUnifiedFeed({
       }
       counts.liveObservations = added;
     }, null);
+  }
+
+  // Observations store their local wall-clock pinned to `Z` (privacy: no tz
+  // offset is ever persisted). That fake-UTC value sorts ~offset hours early
+  // against real-UTC records and buckets into the wrong local day. Rebuild each
+  // observation's ordering timestamp as a local instant so it interleaves and
+  // day-groups correctly. No-op in Node/UTC (snapshot unchanged); in the
+  // browser it maps the observer's wall-clock to the viewer's clock. Both the
+  // mirrored and the live-augmented items carry `observedDate`/`observedTime`.
+  for (const item of unified) {
+    if (item.verb !== 'mothing' && item.verb !== 'observing') continue;
+    const instant = observationFeedInstant(item.payload?.observedDate, item.payload?.observedTime);
+    if (instant) item.createdAt = instant;
   }
 
   sortUnifiedFeed(unified);

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -549,6 +549,35 @@ export function observedTimestamp(observedDate, observedTime) {
 }
 
 /**
+ * The instant to ORDER and DISPLAY an observation by in a feed, rebuilt from
+ * its stored local wall-clock (`observedDate` + `observedTime`) interpreted in
+ * the *runtime's* time zone.
+ *
+ * `observedTimestamp` pins the wall-clock to `Z` so no tz offset is ever stored
+ * (a tz offset is a coarse location hint). But that fake-UTC value is not a real
+ * instant: against genuinely-UTC records (Bluesky posts, statuses) it sorts
+ * ~offset hours early, and localizing it for display double-shifts the clock
+ * (a 2:59pm sighting reads 10:59am to an observer in UTC−4). Reconstructing it
+ * as a local instant restores correct interleaving, correct local-day
+ * bucketing, and — round-tripped back through `toLocaleTimeString` — the right
+ * displayed time, for a viewer in the observer's own zone (the common case; the
+ * offset is never persisted, so a far-away viewer still can't do better).
+ *
+ * In Node/UTC (the static prefetch) this returns the same instant as
+ * `observedTimestamp`, so the snapshot is byte-identical; only the browser
+ * rebuild, running in the viewer's zone, shifts it.
+ */
+export function observationFeedInstant(observedDate, observedTime) {
+  const dm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(observedDate || ''));
+  if (!dm) return null;
+  const tm = /^(\d{2}):(\d{2})$/.exec(String(observedTime || ''));
+  const hh = tm ? Number(tm[1]) : 12; // noon fallback for a timeless observation
+  const mm = tm ? Number(tm[2]) : 0;
+  const d = new Date(Number(dm[1]), Number(dm[2]) - 1, Number(dm[3]), hh, mm, 0, 0);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/**
  * One observation record value under `$type`, keyed downstream by the iNat
  * id. The mothing and observing observation lexicons share the exact same
  * shape — only the `$type` differs — so both go through here.

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -147,6 +147,22 @@ export function formatTime(date) {
 }
 
 /**
+ * Format a bare local wall-clock "HH:MM" (24-hour) as a lowercase 12-hour
+ * time like "2:59 pm" — no Date, no timezone conversion. Use this for values
+ * that are ALREADY local time-of-day (e.g. an iNaturalist observation's stored
+ * wall-clock); running them through `formatTime`, which localizes, would
+ * re-shift the clock and show the wrong time. Returns '' for non-"HH:MM" input.
+ */
+export function formatWallClockTime(hhmm) {
+  const m = /^(\d{2}):(\d{2})$/.exec(String(hhmm || ''));
+  if (!m) return '';
+  let h = Number(m[1]);
+  const ampm = h >= 12 ? 'pm' : 'am';
+  h = h % 12 || 12;
+  return `${h}:${m[2]} ${ampm}`;
+}
+
+/**
  * Turn ISO into something that round-trips through JSON without locale drift.
  */
 export function toIso(date) {


### PR DESCRIPTION
Observation rows in the home feed showed the wrong time (a 2:59 PM sighting read 10:59 am) and sorted into the wrong place (below same-day posts they were actually later than).

## Root cause
To protect location privacy, the mirror deliberately drops the timezone offset and stores each observation's **local wall-clock** pinned to `Z` (`observedTimestamp`) — so 2:59 PM EDT becomes `2026-07-11T14:59:00.000Z`. The home feed treated that fake-UTC value as a real instant, which broke two things for a viewer whose zone isn't UTC:

- **Display** — `formatTime` localized `14:59Z` to the viewer's zone → a second 4-hour shift → 10:59 am.
- **Sort / day-grouping** — it sorted ~offset hours early, so observations sank below same-day statuses/posts they were actually later than.

## Fix (no offset persisted)
- **`src/lib/feedBuilder.js`** — just before sorting, each observation's ordering timestamp is rebuilt from its wall-clock interpreted in the runtime's own zone (`observationFeedInstant`), so it interleaves and day-buckets correctly. **No-op in Node/UTC**, so the static prefetch snapshot is byte-identical; only the browser rebuild shifts it into the viewer's zone.
- **`src/components/FeedLedgerRow.jsx`** — observation rows display the wall-clock time-of-day directly (`formatWallClockTime`), tz-independent, matching the `/mothing` page.
- **`src/lib/inaturalist.js`** / **`src/lib/time.js`** — the two new pure helpers.

## Trade-off
The offset is never stored, so the wall-clock is treated as the *viewer's* local time — correct for the observer's own zone (the common case); a distant-timezone viewer can't do better without the location data we intentionally drop.

## Verification
Simulating the EDT observer zone: `14:59` → **2:59 pm** (was 10:59 am), `15:25` → **3:25 pm**; feed order becomes `3:25pm > 2:59pm > brunch(12:06pm)`. UTC no-op confirmed (snapshot unchanged). Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_