### PR TITLE
Guestbook: sign the site with a record on your own PDS, assembled from backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Schema-only documentation lives under [`lexicons/`](lexicons/):
   dropped or double-counted. Same location-stripping guarantee. The
   `is.dame.observing/self` summary doubles as the incremental mirror's
   freshness marker across all observations.
+- `is.dame.guestbook` / `is.dame.guestbook.entry` — a decentralized
+  guestbook, rendered at `/guestbook`. The book is a singleton on my PDS
+  (`at://{me}/is.dame.guestbook/self`); each signature is an
+  `is.dame.guestbook.entry` record **on the visitor's own PDS** whose
+  `subject` backlinks to the book. Reads are assembled live from
+  Constellation backlinks hydrated through Slingshot; writes happen in the
+  browser via atproto OAuth. See [`lexicons/GUESTBOOK.md`](lexicons/GUESTBOOK.md).
+  Create the book once with [`scripts/create-guestbook.mjs`](scripts/create-guestbook.mjs).
 
 Plus `fm.teal.alpha.feed.play` (teal.fm) for the now-playing signal.
 

--- a/lexicons/GUESTBOOK.md
+++ b/lexicons/GUESTBOOK.md
@@ -1,0 +1,68 @@
+# Guestbook lexicons
+
+A decentralized guestbook on the AT Protocol. The book lives on the host's
+PDS; every signature lives on the **signer's** PDS. No central database holds
+the messages — the guestbook is assembled at read time from backlinks.
+
+```
+is.dame.guestbook (self)          ← on MY repo: the book itself (title, description)
+        ▲
+        │ subject (at-uri)
+        │
+is.dame.guestbook.entry           ← on EACH VISITOR's repo: their signature
+  { subject, text?, signature?, mark?, location?, createdAt }
+```
+
+## The two records
+
+### `is.dame.guestbook` — the book
+
+A singleton (`rkey = self`) on the host's repo. It exists mainly to be a
+stable **backlink target**: entries point their `subject` at
+`at://<host-did>/is.dame.guestbook/self`. It also carries the book's display
+title and a description of what signing means. Create it once with
+[`scripts/create-guestbook.mjs`](../scripts/create-guestbook.mjs).
+
+### `is.dame.guestbook.entry` — a signature
+
+One record per signature, written to the **visitor's own repo** when they sign
+in with atproto OAuth on `/guestbook`. Everything except `subject` and
+`createdAt` is optional, so a signature can be:
+
+- a **message** (`text`, ≤300 graphemes),
+- just a **mark** (`mark`, one glyph — "I was here"),
+- or both, plus an optional `signature` (a name to sign as, when the profile
+  displayName isn't how they want to be remembered) and `location`
+  (free-text "signing from…" — never structured geo data).
+
+## How the book is read
+
+1. **Backlinks — [Constellation](https://constellation.microcosm.blue).**
+   `blue.microcosm.links.getBacklinks` with
+   `subject = at://…/is.dame.guestbook/self` and
+   `source = is.dame.guestbook.entry:subject` returns
+   `{ total, records: [{did, collection, rkey}], cursor }` — the list of
+   everyone who signed, newest first, paginated.
+2. **Hydration — [Slingshot](https://slingshot.microcosm.blue).** Each
+   `(did, collection, rkey)` triple is fetched through Slingshot's cached
+   `com.atproto.repo.getRecord`, which resolves the signer's PDS itself.
+   If Slingshot is down, we fall back to resolving the DID document and
+   hitting the signer's PDS directly.
+3. **Identity.** Signer profiles (avatar, displayName, handle) come from the
+   public Bluesky AppView in batches of 25 (`app.bsky.actor.getProfiles`).
+
+Because reading is pure backlink-assembly, a future **AppView** for guestbooks
+only needs to index `is.dame.guestbook.entry` records from the firehose — the
+site would swap step 1–3 for one call without any schema change. And any other
+site can host its own book with the same two lexicons.
+
+## Moderation & ownership
+
+- A visitor can **delete their signature** (it's their record; the site offers
+  the button, `com.atproto.repo.deleteRecord` does the rest) — the backlink
+  disappears from Constellation and the book on the next read.
+- The host can't delete a visitor's record, only choose not to render it;
+  a `hidden`-list on the book record is the natural extension point if it's
+  ever needed.
+- Nothing sensitive is collected: no email, no IP, no structured location —
+  `location` is a free-text field the signer types (or leaves empty).

--- a/lexicons/GUESTBOOK.md
+++ b/lexicons/GUESTBOOK.md
@@ -61,8 +61,15 @@ site can host its own book with the same two lexicons.
 - A visitor can **delete their signature** (it's their record; the site offers
   the button, `com.atproto.repo.deleteRecord` does the rest) — the backlink
   disappears from Constellation and the book on the next read.
-- The host can't delete a visitor's record, only choose not to render it;
-  a `hidden`-list on the book record is the natural extension point if it's
-  ever needed.
+- The host can't delete a visitor's record, only decline to render it. That's
+  the book's **`hidden`** list: an array of entry at-uris the host has tucked
+  out of public display. Hiding/unhiding is a `putRecord` on the book (with a
+  CID swap so concurrent edits can't clobber each other); the public page
+  filters entries against the list at read time and subtracts them from the
+  signature count. Because the list lives on the book record, moderation
+  state is itself portable — any other renderer of the same book can honor
+  (or inspect) it. The site offers it in two places: **edit mode** on
+  `/guestbook` (the owner's pencil button — each signature grows hide/unhide)
+  and the **Guestbook panel** in `/admin` (`?view=guestbook`).
 - Nothing sensitive is collected: no email, no IP, no structured location —
   `location` is a free-text field the signer types (or leaves empty).

--- a/lexicons/is.dame.guestbook.entry.json
+++ b/lexicons/is.dame.guestbook.entry.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.guestbook.entry",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "description": "A guestbook signature. Lives on the SIGNER's repo — the visitor keeps their own words — and points at the book it signs via `subject`, so backlink indexers (Constellation et al.) can assemble the book without any central database. A signature can carry a message, or be nothing more than a mark: proof of presence, like initials scratched into a trail register.",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "The at-uri of the is.dame.guestbook record being signed."
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "Optional note to the host. Plain text."
+          },
+          "signature": {
+            "type": "string",
+            "maxLength": 640,
+            "maxGraphemes": 64,
+            "description": "Optional name to sign as. Omit to be shown by profile displayName / handle."
+          },
+          "mark": {
+            "type": "string",
+            "maxLength": 64,
+            "maxGraphemes": 1,
+            "description": "Optional single glyph left in the margin — an emoji or character, e.g. '✕', '☾', '🌱'."
+          },
+          "location": {
+            "type": "string",
+            "maxLength": 640,
+            "maxGraphemes": 64,
+            "description": "Optional free-text 'signing from…' — a city, a website, 'the bus', anything."
+          },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/is.dame.guestbook.json
+++ b/lexicons/is.dame.guestbook.json
@@ -1,0 +1,22 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.guestbook",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "description": "A guestbook — the 'book' itself, living on the host's PDS. Visitors sign it by writing an is.dame.guestbook.entry record on their OWN repo whose `subject` points at this record's at-uri; the backlinks (indexed by services like Constellation) ARE the guestbook's pages. Singleton for now (rkey 'self'), but nothing prevents a host from keeping several books under other keys someday.",
+      "record": {
+        "type": "object",
+        "required": ["title", "createdAt"],
+        "properties": {
+          "title":       { "type": "string", "maxLength": 640, "maxGraphemes": 64, "description": "Display title of the book, e.g. 'the dame.is guestbook'." },
+          "description": { "type": "string", "maxLength": 3000, "maxGraphemes": 300, "description": "What signing this book means, shown to would-be signers." },
+          "url":         { "type": "string", "format": "uri", "description": "Where the guestbook renders, e.g. https://dame.is/guestbook." },
+          "createdAt":   { "type": "string", "format": "datetime" },
+          "updatedAt":   { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/is.dame.guestbook.json
+++ b/lexicons/is.dame.guestbook.json
@@ -13,6 +13,12 @@
           "title":       { "type": "string", "maxLength": 640, "maxGraphemes": 64, "description": "Display title of the book, e.g. 'the dame.is guestbook'." },
           "description": { "type": "string", "maxLength": 3000, "maxGraphemes": 300, "description": "What signing this book means, shown to would-be signers." },
           "url":         { "type": "string", "format": "uri", "description": "Where the guestbook renders, e.g. https://dame.is/guestbook." },
+          "hidden": {
+            "type": "array",
+            "description": "Entry at-uris the host has tucked out of public display. Moderation-by-curation: the host can't touch a signer's record (only the signer can delete it), so the book instead records which signatures it declines to show. Kept on the book so moderation state is itself a portable public record any renderer can honor.",
+            "maxLength": 5000,
+            "items": { "type": "string", "format": "at-uri" }
+          },
           "createdAt":   { "type": "string", "format": "datetime" },
           "updatedAt":   { "type": "string", "format": "datetime" }
         }

--- a/scripts/create-guestbook.mjs
+++ b/scripts/create-guestbook.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/*
+ * Creates (or refreshes) the `is.dame.guestbook/self` singleton on your PDS —
+ * the "book" that visitors sign. Entries never live here; they live on each
+ * signer's own repo and point their `subject` at this record's at-uri, so the
+ * record mostly exists to be a stable backlink target (plus a title and a
+ * description for would-be signers). See lexicons/GUESTBOOK.md.
+ *
+ * Run once. Re-running updates the title/description in place (putRecord on
+ * the fixed rkey `self`), which is safe: the at-uri — what every signature
+ * points at — never changes.
+ *
+ *   DAME_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+ *     node scripts/create-guestbook.mjs \
+ *       --title "the dame.is guestbook" \
+ *       --description "Leave a note or a mark that you were here."
+ *
+ * Options:
+ *   --title=…        Book title (default "the dame.is guestbook").
+ *   --description=…  What signing means, shown to signers.
+ *   --url=…          Where the book renders (default https://dame.is/guestbook).
+ *   --handle=…       Account handle (default dame.is).
+ *   --pds=…          Use this PDS directly instead of resolving it.
+ *   --dry-run        Print the record that would be written, write nothing.
+ */
+
+import { AtpAgent } from '@atproto/api';
+
+const COLLECTION = 'is.dame.guestbook';
+const RKEY = 'self';
+
+const args = process.argv.slice(2);
+const has = (f) => args.includes(f);
+const val = (name, fallback = null) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+
+const DRY_RUN = has('--dry-run');
+const TITLE = val('title', 'the dame.is guestbook');
+const DESCRIPTION = val(
+  'description',
+  'Leave a note or just a mark that you were here. Your signature is a record on your own PDS; this book is assembled from the backlinks.',
+);
+const URL_ = val('url', 'https://dame.is/guestbook');
+const HANDLE = val('handle', process.env.DAME_HANDLE || 'dame.is');
+const PDS_OVERRIDE = val('pds', process.env.DAME_PDS_SERVICE || null);
+const APP_PASSWORD = process.env.DAME_APP_PASSWORD || process.env.APP_PASSWORD || null;
+
+async function resolveIdentity() {
+  const r = await fetch(
+    `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(HANDLE)}`,
+  );
+  if (!r.ok) throw new Error(`resolveHandle(${HANDLE}) → HTTP ${r.status}`);
+  const { did } = await r.json();
+  if (PDS_OVERRIDE) return { did, pds: PDS_OVERRIDE };
+  const docUrl = did.startsWith('did:web:')
+    ? `https://${did.slice('did:web:'.length)}/.well-known/did.json`
+    : `https://plc.directory/${did}`;
+  const doc = await (await fetch(docUrl)).json();
+  const svc = (doc.service || []).find(
+    (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer',
+  );
+  if (!svc) throw new Error(`No PDS endpoint in DID doc for ${did}`);
+  return { did, pds: svc.serviceEndpoint };
+}
+
+async function main() {
+  const now = new Date().toISOString();
+  const record = {
+    $type: COLLECTION,
+    title: TITLE,
+    description: DESCRIPTION,
+    url: URL_,
+    createdAt: now,
+  };
+
+  console.log('[guestbook] record:\n' + JSON.stringify(record, null, 2));
+  if (DRY_RUN) {
+    console.log('\n[guestbook] dry-run — nothing written.');
+    return;
+  }
+  if (!APP_PASSWORD) throw new Error('Set DAME_APP_PASSWORD (an app password) to create the guestbook.');
+
+  const { did, pds } = await resolveIdentity();
+  console.log(`\n[guestbook] ${HANDLE} → ${did}\n[guestbook] PDS: ${pds}`);
+  const agent = new AtpAgent({ service: pds });
+  await agent.login({ identifier: HANDLE, password: APP_PASSWORD });
+
+  // Keep the original createdAt when refreshing an existing book so the
+  // record's age reflects when the book was opened, not last retitled.
+  try {
+    const existing = await agent.com.atproto.repo.getRecord({ repo: did, collection: COLLECTION, rkey: RKEY });
+    if (existing?.data?.value?.createdAt) {
+      record.createdAt = existing.data.value.createdAt;
+      record.updatedAt = now;
+      console.log('[guestbook] book already exists — refreshing it in place.');
+    }
+  } catch {
+    // No existing record: this is the first opening of the book.
+  }
+
+  const res = await agent.com.atproto.repo.putRecord({
+    repo: did,
+    collection: COLLECTION,
+    rkey: RKEY,
+    record,
+  });
+  console.log(`\n[guestbook] ✓ ${res.data.uri}`);
+  console.log('\nThe site already points at this at-uri (src/config.js → GUESTBOOK_SUBJECT).');
+  console.log('Visitors can now sign at /guestbook.');
+}
+
+main().catch((err) => {
+  console.error('\n[guestbook] failed:', err?.message || err);
+  process.exitCode = 1;
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import CuratingChannel from './pages/CuratingChannel.jsx';
 import Resume from './pages/Resume.jsx';
 import Sharing from './pages/Sharing.jsx';
 import Mothing from './pages/Mothing.jsx';
+import Guestbook from './pages/Guestbook.jsx';
 import Record from './pages/Record.jsx';
 import NotFound from './pages/NotFound.jsx';
 import { VERB_REGISTRY } from './lib/verbRegistry.js';
@@ -113,6 +114,7 @@ export default function App() {
                   <Route path="/for-hire/:slug" element={<Resume />} />
                   <Route path="/sharing" element={<Sharing />} />
                   <Route path="/mothing" element={<Mothing />} />
+                  <Route path="/guestbook" element={<Guestbook />} />
                   {generatedRecordRoutes()}
                   <Route
                     path="/admin"

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -18,6 +18,7 @@ const ROUTES = [
   { to: '/listening', label: 'listening' },
   { to: '/curating', label: 'curating' },
   { to: '/mothing', label: 'mothing' },
+  { to: '/guestbook', label: 'guestbook' },
 ];
 
 export default function ActionDock() {

--- a/src/components/GuestbookEntryRow.jsx
+++ b/src/components/GuestbookEntryRow.jsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { explorerPathFromAtUri } from '../lib/atproto.js';
+import { relativeTime } from '../lib/time.js';
+import '../pages/Guestbook.css';
+
+/**
+ * One guestbook signature — shared between /guestbook and the admin
+ * moderation panel. Name/handle from the signer's profile (their
+ * `signature` field wins when present), timestamp linking into the site's
+ * explorer view of the actual record, and either their note, their mark,
+ * or both.
+ *
+ *   - `mine` + `onRemove`          → the signer's own delete button.
+ *   - `moderating` + `onSetHidden` → the host's hide/unhide control; hidden
+ *                                    rows render dimmed with a badge.
+ */
+export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, onSetHidden }) {
+  const [removing, setRemoving] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  const [modError, setModError] = useState(null);
+  const { value, profile } = entry;
+  const name =
+    value.signature?.trim() ||
+    profile?.displayName?.trim() ||
+    (profile?.handle && profile.handle !== 'handle.invalid' ? `@${profile.handle}` : null) ||
+    shortDid(entry.did);
+  const handle = profile?.handle && profile.handle !== 'handle.invalid' ? profile.handle : null;
+  const explorerPath = explorerPathFromAtUri(entry.uri);
+
+  async function remove() {
+    if (removing) return;
+    if (!window.confirm('Remove your signature from the book?')) return;
+    setRemoving(true);
+    try {
+      await onRemove(entry);
+    } catch {
+      setRemoving(false);
+    }
+  }
+
+  async function toggleHidden() {
+    if (toggling) return;
+    setToggling(true);
+    setModError(null);
+    try {
+      await onSetHidden(entry, !entry.hidden);
+    } catch (err) {
+      setModError(err?.message || String(err));
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  return (
+    <li className={`guestbook-entry${entry.hidden ? ' guestbook-entry-is-hidden' : ''}`}>
+      <span className="guestbook-entry-avatar" aria-hidden="true">
+        {profile?.avatar ? (
+          <img src={profile.avatar} alt="" loading="lazy" width={40} height={40} />
+        ) : (
+          // Borrow the signer's mark as a stand-in portrait — unless the
+          // mark is already the whole message, where doubling it reads odd.
+          <span className="guestbook-entry-avatar-fallback">
+            {value.text && value.mark ? value.mark : '@'}
+          </span>
+        )}
+      </span>
+      <div className="guestbook-entry-body">
+        <header className="guestbook-entry-head">
+          <span className="guestbook-entry-name">
+            {handle ? (
+              <a
+                href={`https://bsky.app/profile/${handle}`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {name}
+              </a>
+            ) : (
+              name
+            )}
+          </span>
+          {handle && name !== `@${handle}` && (
+            <span className="guestbook-entry-handle gutter">@{handle}</span>
+          )}
+          {value.location && (
+            <span className="guestbook-entry-location gutter">from {value.location}</span>
+          )}
+          <span className="guestbook-entry-time gutter">
+            {explorerPath ? (
+              <Link to={explorerPath}>{relativeTime(value.createdAt)}</Link>
+            ) : (
+              relativeTime(value.createdAt)
+            )}
+          </span>
+          {entry.hidden && moderating && (
+            <span className="guestbook-entry-hidden-badge small-caps">hidden</span>
+          )}
+          {mine && (
+            <button
+              type="button"
+              className="guestbook-entry-remove"
+              onClick={remove}
+              disabled={removing}
+              title="Remove your signature"
+            >
+              {removing ? '…' : 'remove'}
+            </button>
+          )}
+          {moderating && (
+            <button
+              type="button"
+              className="guestbook-entry-moderate"
+              onClick={toggleHidden}
+              disabled={toggling}
+              title={
+                entry.hidden
+                  ? 'Show this signature publicly again'
+                  : 'Hide this signature from public display'
+              }
+            >
+              {toggling ? '…' : entry.hidden ? 'unhide' : 'hide'}
+            </button>
+          )}
+        </header>
+        {modError && <p className="signin-error">{modError}</p>}
+        {value.text ? (
+          <p className="guestbook-entry-text">
+            {value.text}
+            {value.mark && <span className="guestbook-entry-inline-mark"> {value.mark}</span>}
+          </p>
+        ) : value.mark ? (
+          <p className="guestbook-entry-mark" title="left their mark">
+            {value.mark}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function shortDid(did) {
+  if (!did) return 'someone';
+  if (did.length <= 24) return did;
+  return `${did.slice(0, 12)}…${did.slice(-6)}`;
+}

--- a/src/components/GuestbookModerationPanel.jsx
+++ b/src/components/GuestbookModerationPanel.jsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageShell from './PageShell.jsx';
+import GuestbookEntryRow from './GuestbookEntryRow.jsx';
+import { AdminRecordListSkeleton } from './Skeleton.jsx';
+import { fetchGuestbookEntries, setEntryHidden } from '../lib/guestbook.js';
+import { GUESTBOOK_NSID, GUESTBOOK_ENTRY_NSID } from '../config.js';
+
+/**
+ * Admin › Guestbook — the moderation desk (`/admin?view=guestbook`).
+ *
+ * Lists every signature, hidden ones included (dimmed, badged), with
+ * hide/unhide per row. Hiding edits the book record's `hidden` list; the
+ * signers' records are never touched. The same controls appear on
+ * /guestbook itself in owner edit mode — this view exists for working
+ * through the whole book without leaving admin.
+ */
+export default function GuestbookModerationPanel({ agent }) {
+  const [entries, setEntries] = useState(null);
+  const [total, setTotal] = useState(null);
+  const [hiddenCount, setHiddenCount] = useState(0);
+  const [book, setBook] = useState(null);
+  const [cursor, setCursor] = useState(null);
+  const [status, setStatus] = useState('loading'); // loading | ready | error
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+    const page = await fetchGuestbookEntries();
+    if (!page) {
+      setStatus('error');
+      return;
+    }
+    setEntries(page.entries);
+    setTotal(page.total);
+    setHiddenCount(page.hiddenCount || 0);
+    setBook(page.book);
+    setCursor(page.cursor);
+    setStatus('ready');
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function loadMore() {
+    if (!cursor || loadingMore) return;
+    setLoadingMore(true);
+    const page = await fetchGuestbookEntries({ cursor });
+    if (page) {
+      setEntries((prev) => [...(prev || []), ...page.entries]);
+      setCursor(page.cursor);
+    }
+    setLoadingMore(false);
+  }
+
+  async function handleSetHidden(entry, hide) {
+    await setEntryHidden(agent, entry.uri, hide);
+    setEntries((prev) =>
+      (prev || []).map((e) => (e.uri === entry.uri ? { ...e, hidden: hide } : e)),
+    );
+    setHiddenCount((c) => Math.max(0, c + (hide ? 1 : -1)));
+    // A hide can auto-create the book record; reflect that without refetching.
+    setBook((b) => b || { created: true });
+  }
+
+  const publicCount = typeof total === 'number' ? Math.max(0, total - hiddenCount) : null;
+
+  return (
+    <PageShell
+      title="Guestbook"
+      intro="Visitors' signatures, gathered from backlinks. Each lives on its signer's PDS — hiding one only curates what this site renders, by listing its at-uri on the book record."
+      headTitle="Guestbook — Admin — dame.is"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <code className="admin-collection-nsid">{GUESTBOOK_ENTRY_NSID}</code>
+        <Link
+          to={`/admin?c=${encodeURIComponent(GUESTBOOK_NSID)}&r=self`}
+          className="admin-gate-button admin-gate-button-tight"
+        >
+          Edit the book record
+        </Link>
+        <Link to="/guestbook" className="admin-gate-button admin-gate-button-tight">
+          View /guestbook
+        </Link>
+      </div>
+
+      {status === 'ready' && !book && (
+        <p className="placeholder-card">
+          The book record (<code>{GUESTBOOK_NSID}/self</code>) doesn't exist yet — run{' '}
+          <code>scripts/create-guestbook.mjs</code> to open it with a proper title.
+          Hiding an entry below will also create it on the spot with default chrome.
+        </p>
+      )}
+
+      <section className="guestbook-entries">
+        <h2 className="guestbook-entries-heading small-caps">
+          {typeof total === 'number'
+            ? `${total.toLocaleString()} ${total === 1 ? 'signature' : 'signatures'}`
+            : 'Signatures'}
+          {hiddenCount > 0 && (
+            <span className="guestbook-hidden-count">
+              {' '}· {hiddenCount} hidden · {publicCount} public
+            </span>
+          )}
+        </h2>
+        {status === 'loading' ? (
+          <AdminRecordListSkeleton rows={5} label="Loading signatures" />
+        ) : status === 'error' ? (
+          <p className="feed-empty">
+            The backlink index is unreachable right now — try again in a bit.
+          </p>
+        ) : !entries || entries.length === 0 ? (
+          <p className="feed-empty">No signatures yet.</p>
+        ) : (
+          <>
+            <ul className="guestbook-list reveal-stagger">
+              {entries.map((entry) => (
+                <GuestbookEntryRow
+                  key={entry.uri}
+                  entry={entry}
+                  moderating
+                  onSetHidden={handleSetHidden}
+                />
+              ))}
+            </ul>
+            {cursor && (
+              <button
+                type="button"
+                className="guestbook-more"
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? 'Turning the page…' : 'Earlier signatures'}
+              </button>
+            )}
+          </>
+        )}
+      </section>
+    </PageShell>
+  );
+}

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,15 @@ export const PORTFOLIO_PUBLICATION = 'at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/site
  */
 export const BLOG_PUBLICATION = 'at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/site.standard.publication/3lpq72oeo3c2y';
 
+// --- guestbook ---------------------------------------------------------------
+// The guestbook is read from backlinks: visitors write an
+// `is.dame.guestbook.entry` record on their OWN PDS whose `subject` points at
+// the singleton book record below; Constellation indexes the links and
+// Slingshot hydrates the records. See lexicons/GUESTBOOK.md.
+export const GUESTBOOK_NSID = 'is.dame.guestbook';
+export const GUESTBOOK_ENTRY_NSID = 'is.dame.guestbook.entry';
+export const GUESTBOOK_SUBJECT = `at://${ME_DID}/${GUESTBOOK_NSID}/self`;
+
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';

--- a/src/hooks/useAtprotoSession.jsx
+++ b/src/hooks/useAtprotoSession.jsx
@@ -71,6 +71,12 @@ export function AtprotoSessionProvider({ children }) {
 
   const signIn = useCallback(async (input) => {
     const client = getOauthClient();
+    // Remember where the visitor was so the callback can send them back
+    // (e.g. signing in from /guestbook to sign it). Session-scoped so a
+    // stale path never leaks into a later, unrelated sign-in.
+    try {
+      sessionStorage.setItem('dame.oauth.return', window.location.pathname);
+    } catch {}
     // Resolves to a redirect — promise typically never resolves.
     await client.signIn(input, { scope: OAUTH_SCOPE });
   }, []);

--- a/src/lib/guestbook.js
+++ b/src/lib/guestbook.js
@@ -1,0 +1,189 @@
+// Guestbook assembly + signing.
+//
+// The guestbook has no database: visitors write an `is.dame.guestbook.entry`
+// record on their OWN repo pointing at the book singleton on mine, and this
+// module rebuilds the book at read time —
+//
+//   Constellation (who signed?)  →  Slingshot (what did they write?)
+//                                →  AppView   (who are they, visually?)
+//
+// Falls back to a direct DID-doc + PDS fetch per record when Slingshot is
+// unavailable. See lexicons/GUESTBOOK.md for the full design.
+
+import { getBacklinks } from './constellation.js';
+import { getRecordCached } from './slingshot.js';
+import { resolvePds, getRecord, toAtUri } from './atproto.js';
+import { APPVIEW, GUESTBOOK_ENTRY_NSID, GUESTBOOK_SUBJECT } from '../config.js';
+
+/** Constellation source tuple: which records/fields point at the book. */
+export const GUESTBOOK_SOURCE = `${GUESTBOOK_ENTRY_NSID}:subject`;
+
+/** Page size for the entries list. Also the Constellation page size. */
+export const GUESTBOOK_PAGE_SIZE = 25;
+
+// --- reading -----------------------------------------------------------------
+
+/**
+ * One page of the book.
+ *
+ * Returns `{ total, cursor, entries }` where each entry is
+ * `{ uri, did, rkey, value, profile }` (profile may be null), newest first.
+ * Returns `null` only when Constellation itself is unreachable; signatures
+ * whose records can't be hydrated (deleted, PDS down) are dropped from the
+ * page rather than failing it.
+ */
+export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, cursor } = {}) {
+  const page = await getBacklinks(GUESTBOOK_SUBJECT, GUESTBOOK_SOURCE, { limit, cursor });
+  if (!page) return null;
+  const refs = Array.isArray(page.records) ? page.records : [];
+
+  const hydrated = await Promise.all(refs.map(hydrateEntry));
+  const entries = hydrated.filter(Boolean);
+
+  const profiles = await fetchProfiles(entries.map((e) => e.did));
+  for (const entry of entries) {
+    entry.profile = profiles.get(entry.did) || null;
+  }
+
+  return {
+    total: page.total ?? null,
+    cursor: page.cursor || null,
+    entries,
+  };
+}
+
+/**
+ * Hydrate one Constellation ref (`{did, collection, rkey}`) into an entry.
+ * Slingshot first; on a miss, resolve the signer's PDS and fetch directly.
+ * Returns `null` when the record is gone or malformed.
+ */
+async function hydrateEntry(ref) {
+  const { did, collection, rkey } = ref || {};
+  if (!did || !collection || !rkey) return null;
+
+  let record = await getRecordCached({ repo: did, collection, rkey });
+  if (!record) {
+    try {
+      const pds = await resolvePds(did);
+      record = await getRecord(pds, { repo: did, collection, rkey });
+    } catch {
+      return null;
+    }
+  }
+
+  const value = record?.value;
+  // Belt-and-braces: Constellation already filtered on subject, but a
+  // record may have been rewritten to point elsewhere since indexing.
+  if (!value || value.subject !== GUESTBOOK_SUBJECT) return null;
+
+  return {
+    uri: record.uri || toAtUri({ did, collection, rkey }),
+    did,
+    rkey,
+    value,
+    profile: null,
+  };
+}
+
+/**
+ * Batch-resolve signer profiles from the public AppView
+ * (`app.bsky.actor.getProfiles`, 25 actors per call). Best-effort: a failed
+ * batch just leaves those signers rendering by DID. Returns Map<did, profile>.
+ */
+async function fetchProfiles(dids) {
+  const unique = [...new Set(dids.filter(Boolean))];
+  const out = new Map();
+  for (let i = 0; i < unique.length; i += 25) {
+    const chunk = unique.slice(i, i + 25);
+    const params = new URLSearchParams();
+    for (const did of chunk) params.append('actors', did);
+    try {
+      const res = await fetch(`${APPVIEW}/xrpc/app.bsky.actor.getProfiles?${params}`);
+      if (!res.ok) continue;
+      const data = await res.json();
+      for (const profile of data?.profiles || []) {
+        if (profile?.did) out.set(profile.did, profile);
+      }
+    } catch {
+      // leave this chunk unresolved
+    }
+  }
+  return out;
+}
+
+// --- writing -----------------------------------------------------------------
+
+/** Grapheme limits mirrored from lexicons/is.dame.guestbook.entry.json. */
+export const ENTRY_TEXT_MAX_GRAPHEMES = 300;
+export const ENTRY_NAME_MAX_GRAPHEMES = 64;
+
+/**
+ * Count user-perceived characters, so an emoji signature isn't over-charged.
+ * Falls back to code points where Intl.Segmenter is missing.
+ */
+export function graphemeLength(s) {
+  const str = String(s || '');
+  if (typeof Intl !== 'undefined' && Intl.Segmenter) {
+    let n = 0;
+    for (const _ of new Intl.Segmenter().segment(str)) n += 1;
+    return n;
+  }
+  return [...str].length;
+}
+
+/**
+ * Sign the book: create an `is.dame.guestbook.entry` on the signer's repo
+ * (the PDS mints the TID rkey). At least one of `text` / `mark` must be
+ * present — an empty signature says nothing, not even "I was here".
+ * Returns `{ uri, cid, value }` for optimistic rendering.
+ */
+export async function signGuestbook(agent, { text, signature, mark, location } = {}) {
+  if (!agent) throw new Error('Sign in to sign the guestbook.');
+  const cleanText = String(text || '').trim();
+  const cleanName = String(signature || '').trim();
+  const cleanMark = String(mark || '').trim();
+  const cleanLocation = String(location || '').trim();
+  if (!cleanText && !cleanMark) {
+    throw new Error('Write a note or pick a mark first.');
+  }
+  if (graphemeLength(cleanText) > ENTRY_TEXT_MAX_GRAPHEMES) {
+    throw new Error(`Notes max out at ${ENTRY_TEXT_MAX_GRAPHEMES} characters.`);
+  }
+  if (graphemeLength(cleanName) > ENTRY_NAME_MAX_GRAPHEMES) {
+    throw new Error(`Signatures max out at ${ENTRY_NAME_MAX_GRAPHEMES} characters.`);
+  }
+  if (cleanMark && graphemeLength(cleanMark) > 1) {
+    throw new Error('A mark is a single character.');
+  }
+
+  const value = {
+    $type: GUESTBOOK_ENTRY_NSID,
+    subject: GUESTBOOK_SUBJECT,
+    createdAt: new Date().toISOString(),
+  };
+  if (cleanText) value.text = cleanText;
+  if (cleanName) value.signature = cleanName;
+  if (cleanMark) value.mark = cleanMark;
+  if (cleanLocation) value.location = cleanLocation;
+
+  const did = agent.assertDid;
+  const res = await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: GUESTBOOK_ENTRY_NSID,
+    record: value,
+  });
+  return { uri: res.data.uri, cid: res.data.cid, value };
+}
+
+/**
+ * Remove one of the signer's own entries. Their record, their eraser —
+ * Constellation drops the backlink once the delete propagates.
+ */
+export async function deleteGuestbookEntry(agent, rkey) {
+  if (!agent) throw new Error('Sign in first.');
+  await agent.com.atproto.repo.deleteRecord({
+    repo: agent.assertDid,
+    collection: GUESTBOOK_ENTRY_NSID,
+    rkey,
+  });
+}

--- a/src/lib/guestbook.js
+++ b/src/lib/guestbook.js
@@ -13,7 +13,13 @@
 import { getBacklinks } from './constellation.js';
 import { getRecordCached } from './slingshot.js';
 import { resolvePds, getRecord, toAtUri } from './atproto.js';
-import { APPVIEW, GUESTBOOK_ENTRY_NSID, GUESTBOOK_SUBJECT } from '../config.js';
+import {
+  APPVIEW,
+  ME_DID,
+  GUESTBOOK_NSID,
+  GUESTBOOK_ENTRY_NSID,
+  GUESTBOOK_SUBJECT,
+} from '../config.js';
 
 /** Constellation source tuple: which records/fields point at the book. */
 export const GUESTBOOK_SOURCE = `${GUESTBOOK_ENTRY_NSID}:subject`;
@@ -24,31 +30,67 @@ export const GUESTBOOK_PAGE_SIZE = 25;
 // --- reading -----------------------------------------------------------------
 
 /**
+ * The book record itself (`is.dame.guestbook/self` on my repo) — Slingshot
+ * first, direct PDS fallback. Returns `{ uri, cid, value }` or `null` when
+ * the book hasn't been opened yet (entries still work; the book is mostly a
+ * backlink target). The `hidden` list on it drives moderation.
+ */
+export async function fetchGuestbookBook() {
+  const parts = { repo: ME_DID, collection: GUESTBOOK_NSID, rkey: 'self' };
+  const cached = await getRecordCached(parts);
+  if (cached) return cached;
+  try {
+    const pds = await resolvePds(ME_DID);
+    return await getRecord(pds, parts);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * One page of the book.
  *
- * Returns `{ total, cursor, entries }` where each entry is
- * `{ uri, did, rkey, value, profile }` (profile may be null), newest first.
+ * Returns `{ total, publicTotal, hiddenCount, cursor, entries, book }` where
+ * each entry is `{ uri, did, rkey, value, profile, hidden }` (profile may be
+ * null), newest first. `hidden` reflects the book's moderation list; callers
+ * decide whether to render hidden entries (the public page filters them, the
+ * moderation surfaces show them dimmed). `publicTotal` is the backlink total
+ * minus the hidden list, for the public signature count.
  * Returns `null` only when Constellation itself is unreachable; signatures
  * whose records can't be hydrated (deleted, PDS down) are dropped from the
  * page rather than failing it.
  */
 export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, cursor } = {}) {
-  const page = await getBacklinks(GUESTBOOK_SUBJECT, GUESTBOOK_SOURCE, { limit, cursor });
+  const [page, book] = await Promise.all([
+    getBacklinks(GUESTBOOK_SUBJECT, GUESTBOOK_SOURCE, { limit, cursor }),
+    fetchGuestbookBook(),
+  ]);
   if (!page) return null;
   const refs = Array.isArray(page.records) ? page.records : [];
+  const hiddenUris = new Set(book?.value?.hidden || []);
 
   const hydrated = await Promise.all(refs.map(hydrateEntry));
   const entries = hydrated.filter(Boolean);
+  for (const entry of entries) {
+    entry.hidden = hiddenUris.has(entry.uri);
+  }
 
   const profiles = await fetchProfiles(entries.map((e) => e.did));
   for (const entry of entries) {
     entry.profile = profiles.get(entry.did) || null;
   }
 
+  const total = page.total ?? null;
   return {
-    total: page.total ?? null,
+    total,
+    // Approximate when a hidden record has since been deleted by its signer
+    // (the backlink drops out of `total` but its uri lingers in the list);
+    // close enough for a count caption.
+    publicTotal: total != null ? Math.max(0, total - hiddenUris.size) : null,
+    hiddenCount: hiddenUris.size,
     cursor: page.cursor || null,
     entries,
+    book,
   };
 }
 
@@ -185,5 +227,56 @@ export async function deleteGuestbookEntry(agent, rkey) {
     repo: agent.assertDid,
     collection: GUESTBOOK_ENTRY_NSID,
     rkey,
+  });
+}
+
+// --- moderation (host only) ---------------------------------------------------
+
+/**
+ * Hide or unhide a signature from public display by editing the book's
+ * `hidden` list. The signer's record is untouched — this is curation, not
+ * deletion. Only the host's agent can do this (the PDS rejects writes to a
+ * repo you don't own). Uses a CID swap so two moderation clicks racing each
+ * other fail loudly instead of silently dropping one.
+ *
+ * If the book record doesn't exist yet (someone signed before
+ * scripts/create-guestbook.mjs ran), it's created on the spot with default
+ * chrome so the hide isn't lost.
+ */
+export async function setEntryHidden(agent, entryUri, hide) {
+  if (!agent) throw new Error('Sign in first.');
+  const repo = agent.assertDid;
+  const now = new Date().toISOString();
+
+  let existing = null;
+  try {
+    existing = await agent.com.atproto.repo.getRecord({
+      repo,
+      collection: GUESTBOOK_NSID,
+      rkey: 'self',
+    });
+  } catch {
+    // No book yet — fall through to creating one.
+  }
+
+  const value = existing?.data?.value || {
+    $type: GUESTBOOK_NSID,
+    title: 'guestbook',
+    createdAt: now,
+  };
+  const hidden = new Set(Array.isArray(value.hidden) ? value.hidden : []);
+  if (hide) hidden.add(entryUri);
+  else hidden.delete(entryUri);
+
+  const record = { ...value, updatedAt: now };
+  if (hidden.size > 0) record.hidden = [...hidden];
+  else delete record.hidden;
+
+  await agent.com.atproto.repo.putRecord({
+    repo,
+    collection: GUESTBOOK_NSID,
+    rkey: 'self',
+    record,
+    ...(existing?.data?.cid ? { swapRecord: existing.data.cid } : {}),
   });
 }

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -5,7 +5,7 @@
 // intentionally lightweight — they cover the everyday fields, and the JSON
 // toggle inside the editor lets you reach anything they don't model.
 
-import { COLLECTIONS } from '../config.js';
+import { COLLECTIONS, GUESTBOOK_NSID } from '../config.js';
 
 /**
  * Field types understood by the form renderer:
@@ -316,6 +316,26 @@ export const LEXICONS = {
       { key: 'text', label: 'Text', type: 'textarea', required: true, maxLength: 300 },
       { key: 'langs', label: 'Languages', type: 'tags', default: ['en'], hint: 'BCP-47 codes' },
       { key: 'createdAt', label: 'Created at', type: 'datetime', default: 'now', required: true },
+    ],
+  },
+
+  [GUESTBOOK_NSID]: {
+    label: 'Guestbook (the book)',
+    summary:
+      'The book record visitors sign (rkey "self") — its at-uri is what every signature backlinks to. `hidden` is the moderation list; usually managed from the Guestbook panel or edit mode on /guestbook rather than here.',
+    rkeyMode: 'fixed',
+    rkeyPlaceholder: 'self',
+    rkeyDefault: 'self',
+    typeFieldValue: GUESTBOOK_NSID,
+    fields: [
+      { key: 'title', label: 'Title', type: 'text', required: true, placeholder: 'the dame.is guestbook' },
+      { key: 'description', label: 'Description', type: 'textarea', hint: 'What signing means, shown to would-be signers.' },
+      { key: 'url', label: 'URL', type: 'text', placeholder: 'https://dame.is/guestbook' },
+      {
+        key: 'hidden', label: 'Hidden entry at-uris', type: 'json',
+        hint: 'Array of entry at-uris tucked out of public display. Prefer the hide/unhide buttons on /admin?view=guestbook.',
+      },
+      ...COMMON_TIMESTAMPS,
     ],
   },
 };

--- a/src/lib/pageRegistry.js
+++ b/src/lib/pageRegistry.js
@@ -71,6 +71,13 @@ export const PAGE_REGISTRY = {
     intro: 'Moths I’ve found and photographed, pulled from iNaturalist. A running field notebook of the winged things drawn to the light.',
     collection: null,
   },
+  guestbook: {
+    slug: 'guestbook',
+    label: 'Guestbook',
+    title: 'Guestbook',
+    intro: 'Sign in with any atproto account and leave a note — or just a mark that you were here. Every signature lives on the signer’s own PDS and reaches this page as a backlink.',
+    collection: null,
+  },
   resume: {
     slug: 'resume',
     label: 'For hire',

--- a/src/lib/slingshot.js
+++ b/src/lib/slingshot.js
@@ -1,0 +1,26 @@
+// Tiny client for the Slingshot record edge-cache
+// (https://slingshot.microcosm.blue). Slingshot serves
+// `com.atproto.repo.getRecord` for ANY repo on the network, resolving the
+// DID → PDS hop itself and caching hot records — which makes it the cheap
+// way to hydrate a pile of backlinks that point at many different PDSes.
+// Mirrors constellation.js: every call swallows errors and returns `null`
+// so callers can fall back (e.g. to a direct PDS fetch) without try/catch.
+
+const SLINGSHOT_BASE = 'https://slingshot.microcosm.blue';
+
+/**
+ * Fetch one record through the cache. Returns the usual getRecord shape
+ * (`{ uri, cid, value }`) or `null` on any failure — including
+ * RecordNotFound, so a `null` may mean "deleted since it was indexed".
+ */
+export async function getRecordCached({ repo, collection, rkey }) {
+  if (!repo || !collection || !rkey) return null;
+  const params = new URLSearchParams({ repo, collection, rkey });
+  try {
+    const res = await fetch(`${SLINGSHOT_BASE}/xrpc/com.atproto.repo.getRecord?${params}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
 import PageContentPanel from '../components/PageContentPanel.jsx';
+import GuestbookModerationPanel from '../components/GuestbookModerationPanel.jsx';
 import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -64,6 +65,9 @@ export default function Admin() {
 
   if (view === 'pages') {
     return <PagesOverview agent={agent} did={did} />;
+  }
+  if (view === 'guestbook') {
+    return <GuestbookModerationPanel agent={agent} />;
   }
   if (view === 'listening') {
     return <ListeningManager agent={agent} did={did} />;
@@ -201,6 +205,8 @@ const PICKER_GROUPS = [
     items: [
       { to: '/admin?view=pages', label: 'Site pages', nsid: COLLECTIONS.page,
         summary: 'Titles, intros, and page bodies — see which serve from the PDS vs local defaults, and edit the raw records.' },
+      { to: '/admin?view=guestbook', label: 'Guestbook', nsid: 'is.dame.guestbook.entry',
+        summary: 'Visitors\' signatures, gathered from backlinks. Hide/unhide them from public display — their records stay on their signers\' PDSes.' },
       { collection: COLLECTIONS.profile, label: 'About',
         summary: 'The extended profile (rkey "self") that backs /themself.' },
       { collection: COLLECTIONS.heroPhrase, label: 'Hero phrases',

--- a/src/pages/Guestbook.css
+++ b/src/pages/Guestbook.css
@@ -1,0 +1,287 @@
+/* Guestbook — the pen (sign form) and the pages (signature ledger). */
+
+/* --- invite / form ------------------------------------------------------ */
+
+.guestbook-invite,
+.guestbook-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  background: color-mix(in srgb, var(--page-edge) 55%, transparent);
+}
+
+.guestbook-invite-text {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.guestbook-invite .signin-button,
+.guestbook-form .signin-button {
+  align-self: flex-start;
+}
+
+.guestbook-form-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.guestbook-form-eyebrow {
+  color: var(--ink-faint);
+  letter-spacing: 0.18em;
+}
+
+.guestbook-form-signer {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--ink);
+}
+
+.guestbook-form-avatar {
+  width: 1.4em;
+  height: 1.4em;
+  object-fit: cover;
+  border: 1px solid var(--rule);
+  align-self: center;
+}
+
+.guestbook-textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 4.5em;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--serif);
+  font-size: var(--text-base, 1rem);
+  color: var(--ink);
+  background: var(--page-edge);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  outline: none;
+  transition: border-color 120ms ease;
+}
+
+.guestbook-textarea:focus {
+  border-color: var(--accent);
+}
+
+.guestbook-remaining {
+  align-self: flex-end;
+  margin-top: calc(var(--space-2) * -1);
+}
+
+.guestbook-over {
+  color: var(--tan);
+}
+
+.guestbook-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.guestbook-marks {
+  display: inline-flex;
+  gap: var(--space-1);
+}
+
+.guestbook-mark {
+  width: 2.2rem;
+  height: 2.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-md, 1.1rem);
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.guestbook-mark:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+.guestbook-mark-active {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.guestbook-location {
+  flex: 1 1 12rem;
+  max-width: 18rem;
+}
+
+.guestbook-form-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.guestbook-signed-note {
+  color: var(--accent);
+}
+
+/* --- entries ------------------------------------------------------------ */
+
+.guestbook-entries {
+  margin-top: var(--space-8);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--rule);
+}
+
+.guestbook-entries-heading {
+  font-family: var(--sans);
+  letter-spacing: 0.18em;
+  color: var(--ink-muted);
+  margin: 0 0 var(--space-4);
+}
+
+.guestbook-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.guestbook-entry {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.guestbook-entry:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.guestbook-entry-avatar {
+  flex: none;
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.guestbook-entry-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: 1px solid var(--rule);
+}
+
+.guestbook-entry-avatar-fallback {
+  width: 100%;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-faint);
+  border: 1px dashed var(--rule);
+}
+
+.guestbook-entry-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.guestbook-entry-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.guestbook-entry-name {
+  color: var(--ink);
+}
+
+.guestbook-entry-name a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.guestbook-entry-name a:hover {
+  color: var(--accent);
+}
+
+.guestbook-entry-time {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.guestbook-entry-time a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.guestbook-entry-time a:hover {
+  color: var(--accent);
+}
+
+.guestbook-entry-remove {
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.12em;
+  font-size: var(--text-xs);
+  color: var(--tan);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.guestbook-entry-text {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--ink);
+}
+
+.guestbook-entry-inline-mark {
+  color: var(--accent);
+}
+
+/* A mark-only signature: the glyph IS the message. */
+.guestbook-entry-mark {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.guestbook-more {
+  margin-top: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.18em;
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.guestbook-more:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+.guestbook-more:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/pages/Guestbook.css
+++ b/src/pages/Guestbook.css
@@ -261,6 +261,51 @@
   color: var(--accent);
 }
 
+/* --- moderation (owner edit mode) ---------------------------------------- */
+
+.guestbook-hidden-count {
+  color: var(--ink-faint);
+}
+
+.guestbook-moderation-note {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+  font-style: italic;
+}
+
+/* A hidden signature in the moderation view: present, but clearly benched. */
+.guestbook-entry-is-hidden {
+  opacity: 0.45;
+}
+
+.guestbook-entry-hidden-badge {
+  font-family: var(--sans);
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  color: var(--tan);
+  border: 1px solid color-mix(in srgb, var(--tan) 45%, transparent);
+  border-radius: var(--radius-2);
+  padding: 0 var(--space-2);
+}
+
+.guestbook-entry-moderate {
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.12em;
+  font-size: var(--text-xs);
+  color: var(--accent);
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--accent-soft) 55%, transparent);
+  border-radius: var(--radius-2);
+  padding: 0 var(--space-2);
+  cursor: pointer;
+}
+
+.guestbook-entry-moderate:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
 .guestbook-more {
   margin-top: var(--space-4);
   padding: var(--space-2) var(--space-3);

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageShell from '../components/PageShell.jsx';
+import { CommentsSkeleton } from '../components/Skeleton.jsx';
+import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
+import { useActionDock } from '../hooks/useActionDock.jsx';
+import { usePageContent } from '../hooks/usePageContent.js';
+import {
+  fetchGuestbookEntries,
+  signGuestbook,
+  deleteGuestbookEntry,
+  graphemeLength,
+  ENTRY_TEXT_MAX_GRAPHEMES,
+  GUESTBOOK_PAGE_SIZE,
+} from '../lib/guestbook.js';
+import { getProfile, explorerPathFromAtUri, rkeyFromAtUri } from '../lib/atproto.js';
+import { relativeTime } from '../lib/time.js';
+import { GUESTBOOK_SUBJECT } from '../config.js';
+import './Guestbook.css';
+
+/** The margin-marks a visitor can leave instead of (or besides) a note. */
+const MARKS = ['✕', '☾', '✦', '❀', '☺', '♥'];
+
+/**
+ * The guestbook. Every signature on this page is a record on the SIGNER's
+ * own PDS pointing back at the book on mine — the page just gathers the
+ * backlinks (Constellation), hydrates them (Slingshot), and offers a pen.
+ */
+export default function Guestbook() {
+  const { title, intro } = usePageContent('guestbook');
+  const { session, agent, did } = useAtprotoSession();
+
+  // --- the book's pages ------------------------------------------------
+  const [entries, setEntries] = useState(null);
+  const [total, setTotal] = useState(null);
+  const [cursor, setCursor] = useState(null);
+  const [status, setStatus] = useState('loading'); // loading | ready | error
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const loadFirstPage = useCallback(async () => {
+    setStatus('loading');
+    const page = await fetchGuestbookEntries();
+    if (!page) {
+      setStatus('error');
+      return;
+    }
+    setEntries(page.entries);
+    setTotal(page.total);
+    setCursor(page.cursor);
+    setStatus('ready');
+  }, []);
+
+  useEffect(() => {
+    loadFirstPage();
+  }, [loadFirstPage]);
+
+  async function loadMore() {
+    if (!cursor || loadingMore) return;
+    setLoadingMore(true);
+    const page = await fetchGuestbookEntries({ cursor });
+    if (page) {
+      setEntries((prev) => [...(prev || []), ...page.entries]);
+      setCursor(page.cursor);
+      if (page.total != null) setTotal(page.total);
+    }
+    setLoadingMore(false);
+  }
+
+  // --- the signer ------------------------------------------------------
+  // The signed-in visitor's profile, for the "signing as" line and for
+  // optimistically rendering their fresh signature before Constellation
+  // has indexed it.
+  const [myProfile, setMyProfile] = useState(null);
+  useEffect(() => {
+    setMyProfile(null);
+    if (!did) return undefined;
+    let cancelled = false;
+    getProfile(did)
+      .then((p) => {
+        if (!cancelled && p) setMyProfile(p);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [did]);
+
+  function handleSigned(entry) {
+    setEntries((prev) => [{ ...entry, profile: myProfile }, ...(prev || [])]);
+    setTotal((t) => (typeof t === 'number' ? t + 1 : t));
+  }
+
+  async function handleRemove(entry) {
+    if (!agent) return;
+    await deleteGuestbookEntry(agent, entry.rkey);
+    setEntries((prev) => (prev || []).filter((e) => e.uri !== entry.uri));
+    setTotal((t) => (typeof t === 'number' && t > 0 ? t - 1 : t));
+  }
+
+  const count = typeof total === 'number' ? total : entries?.length ?? null;
+
+  return (
+    <PageShell
+      title={title}
+      intro={intro}
+      atUri={GUESTBOOK_SUBJECT}
+      headTitle="dame.is hosting a guestbook"
+    >
+      {session ? (
+        <SignForm agent={agent} did={did} profile={myProfile} onSigned={handleSigned} />
+      ) : (
+        <SignInInvite />
+      )}
+
+      <section className="guestbook-entries">
+        <h2 className="guestbook-entries-heading small-caps">
+          {count != null
+            ? `${count.toLocaleString()} ${count === 1 ? 'signature' : 'signatures'}`
+            : 'Signatures'}
+        </h2>
+        {status === 'loading' ? (
+          <CommentsSkeleton rows={4} />
+        ) : status === 'error' ? (
+          <p className="feed-empty">
+            The backlink index is unreachable right now — the signatures are safe on their
+            signers' PDSes; try again in a bit.
+          </p>
+        ) : !entries || entries.length === 0 ? (
+          <p className="feed-empty">No signatures yet. The first page is blank — sign it?</p>
+        ) : (
+          <>
+            <ul className="guestbook-list reveal-stagger">
+              {entries.map((entry) => (
+                <EntryRow
+                  key={entry.uri}
+                  entry={entry}
+                  mine={entry.did === did}
+                  onRemove={handleRemove}
+                />
+              ))}
+            </ul>
+            {cursor && (
+              <button
+                type="button"
+                className="guestbook-more"
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? 'Turning the page…' : 'Earlier signatures'}
+              </button>
+            )}
+          </>
+        )}
+      </section>
+    </PageShell>
+  );
+}
+
+/**
+ * Signed-out state: explain the deal (your words stay on YOUR data server),
+ * then hand off to the dock's account panel for the OAuth flow. The current
+ * path is stashed so the callback returns the signer here.
+ */
+function SignInInvite() {
+  const { openDock, setView } = useActionDock();
+
+  function openAccount() {
+    openDock();
+    setView('account');
+  }
+
+  return (
+    <div className="guestbook-invite">
+      <p className="guestbook-invite-text">
+        Sign in with any AT Protocol account (a Bluesky handle works) to leave a note or just a
+        mark that you were here. Your signature is written to <em>your own</em> data server, not
+        this site — this page only gathers the backlinks.
+      </p>
+      <button type="button" className="signin-button" onClick={openAccount}>
+        Sign in to sign
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The pen: a note, an optional one-glyph mark, an optional "signing from".
+ * A signature needs at least a note or a mark.
+ */
+function SignForm({ agent, did, profile, onSigned }) {
+  const [text, setText] = useState('');
+  const [mark, setMark] = useState('');
+  const [location, setLocation] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [signedAt, setSignedAt] = useState(null);
+
+  const remaining = ENTRY_TEXT_MAX_GRAPHEMES - graphemeLength(text);
+  const canSign = !busy && (text.trim() || mark);
+
+  const signingAs = useMemo(() => {
+    if (profile?.displayName?.trim()) return profile.displayName.trim();
+    if (profile?.handle && profile.handle !== 'handle.invalid') return `@${profile.handle}`;
+    return did || '';
+  }, [profile, did]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (!canSign) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { uri, value } = await signGuestbook(agent, { text, mark, location });
+      onSigned({ uri, did, rkey: rkeyFromAtUri(uri), value });
+      setText('');
+      setMark('');
+      setLocation('');
+      setSignedAt(new Date());
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="guestbook-form" onSubmit={handleSubmit}>
+      <div className="guestbook-form-head">
+        <span className="small-caps guestbook-form-eyebrow">Signing as</span>
+        <span className="guestbook-form-signer">
+          {profile?.avatar && <img className="guestbook-form-avatar" src={profile.avatar} alt="" />}
+          {signingAs}
+        </span>
+      </div>
+
+      <textarea
+        className="guestbook-textarea"
+        rows={3}
+        placeholder="Leave a note… (or just a mark below)"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        disabled={busy}
+      />
+      {remaining < 40 && (
+        <span className={`guestbook-remaining gutter${remaining < 0 ? ' guestbook-over' : ''}`}>
+          {remaining}
+        </span>
+      )}
+
+      <div className="guestbook-form-row">
+        <div className="guestbook-marks" role="group" aria-label="Leave a mark">
+          {MARKS.map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={`guestbook-mark${mark === m ? ' guestbook-mark-active' : ''}`}
+              aria-pressed={mark === m}
+              onClick={() => setMark((cur) => (cur === m ? '' : m))}
+              disabled={busy}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+        <input
+          className="guestbook-location signin-input"
+          type="text"
+          placeholder="signing from… (optional)"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          maxLength={64}
+          disabled={busy}
+        />
+      </div>
+
+      <div className="guestbook-form-actions">
+        <button type="submit" className="signin-button" disabled={!canSign}>
+          {busy ? 'Signing…' : 'Sign the book'}
+        </button>
+        {signedAt && !error && (
+          <span className="guestbook-signed-note gutter">
+            Signed — the record now lives on your PDS.
+          </span>
+        )}
+      </div>
+      {error && <p className="signin-error">{error}</p>}
+    </form>
+  );
+}
+
+/**
+ * One signature. Name/handle from the signer's profile (their `signature`
+ * field wins when present), timestamp linking into the site's explorer view
+ * of the actual record, and either their note, their mark, or both.
+ */
+function EntryRow({ entry, mine, onRemove }) {
+  const [removing, setRemoving] = useState(false);
+  const { value, profile } = entry;
+  const name =
+    value.signature?.trim() ||
+    profile?.displayName?.trim() ||
+    (profile?.handle && profile.handle !== 'handle.invalid' ? `@${profile.handle}` : null) ||
+    shortDid(entry.did);
+  const handle = profile?.handle && profile.handle !== 'handle.invalid' ? profile.handle : null;
+  const explorerPath = explorerPathFromAtUri(entry.uri);
+
+  async function remove() {
+    if (removing) return;
+    if (!window.confirm('Remove your signature from the book?')) return;
+    setRemoving(true);
+    try {
+      await onRemove(entry);
+    } catch {
+      setRemoving(false);
+    }
+  }
+
+  return (
+    <li className="guestbook-entry">
+      <span className="guestbook-entry-avatar" aria-hidden="true">
+        {profile?.avatar ? (
+          <img src={profile.avatar} alt="" loading="lazy" width={40} height={40} />
+        ) : (
+          // Borrow the signer's mark as a stand-in portrait — unless the
+          // mark is already the whole message, where doubling it reads odd.
+          <span className="guestbook-entry-avatar-fallback">
+            {value.text && value.mark ? value.mark : '@'}
+          </span>
+        )}
+      </span>
+      <div className="guestbook-entry-body">
+        <header className="guestbook-entry-head">
+          <span className="guestbook-entry-name">
+            {handle ? (
+              <a
+                href={`https://bsky.app/profile/${handle}`}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {name}
+              </a>
+            ) : (
+              name
+            )}
+          </span>
+          {handle && name !== `@${handle}` && (
+            <span className="guestbook-entry-handle gutter">@{handle}</span>
+          )}
+          {value.location && (
+            <span className="guestbook-entry-location gutter">from {value.location}</span>
+          )}
+          <span className="guestbook-entry-time gutter">
+            {explorerPath ? (
+              <Link to={explorerPath}>{relativeTime(value.createdAt)}</Link>
+            ) : (
+              relativeTime(value.createdAt)
+            )}
+          </span>
+          {mine && (
+            <button
+              type="button"
+              className="guestbook-entry-remove"
+              onClick={remove}
+              disabled={removing}
+              title="Remove your signature"
+            >
+              {removing ? '…' : 'remove'}
+            </button>
+          )}
+        </header>
+        {value.text ? (
+          <p className="guestbook-entry-text">
+            {value.text}
+            {value.mark && <span className="guestbook-entry-inline-mark"> {value.mark}</span>}
+          </p>
+        ) : value.mark ? (
+          <p className="guestbook-entry-mark" title="left their mark">
+            {value.mark}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function shortDid(did) {
+  if (!did) return 'someone';
+  if (did.length <= 24) return did;
+  return `${did.slice(0, 12)}…${did.slice(-6)}`;
+}

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -1,21 +1,21 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import GuestbookEntryRow from '../components/GuestbookEntryRow.jsx';
 import { CommentsSkeleton } from '../components/Skeleton.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { useActionDock } from '../hooks/useActionDock.jsx';
 import { usePageContent } from '../hooks/usePageContent.js';
+import { useEditMode } from '../hooks/useEditMode.jsx';
 import {
   fetchGuestbookEntries,
   signGuestbook,
   deleteGuestbookEntry,
+  setEntryHidden,
   graphemeLength,
   ENTRY_TEXT_MAX_GRAPHEMES,
-  GUESTBOOK_PAGE_SIZE,
 } from '../lib/guestbook.js';
-import { getProfile, explorerPathFromAtUri, rkeyFromAtUri } from '../lib/atproto.js';
-import { relativeTime } from '../lib/time.js';
-import { GUESTBOOK_SUBJECT } from '../config.js';
+import { getProfile, rkeyFromAtUri } from '../lib/atproto.js';
+import { ME_DID, GUESTBOOK_SUBJECT } from '../config.js';
 import './Guestbook.css';
 
 /** The margin-marks a visitor can leave instead of (or besides) a note. */
@@ -30,9 +30,15 @@ export default function Guestbook() {
   const { title, intro } = usePageContent('guestbook');
   const { session, agent, did } = useAtprotoSession();
 
+  // Owner + the chrome bar's pencil = moderation: hidden entries surface
+  // (dimmed) and every signature grows a hide/unhide control.
+  const { active: editActive } = useEditMode();
+  const moderating = did === ME_DID && editActive;
+
   // --- the book's pages ------------------------------------------------
   const [entries, setEntries] = useState(null);
   const [total, setTotal] = useState(null);
+  const [hiddenCount, setHiddenCount] = useState(0);
   const [cursor, setCursor] = useState(null);
   const [status, setStatus] = useState('loading'); // loading | ready | error
   const [loadingMore, setLoadingMore] = useState(false);
@@ -46,6 +52,7 @@ export default function Guestbook() {
     }
     setEntries(page.entries);
     setTotal(page.total);
+    setHiddenCount(page.hiddenCount || 0);
     setCursor(page.cursor);
     setStatus('ready');
   }, []);
@@ -97,7 +104,18 @@ export default function Guestbook() {
     setTotal((t) => (typeof t === 'number' && t > 0 ? t - 1 : t));
   }
 
-  const count = typeof total === 'number' ? total : entries?.length ?? null;
+  async function handleSetHidden(entry, hide) {
+    await setEntryHidden(agent, entry.uri, hide);
+    setEntries((prev) =>
+      (prev || []).map((e) => (e.uri === entry.uri ? { ...e, hidden: hide } : e)),
+    );
+    setHiddenCount((c) => Math.max(0, c + (hide ? 1 : -1)));
+  }
+
+  // The public page renders the curated book; moderation sees everything.
+  const visible = entries ? (moderating ? entries : entries.filter((e) => !e.hidden)) : null;
+  const count =
+    typeof total === 'number' ? Math.max(0, total - hiddenCount) : visible?.length ?? null;
 
   return (
     <PageShell
@@ -117,7 +135,16 @@ export default function Guestbook() {
           {count != null
             ? `${count.toLocaleString()} ${count === 1 ? 'signature' : 'signatures'}`
             : 'Signatures'}
+          {moderating && hiddenCount > 0 && (
+            <span className="guestbook-hidden-count"> · {hiddenCount} hidden</span>
+          )}
         </h2>
+        {moderating && (
+          <p className="guestbook-moderation-note">
+            Edit mode — hiding tucks a signature out of public display by listing it on the
+            book record; the signer's own record is untouched.
+          </p>
+        )}
         {status === 'loading' ? (
           <CommentsSkeleton rows={4} />
         ) : status === 'error' ? (
@@ -125,17 +152,19 @@ export default function Guestbook() {
             The backlink index is unreachable right now — the signatures are safe on their
             signers' PDSes; try again in a bit.
           </p>
-        ) : !entries || entries.length === 0 ? (
+        ) : !visible || visible.length === 0 ? (
           <p className="feed-empty">No signatures yet. The first page is blank — sign it?</p>
         ) : (
           <>
             <ul className="guestbook-list reveal-stagger">
-              {entries.map((entry) => (
-                <EntryRow
+              {visible.map((entry) => (
+                <GuestbookEntryRow
                   key={entry.uri}
                   entry={entry}
                   mine={entry.did === did}
                   onRemove={handleRemove}
+                  moderating={moderating}
+                  onSetHidden={handleSetHidden}
                 />
               ))}
             </ul>
@@ -288,103 +317,3 @@ function SignForm({ agent, did, profile, onSigned }) {
   );
 }
 
-/**
- * One signature. Name/handle from the signer's profile (their `signature`
- * field wins when present), timestamp linking into the site's explorer view
- * of the actual record, and either their note, their mark, or both.
- */
-function EntryRow({ entry, mine, onRemove }) {
-  const [removing, setRemoving] = useState(false);
-  const { value, profile } = entry;
-  const name =
-    value.signature?.trim() ||
-    profile?.displayName?.trim() ||
-    (profile?.handle && profile.handle !== 'handle.invalid' ? `@${profile.handle}` : null) ||
-    shortDid(entry.did);
-  const handle = profile?.handle && profile.handle !== 'handle.invalid' ? profile.handle : null;
-  const explorerPath = explorerPathFromAtUri(entry.uri);
-
-  async function remove() {
-    if (removing) return;
-    if (!window.confirm('Remove your signature from the book?')) return;
-    setRemoving(true);
-    try {
-      await onRemove(entry);
-    } catch {
-      setRemoving(false);
-    }
-  }
-
-  return (
-    <li className="guestbook-entry">
-      <span className="guestbook-entry-avatar" aria-hidden="true">
-        {profile?.avatar ? (
-          <img src={profile.avatar} alt="" loading="lazy" width={40} height={40} />
-        ) : (
-          // Borrow the signer's mark as a stand-in portrait — unless the
-          // mark is already the whole message, where doubling it reads odd.
-          <span className="guestbook-entry-avatar-fallback">
-            {value.text && value.mark ? value.mark : '@'}
-          </span>
-        )}
-      </span>
-      <div className="guestbook-entry-body">
-        <header className="guestbook-entry-head">
-          <span className="guestbook-entry-name">
-            {handle ? (
-              <a
-                href={`https://bsky.app/profile/${handle}`}
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </span>
-          {handle && name !== `@${handle}` && (
-            <span className="guestbook-entry-handle gutter">@{handle}</span>
-          )}
-          {value.location && (
-            <span className="guestbook-entry-location gutter">from {value.location}</span>
-          )}
-          <span className="guestbook-entry-time gutter">
-            {explorerPath ? (
-              <Link to={explorerPath}>{relativeTime(value.createdAt)}</Link>
-            ) : (
-              relativeTime(value.createdAt)
-            )}
-          </span>
-          {mine && (
-            <button
-              type="button"
-              className="guestbook-entry-remove"
-              onClick={remove}
-              disabled={removing}
-              title="Remove your signature"
-            >
-              {removing ? '…' : 'remove'}
-            </button>
-          )}
-        </header>
-        {value.text ? (
-          <p className="guestbook-entry-text">
-            {value.text}
-            {value.mark && <span className="guestbook-entry-inline-mark"> {value.mark}</span>}
-          </p>
-        ) : value.mark ? (
-          <p className="guestbook-entry-mark" title="left their mark">
-            {value.mark}
-          </p>
-        ) : null}
-      </div>
-    </li>
-  );
-}
-
-function shortDid(did) {
-  if (!did) return 'someone';
-  if (did.length <= 24) return did;
-  return `${did.slice(0, 12)}…${did.slice(-6)}`;
-}

--- a/src/pages/OauthCallback.jsx
+++ b/src/pages/OauthCallback.jsx
@@ -16,7 +16,14 @@ export default function OauthCallback() {
   useEffect(() => {
     if (loading) return;
     if (session) {
-      const dest = did === ME_DID ? '/admin' : '/';
+      // Visitors go back to wherever they started the flow (the guestbook,
+      // usually); the owner still lands on the admin desk.
+      let returnTo = null;
+      try {
+        returnTo = sessionStorage.getItem('dame.oauth.return');
+        sessionStorage.removeItem('dame.oauth.return');
+      } catch {}
+      const dest = did === ME_DID ? '/admin' : returnTo || '/';
       navigate(dest, { replace: true });
     }
   }, [loading, session, did, navigate]);


### PR DESCRIPTION
## What

A decentralized guestbook at `/guestbook`. Visitors sign in with any atproto account and leave a note, a one-glyph mark (✕ ☾ ✦ ❀ ☺ ♥), or both — plus an optional sign-as name and free-text "signing from…". Every signature is an `is.dame.guestbook.entry` record written to the **visitor's own PDS**, whose `subject` backlinks to the book singleton (`at://{me}/is.dame.guestbook/self`).

## How it reads

No database. The page assembles the book at read time:

1. **Constellation** — `blue.microcosm.links.getBacklinks` lists who signed (paginated, with total).
2. **Slingshot** — cached `com.atproto.repo.getRecord` hydrates each signer's record (direct PDS fetch as fallback).
3. **AppView** — `app.bsky.actor.getProfiles` fills in avatars/names in batches of 25.

A future guestbook AppView only needs to index the entry lexicon from the firehose — no schema change.

## Moderation

The host can't delete a visitor's record, so moderation is curation: the book record carries a `hidden` list of entry at-uris, and the public page filters against it (adjusting the signature count). Two surfaces drive it:

- **Edit mode on /guestbook** — the owner's pencil; every signature grows hide/unhide, hidden ones render dimmed with a badge.
- **Admin › Guestbook** (`/admin?view=guestbook`) — the whole book with per-row hide/unhide and public/hidden tallies.

Hides use a CID swap so racing edits fail loudly; the first hide auto-creates the book if it doesn't exist yet. Signers can always delete their own entry.

## Also

- `lexicons/GUESTBOOK.md` design doc + README section
- `scripts/create-guestbook.mjs` opens (or retitles) the book record — run once with `DAME_APP_PASSWORD`
- OAuth callback now returns visitors to the page they signed in from (owner still lands on `/admin`)
- Templated admin editor form for the book record

## Verified

Offline build passes; the live Constellation query for the book returns the empty-book shape; Slingshot hydration confirmed against a real record; browser tests (stubbed services) cover the empty state, populated entries, and hidden-entry filtering (3 total − 1 hidden → "2 signatures"); unit tests cover hide-with-swap, unhide-to-empty, and book auto-create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL)_