### PR TITLE
Home hero: add Guestbook CTA, tighten button copy

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -530,17 +530,20 @@ export default function Home() {
     >
       <nav className="home-hero-cta" aria-label="Primary destinations">
         <Link className="home-hero-cta-btn home-hero-cta-primary" to="/creating">
-          Browse Projects
+          Projects
         </Link>
         <Link className="home-hero-cta-btn" to="/blogging">
-          Read Blog
+          Blog
+        </Link>
+        <Link className="home-hero-cta-btn" to="/guestbook">
+          Guestbook
         </Link>
         <button
           type="button"
           className="home-hero-cta-btn home-hero-shuffle"
           onClick={() => shuffleRef.current?.()}
-          aria-label="Shuffle the hero phrase"
-          title="Shuffle"
+          aria-label="Shuffle hero statement"
+          title="Shuffle hero statement"
         >
           <Shuffle size={16} strokeWidth={1.75} aria-hidden="true" />
         </button>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -197,10 +197,10 @@
   right: 0;
 }
 
-/* Home hero CTAs: two destinations underneath the animated sentence.
-   The primary (Browse Projects) is filled in the accent color to match
-   the compass button's visual weight; the secondary (Read Blog) reads
-   as an outline. */
+/* Home hero CTAs: destinations underneath the animated sentence.
+   The primary (Projects) is filled in the accent color to match the
+   compass button's visual weight; the secondaries (Blog, Guestbook)
+   read as outlines, with the shuffle utility riding at the end. */
 .home-hero-cta {
   display: flex;
   flex-wrap: wrap;
@@ -248,12 +248,13 @@
   color: var(--page);
 }
 
-/* Icon-only shuffle button sits alongside the two text CTAs but
-   reads as a quieter utility action — square footprint, no label
-   text, same border treatment as the secondary text CTA. */
+/* Icon-only shuffle button sits alongside the text CTAs but reads as
+   a quieter utility action — square footprint, no label text, same
+   border treatment as the secondary text CTAs. */
 .home-hero-shuffle {
   padding: 0.6em;
   aspect-ratio: 1;
+  cursor: pointer;
 }
 
 /* Home: visual break between the hero (page-title) and the


### PR DESCRIPTION
The hero CTA row becomes **Projects** (filled primary) · Blog · Guestbook · 🔀 — "Browse Projects"/"Read Blog" tightened to single words, a new Guestbook button linking `/guestbook`, and the shuffle utility stays icon-only with "Shuffle hero statement" as its tooltip/aria-label.

Verified in the built site at desktop and mobile widths; the row wraps cleanly on narrow screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL)_