### PR TITLE
Home feed ledger: tap an observation to open the image lightbox

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1738,6 +1738,12 @@ a.ledger-verb:focus-visible {
   cursor: pointer;
 }
 
+/* A photographed observation row opens the image lightbox on tap — signal
+   it with the same zoom affordance the /mothing grid uses. */
+.feed-item-ledger-lightbox {
+  cursor: zoom-in;
+}
+
 .ledger-count-toggle {
   background: none;
   border: none;

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -98,7 +98,7 @@ function hrefFor(item) {
  * so this component never has to reconcile ledger rows with the
  * selection UI.
  */
-export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
+export default function FeedItem({ item, showVerb = true, layout = 'cards', onOpenLightbox = null }) {
   const navigate = useNavigate();
   const edit = useEditMode();
   // Ledger-only: whether a collapsed listening session is showing its
@@ -142,6 +142,15 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
   // (each expanded track links to its own record page, and the verb cell
   // still links to the session's record).
   const ledgerListenBatch = ledger && isListenBatch(item);
+  // A photographed observation opens the in-feed image lightbox on tap
+  // (like the /mothing page) instead of navigating to its record page. The
+  // verb cell keeps linking to the record, so both paths stay reachable.
+  const isObservation = item.verb === 'mothing' || item.verb === 'observing';
+  const canLightbox =
+    ledger &&
+    isObservation &&
+    typeof onOpenLightbox === 'function' &&
+    Boolean(item.payload?.photos?.[0]);
 
   // Make the whole row tappable as a convenience — handy on mobile where the
   // verb badge / timestamp are small hit targets. We bail when the click
@@ -150,13 +159,17 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
   // (Cmd/Ctrl/middle-click — let the browser open it in a new tab via the
   // verb badge / timestamp links instead).
   function handleRowClick(e) {
-    if (!href && !ledgerListenBatch) return;
+    if (!href && !ledgerListenBatch && !canLightbox) return;
     if (e.defaultPrevented) return;
     if (e.button !== undefined && e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     if (e.target.closest('a, button, input, textarea, label, select, [role="button"], [role="link"]')) return;
     const sel = typeof window !== 'undefined' ? window.getSelection() : null;
     if (sel && sel.toString().length > 0) return;
+    if (canLightbox) {
+      onOpenLightbox(item);
+      return;
+    }
     if (ledgerListenBatch) {
       setLedgerExpanded((v) => !v);
       return;
@@ -211,6 +224,7 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
     `feed-item-${item.verb}`,
     ledger ? 'feed-item-ledger' : '',
     ledgerListenBatch ? 'feed-item-ledger-expandable' : '',
+    canLightbox ? 'feed-item-ledger-lightbox' : '',
     item._thread ? 'feed-item-thread' : '',
     item._thread?.isFirst ? 'feed-item-thread-first' : '',
     item._thread?.isLast ? 'feed-item-thread-last' : '',
@@ -229,7 +243,7 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards' }) {
       data-thread-length={item._thread?.length}
       onClickCapture={selectable ? handleSelectCapture : undefined}
       onClick={
-        !selectable && !listeningEdit && (href || ledgerListenBatch)
+        !selectable && !listeningEdit && (href || ledgerListenBatch || canLightbox)
           ? handleRowClick
           : undefined
       }

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { formatTime } from '../lib/time.js';
+import { formatTime, formatWallClockTime } from '../lib/time.js';
 import { renderPostText } from '../lib/postRichText.jsx';
 import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
@@ -64,6 +64,16 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
   const isObservation = item.verb === 'mothing' || item.verb === 'observing';
   const summary = isRepost || isObservation ? null : summarize(item, { expanded, onToggle });
   const embed = isRepost ? null : ledgerEmbed(item);
+  // Observations show their stored local wall-clock time-of-day directly, never
+  // localized — the record's timestamp is that wall-clock pinned to `Z`, so
+  // running it through `formatTime` (which localizes) would re-shift the clock
+  // (a 2:59pm sighting reading 10:59am). Falls back to the localized time only
+  // for the rare observation with no recorded time.
+  const timeText = isObservation
+    ? formatWallClockTime(item.payload?.observedTime) || (ts ? formatTime(ts) : '')
+    : ts
+      ? formatTime(ts)
+      : '';
   return (
     <>
       {/* Label-less rows (thread continuations) keep an empty verb cell
@@ -87,7 +97,7 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
           </div>
         )}
       </div>
-      <span className="ledger-time">{ts ? formatTime(ts) : ''}</span>
+      <span className="ledger-time">{timeText}</span>
       {expanded && isListenBatch(item) && item.plays.map((play) => {
         const playTs = play?.createdAt || play?.payload?.playedTime || null;
         const playHref = recordPathFromAtUri(play?.atUri);

--- a/src/lib/feedBuilder.js
+++ b/src/lib/feedBuilder.js
@@ -28,6 +28,7 @@ import { VERB_REGISTRY } from './verbRegistry.js';
 import { isPortfolioDoc } from './publications.js';
 import { createSubjectResolver } from './subjectResolver.js';
 import { fetchLiveObservationItems } from './liveObservations.js';
+import { observationFeedInstant } from './inaturalist.js';
 import { compareIsoDesc } from './time.js';
 
 /**
@@ -707,6 +708,19 @@ export async function buildUnifiedFeed({
       }
       counts.liveObservations = added;
     }, null);
+  }
+
+  // Observations store their local wall-clock pinned to `Z` (privacy: no tz
+  // offset is ever persisted). That fake-UTC value sorts ~offset hours early
+  // against real-UTC records and buckets into the wrong local day. Rebuild each
+  // observation's ordering timestamp as a local instant so it interleaves and
+  // day-groups correctly. No-op in Node/UTC (snapshot unchanged); in the
+  // browser it maps the observer's wall-clock to the viewer's clock. Both the
+  // mirrored and the live-augmented items carry `observedDate`/`observedTime`.
+  for (const item of unified) {
+    if (item.verb !== 'mothing' && item.verb !== 'observing') continue;
+    const instant = observationFeedInstant(item.payload?.observedDate, item.payload?.observedTime);
+    if (instant) item.createdAt = instant;
   }
 
   sortUnifiedFeed(unified);

--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -549,6 +549,35 @@ export function observedTimestamp(observedDate, observedTime) {
 }
 
 /**
+ * The instant to ORDER and DISPLAY an observation by in a feed, rebuilt from
+ * its stored local wall-clock (`observedDate` + `observedTime`) interpreted in
+ * the *runtime's* time zone.
+ *
+ * `observedTimestamp` pins the wall-clock to `Z` so no tz offset is ever stored
+ * (a tz offset is a coarse location hint). But that fake-UTC value is not a real
+ * instant: against genuinely-UTC records (Bluesky posts, statuses) it sorts
+ * ~offset hours early, and localizing it for display double-shifts the clock
+ * (a 2:59pm sighting reads 10:59am to an observer in UTC−4). Reconstructing it
+ * as a local instant restores correct interleaving, correct local-day
+ * bucketing, and — round-tripped back through `toLocaleTimeString` — the right
+ * displayed time, for a viewer in the observer's own zone (the common case; the
+ * offset is never persisted, so a far-away viewer still can't do better).
+ *
+ * In Node/UTC (the static prefetch) this returns the same instant as
+ * `observedTimestamp`, so the snapshot is byte-identical; only the browser
+ * rebuild, running in the viewer's zone, shifts it.
+ */
+export function observationFeedInstant(observedDate, observedTime) {
+  const dm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(observedDate || ''));
+  if (!dm) return null;
+  const tm = /^(\d{2}):(\d{2})$/.exec(String(observedTime || ''));
+  const hh = tm ? Number(tm[1]) : 12; // noon fallback for a timeless observation
+  const mm = tm ? Number(tm[2]) : 0;
+  const d = new Date(Number(dm[1]), Number(dm[2]) - 1, Number(dm[3]), hh, mm, 0, 0);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/**
  * One observation record value under `$type`, keyed downstream by the iNat
  * id. The mothing and observing observation lexicons share the exact same
  * shape — only the `$type` differs — so both go through here.

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -147,6 +147,22 @@ export function formatTime(date) {
 }
 
 /**
+ * Format a bare local wall-clock "HH:MM" (24-hour) as a lowercase 12-hour
+ * time like "2:59 pm" — no Date, no timezone conversion. Use this for values
+ * that are ALREADY local time-of-day (e.g. an iNaturalist observation's stored
+ * wall-clock); running them through `formatTime`, which localizes, would
+ * re-shift the clock and show the wrong time. Returns '' for non-"HH:MM" input.
+ */
+export function formatWallClockTime(hhmm) {
+  const m = /^(\d{2}):(\d{2})$/.exec(String(hhmm || ''));
+  if (!m) return '';
+  let h = Number(m[1]);
+  const ampm = h >= 12 ? 'pm' : 'am';
+  h = h % 12 || 12;
+  return `${h}:${m[2]} ${ampm}`;
+}
+
+/**
  * Turn ISO into something that round-trips through JSON without locale drift.
  */
 export function toIso(date) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,6 +11,8 @@ import FeedFilters, {
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
 import HeroSentence from '../components/HeroSentence.jsx';
+import Lightbox from '../components/Lightbox.jsx';
+import { photoUrl } from '../lib/inaturalist.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import {
   readFeedCache,
@@ -456,6 +458,48 @@ export default function Home() {
   const visible = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
   const hasMore = filtered.length > visible.length;
 
+  // Photographed iNaturalist observations (mothing + observing) currently in
+  // view, shaped for the in-feed image lightbox. Tapping an observation row
+  // opens this at that observation's index; prev/next then walks every
+  // observation on screen — the home-feed cousin of the /mothing grid's
+  // lightbox. Keyed by at:// URI so a tapped row maps straight to its slide.
+  const observationPhotos = useMemo(() => {
+    const images = [];
+    const indexByUri = new Map();
+    for (const item of visible) {
+      if (item.verb !== 'mothing' && item.verb !== 'observing') continue;
+      const photo = item.payload?.photos?.[0];
+      const large = photo ? photoUrl(photo, 'large') : null;
+      if (!large) continue;
+      const taxon = item.payload?.taxon || {};
+      const name =
+        taxon.commonName ||
+        taxon.name ||
+        (item.verb === 'mothing' ? 'Unidentified moth' : 'Unidentified organism');
+      const sci = taxon.name;
+      if (item.atUri) indexByUri.set(item.atUri, images.length);
+      images.push({
+        src: large,
+        thumb: photoUrl(photo, 'medium'),
+        alt: sci && sci !== name ? `${name} — ${sci}` : name,
+        sourceUrl: item.payload?.url || undefined,
+        searchUrl: `https://lens.google.com/uploadbyurl?url=${encodeURIComponent(large)}`,
+      });
+    }
+    return { images, indexByUri };
+  }, [visible]);
+
+  // `lightboxIndex` is the active slide, -1 when closed. A ref carries the
+  // latest URI→index map so the open callback stays stable across renders
+  // (it's handed to every FeedItem).
+  const [lightboxIndex, setLightboxIndex] = useState(-1);
+  const observationPhotosRef = useRef(observationPhotos);
+  observationPhotosRef.current = observationPhotos;
+  const openObservationLightbox = useCallback((item) => {
+    const idx = observationPhotosRef.current.indexByUri.get(item?.atUri);
+    if (typeof idx === 'number' && idx >= 0) setLightboxIndex(idx);
+  }, []);
+
   // The feed has no single backing record, so hand the global footer the
   // newest visible record's instant — it reports "latest record …" in place
   // of the record page's "written … · updated …" pair.
@@ -557,7 +601,11 @@ export default function Home() {
                             delay: reduce ? 0 : stagger,
                           }}
                         >
-                          <FeedItem item={item} layout={ledger ? 'ledger' : 'cards'} />
+                          <FeedItem
+                            item={item}
+                            layout={ledger ? 'ledger' : 'cards'}
+                            onOpenLightbox={ledger ? openObservationLightbox : undefined}
+                          />
                         </motion.li>
                       );
                     })}
@@ -580,6 +628,13 @@ export default function Home() {
           </div>
         )}
       </section>
+
+      <Lightbox
+        open={lightboxIndex >= 0}
+        index={Math.max(0, lightboxIndex)}
+        onClose={() => setLightboxIndex(-1)}
+        images={observationPhotos.images}
+      />
     </PageShell>
   );
 }


### PR DESCRIPTION
Tapping a photographed iNaturalist observation (`mothing`/`observing`) row in the home feed's ledger now opens the in-feed image lightbox — the home-feed cousin of the `/mothing` grid's lightbox — instead of navigating to the record page.

## Changes
- **`src/pages/Home.jsx`** — builds the lightbox image list from the observations currently in view (keyed by `at://` URI so a tapped row maps straight to its slide), holds the active-slide state, and renders a page-level `<Lightbox>`. An open callback is passed to `FeedItem`, but only in ledger mode.
- **`src/components/FeedItem.jsx`** — a photographed observation row routes a tap to `onOpenLightbox(item)` instead of navigating. The verb cell keeps its record-page link, so a tap on the verb word bails out of the row handler like any nested link — both the photo and the record stay reachable. Live observations (no record page) open the lightbox on any row tap.
- **`src/components/Feed.css`** — a `zoom-in` cursor on lightbox-openable rows to signal the affordance.

## Behavior
- Tap the thumbnail or names → enlarged image; prev/next walks every observation on screen, with **source** (iNaturalist) and **reverse-image-search** links in the control bar.
- Tap the verb ("observing"/"mothing") → still goes to the record page.
- Works for both mirrored and live observations.

## Verification
Drove a real `FeedItem` in headless Chromium: the actual `Lightbox` opened on a thumbnail tap (enlarged image + source link + close control), and a routing test reported **PASS** — thumbnail and names each fire `onOpenLightbox` once with the correct URI, the verb link fires it zero times and keeps its record-page href. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqwfv5WvVxzqaj9vHLuLr9)_