### PR TITLE
Give cross-posted blog posts a category on /creating

### DIFF
--- a/src/lib/publications.js
+++ b/src/lib/publications.js
@@ -18,11 +18,11 @@ const BLOG_TAGS = new Set(['blog', 'blogging']);
 const CREATING_TAGS = new Set(['creating', 'portfolio']);
 const RESERVED_TAGS = new Set([...BLOG_TAGS, ...CREATING_TAGS]);
 
-// The medium a blog post takes on when it's cross-posted onto /creating. A
+// The category a blog post takes on when it's cross-posted onto /creating. A
 // blog doc has no medium of its own — its tags describe subject, not craft —
 // so the whole class shows under this one category rather than appearing on
 // the portfolio grid uncategorized.
-export const WRITING_CATEGORY = 'writing';
+export const CROSSPOST_CATEGORY = 'case study';
 
 function tagList(value) {
   return Array.isArray(value?.tags) ? value.tags : [];
@@ -95,18 +95,19 @@ export function workSlug(value) {
  *
  * A blog post cross-posted onto /creating is the one case with no medium to
  * draw on — it carries only the reserved `creating` marker (its other tags,
- * if any, name topics, not craft) — so it falls back to a `writing` category.
- * That default keeps cross-posted posts from landing on the portfolio grid
- * without a chip and lets them group and filter like every other work. An
- * explicit `category`/`kind` still wins, so a deliberate label overrides it.
+ * if any, name topics, not craft) — so it falls back to a `case study`
+ * category. That default keeps cross-posted posts from landing on the
+ * portfolio grid without a chip and lets them group and filter like every
+ * other work. An explicit `category`/`kind` still wins, so a deliberate label
+ * overrides it.
  */
 export function workCategory(value) {
   if (value?.category) return value.category;
   if (value?.kind) return value.kind;
   // A cross-posted blog doc (blog-homed, opted onto /creating with a
   // `creating`/`portfolio` tag) has no medium of its own — categorize the
-  // whole class as writing rather than promoting a topic tag to a medium.
-  if (isBlogDoc(value) && hasAnyTag(value, CREATING_TAGS)) return WRITING_CATEGORY;
+  // whole class as a case study rather than promoting a topic tag to a medium.
+  if (isBlogDoc(value) && hasAnyTag(value, CREATING_TAGS)) return CROSSPOST_CATEGORY;
   // Skip reserved cross-post tags so a `blog`/`creating` marker never shows
   // up as the work's medium; the first real tag stands in as the category.
   return (

--- a/src/lib/publications.js
+++ b/src/lib/publications.js
@@ -18,6 +18,12 @@ const BLOG_TAGS = new Set(['blog', 'blogging']);
 const CREATING_TAGS = new Set(['creating', 'portfolio']);
 const RESERVED_TAGS = new Set([...BLOG_TAGS, ...CREATING_TAGS]);
 
+// The medium a blog post takes on when it's cross-posted onto /creating. A
+// blog doc has no medium of its own — its tags describe subject, not craft —
+// so the whole class shows under this one category rather than appearing on
+// the portfolio grid uncategorized.
+export const WRITING_CATEGORY = 'writing';
+
 function tagList(value) {
   return Array.isArray(value?.tags) ? value.tags : [];
 }
@@ -86,10 +92,21 @@ export function workSlug(value) {
  * explicit `category`/`kind`; standard docs fold the category into `tags`,
  * so the first tag stands in as the primary medium (the export + migration
  * put the medium first).
+ *
+ * A blog post cross-posted onto /creating is the one case with no medium to
+ * draw on — it carries only the reserved `creating` marker (its other tags,
+ * if any, name topics, not craft) — so it falls back to a `writing` category.
+ * That default keeps cross-posted posts from landing on the portfolio grid
+ * without a chip and lets them group and filter like every other work. An
+ * explicit `category`/`kind` still wins, so a deliberate label overrides it.
  */
 export function workCategory(value) {
   if (value?.category) return value.category;
   if (value?.kind) return value.kind;
+  // A cross-posted blog doc (blog-homed, opted onto /creating with a
+  // `creating`/`portfolio` tag) has no medium of its own — categorize the
+  // whole class as writing rather than promoting a topic tag to a medium.
+  if (isBlogDoc(value) && hasAnyTag(value, CREATING_TAGS)) return WRITING_CATEGORY;
   // Skip reserved cross-post tags so a `blog`/`creating` marker never shows
   // up as the work's medium; the first real tag stands in as the category.
   return (


### PR DESCRIPTION
## What

Blog posts cross-posted onto the portfolio (`/creating`) carried only the reserved `creating` marker, so `workCategory()` returned an empty string — they landed on the grid with no medium chip and were absent from the "filter by kind" list.

This teaches `workCategory()` one rule: a blog-homed `site.standard.document` that's opted onto `/creating` (via a `creating`/`portfolio` tag) now falls back to a **`case study`** category. Cross-posted posts now show a chip, group, and filter like every other work.

## Details

- New `CROSSPOST_CATEGORY = 'case study'` constant in `src/lib/publications.js`.
- Fallback applies only to the cross-posted-blog class (`isBlogDoc(value) && hasAnyTag(value, CREATING_TAGS)`) — portfolio-homed works still take their medium from the first tag, and legacy `is.dame.creating.work` records still use their explicit `category`/`kind`.
- An explicit `category`/`kind` on a record still wins, so any individual post can override the default.
- One shared category rather than promoting a post's topical tags (e.g. `bluesky`) to a medium, so cross-posted posts read as one clean group.

## Verification

`npm run build:offline` passes; unit-checked `workCategory()` against the real cross-posted, portfolio, legacy, and override record shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxcWrwAt1Foe27n29HjphQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxcWrwAt1Foe27n29HjphQ)_