### PR TITLE
Fix stray dashed borders between unrelated home-feed rows

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1605,8 +1605,17 @@ a.reference-card-profile:focus-visible {
 /* Self-thread continuations carry no verb label; instead the rule
    separating them from the post they continue goes dashed — i.e. the
    PREVIOUS row's bottom border. Rows sit inside Home's motion.li
-   wrappers, so the sibling hop happens on those. */
-.feed-ledger .feed-list > li:has(+ li .feed-item-thread-continuation) .feed-item-ledger {
+   wrappers, so the sibling hop happens on those.
+
+   The `:not(.feed-day-group)` is load-bearing: the feed's outer <ol> and
+   each day's inner <ul> BOTH carry .feed-list, so a bare `.feed-list > li`
+   also matches the day-group <li>s. When a later (older) day happened to
+   contain a continuation anywhere in it, that :has() matched the current
+   day-group and dashed every row inside it — the "stray dashed borders on
+   unrelated rows" bug. Threads never span days (they're pulled onto their
+   newest member's day), so the sibling hop only ever means anything
+   between row wrappers within one day; scope it there. */
+.feed-ledger .feed-list > li:not(.feed-day-group):has(+ li .feed-item-thread-continuation) .feed-item-ledger {
   border-bottom-style: dashed;
 }
 


### PR DESCRIPTION
## Problem

On the ledger home feed, the dashed rule that should appear only *above a self-thread continuation* was showing up between unrelated, non-threaded rows — often dashing every row under a day header (see the reported screenshot where all of "Today" was dashed).

## Cause

The dashed separator is drawn by dashing the previous row's bottom border:

```css
.feed-ledger .feed-list > li:has(+ li .feed-item-thread-continuation) .feed-item-ledger
```

The feed nests **two** lists that both carry the `feed-list` class:

- the outer `<ol className="feed-list">` whose children are `<li className="feed-day-group">` (one per day), and
- each day's inner `<ul className="feed-list">` whose children are the row wrappers.

So `.feed-list > li` also matched the day-group `<li>`s. Whenever a later (older) day contained a self-reply thread *anywhere in it*, the `:has(+ li .feed-item-thread-continuation)` matched the current day-group and the trailing ` .feed-item-ledger` dashed **every row inside that day**.

## Fix

Scope the selector with `:not(.feed-day-group)` so the sibling hop only applies between row wrappers within a single day:

```css
.feed-ledger .feed-list > li:not(.feed-day-group):has(+ li .feed-item-thread-continuation) .feed-item-ledger
```

Threads are always anchored onto their newest member's day (`threadAwareDateKey`), so a continuation and its parent are always in the same day's list — nothing intended is lost. Real continuations still get their dashed separator; unrelated rows no longer do.

## Testing

- `vite build` completes cleanly and the `:not(.feed-day-group)` guard is present in the compiled CSS.
- CSS-only, single-selector change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018xkJQHYUdBLUX3fHDuPj1w)_