### PR TITLE
Lock the site to the dynamic sky theme, drop the theme switcher

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -469,10 +469,9 @@
   background: color-mix(in srgb, var(--accent) 20%, var(--page));
 }
 
-/* TEMPORARY: sky-theme test chip beside the theme toggle. A text button
-   (the current hour key, e.g. "3pm") rather than a glyph, since the
-   label IS the state being tested. Remove with the button in
-   ChromeBar.jsx once the sky theme has been vetted. */
+/* Time switcher: the sky clock's hour chip. A text button (the current
+   hour key, e.g. "3pm") rather than a glyph, since the label IS the
+   state — the hour whose sky palette is on screen. */
 .chrome-nav.chrome-sky-hour {
   width: auto;
   min-width: 1.75rem;

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, SwatchBook, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { skyAvatarUrl } from '../lib/skyAvatars.js';
@@ -41,9 +41,8 @@ export default function ChromeBar() {
   // hour — the same art the live Bluesky avatar cycles through, served
   // locally instead of fetched from the profile, so the mark is always
   // in lockstep with the site's own clock (and with the sky theme's
-  // palette). useTheme's hour ticks over hourly in every theme; while
-  // the TEMPORARY bottom-bar chip is overriding the clock in sky mode,
-  // the mark steps with it.
+  // palette). useTheme's hour ticks over hourly; while the bottom-bar
+  // time chip is overriding the clock, the mark steps with it.
   const { skyHour } = useTheme();
   const targetAvatar = skyAvatarUrl(skyHour);
 
@@ -356,8 +355,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const nearBottom = useNearPageBottom();
   const footerRef = useRef(null);
   const { available: filterAvailable } = useFeedFilter();
-  const { theme, cycle: cycleTheme, options: themeOptions, skyHourKey, advanceSkyHour } = useTheme();
-  const nextTheme = themeOptions[(themeOptions.indexOf(theme) + 1) % themeOptions.length];
+  const { skyHourKey, advanceSkyHour } = useTheme();
   // The edit-mode toggle only exists for the site owner. It sits beside the
   // Info button and flips the site into a selectable "edit mode" (see
   // EditModeBar + useEditMode).
@@ -502,31 +500,20 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 exit={{ opacity: 0 }}
                 transition={{ duration: reduce ? 0 : 0.18, ease: [0.22, 0.61, 0.36, 1] }}
               >
+                {/* Time switcher. The site always runs the hour-tracking
+                    sky theme; this chip shows the hour whose palette is on
+                    screen, and each tap advances it one hour (wrapping at
+                    midnight) so you can walk the sky through the day by
+                    hand. */}
                 <button
                   type="button"
-                  className="chrome-nav chrome-theme-toggle"
-                  onClick={cycleTheme}
-                  aria-label={`Switch to ${nextTheme} theme (current: ${theme})`}
-                  title={`Theme: ${theme} — tap to switch`}
+                  className="chrome-nav chrome-sky-hour"
+                  onClick={advanceSkyHour}
+                  aria-label={`Advance the sky one hour (showing ${skyHourKey})`}
+                  title={`Time of day — tap to advance the sky one hour (showing ${skyHourKey})`}
                 >
-                  <SwatchBook className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  {skyHourKey}
                 </button>
-                {/* TEMPORARY: sky-theme test chip. Shows the hour whose
-                    palette is on screen; each tap advances one hour
-                    (wrapping at midnight) so all 24 increments can be
-                    stepped through in place. Remove once the sky theme
-                    has been vetted. */}
-                {theme === 'sky' && (
-                  <button
-                    type="button"
-                    className="chrome-nav chrome-sky-hour"
-                    onClick={advanceSkyHour}
-                    aria-label={`Advance sky theme by one hour (showing ${skyHourKey})`}
-                    title={`Sky theme test — tap to advance one hour (showing ${skyHourKey})`}
-                  >
-                    {skyHourKey}
-                  </button>
-                )}
                 {filterAvailable && (
                   <button
                     type="button"

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -1,63 +1,29 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
   applySkyTheme,
-  clearSkyTheme,
   easternHour,
   secondsUntilNextHour,
   skyHourKey,
 } from '../lib/skyTheme.js';
 
 const ThemeContext = createContext(null);
-const STORAGE_KEY = 'dame.theme';
 
-// Three themes: warm light, dark green, and the hour-tracking sky mode
-// (palette derived from the current sky-avatar frame — see
-// src/lib/skyTheme.js). The toggle cycles light → dark → sky.
-const VALID = ['light', 'dark', 'sky'];
+// The site runs a single, always-on theme: the hour-tracking "sky" mode,
+// whose palette is derived from the current sky-avatar frame (see
+// src/lib/skyTheme.js). The retired static light/dark themes and their
+// switcher have been removed from the chrome — only the sky clock's time
+// switcher survives (the hour chip in the bottom bar), which steps the
+// palette through the day by hand.
+const THEME = 'sky';
 
-// Retired monochrome variants map to their color equivalent so a
-// returning visitor who last used a mono theme keeps its light/dark
-// polarity instead of being reset to the default.
-const THEME_ALIAS = {
-  'light-mono': 'light',
-  'dark-mono': 'dark',
-};
-
-// Matches --surface-raised in theme.css. Used for the iOS Safari URL
-// bar surround / Android browser chrome so the OS UI blends with the
-// dame.is chrome bar instead of falling back to a system default.
-// The sky theme has no fixed value — its color comes from the hour's
-// computed palette in applyTheme.
-const THEME_COLOR = {
-  light: '#e3d8ba',
-  dark: '#13180f',
-};
-
-const DEFAULT_THEME = 'sky';
-
-function migrateStoredTheme(stored) {
-  const resolved = THEME_ALIAS[stored] || stored;
-  if (VALID.includes(resolved)) return resolved;
-  // Legacy / missing values land on the sky theme, so new visitors get
-  // the hour-tracking palette by default — they can flip to a static
-  // light/dark from the chrome bar.
-  return DEFAULT_THEME;
-}
-
-function applyTheme(theme, skyHour) {
-  document.documentElement.setAttribute('data-theme', theme);
-  let color = THEME_COLOR[theme] || THEME_COLOR.light;
-  if (theme === 'sky') {
-    const palette = applySkyTheme(skyHour ?? easternHour());
-    color = palette.themeColor;
-  } else {
-    clearSkyTheme();
-  }
-  applyThemeColor(color);
+function applyTheme(skyHour) {
+  document.documentElement.setAttribute('data-theme', THEME);
+  const palette = applySkyTheme(skyHour ?? easternHour());
+  applyThemeColor(palette.themeColor);
 }
 
 // State for the iOS re-tint scroll nudge below. Module-level so
-// overlapping nudges (rapid theme/hour changes — e.g. mashing the sky
+// overlapping nudges (rapid hour changes — e.g. mashing the sky
 // hour chip) share one TRUE baseline: a later nudge must not read the
 // 1px-displaced position left by an earlier one as its "original"
 // scroll position, or each overlap leaks a permanent 1px downward
@@ -78,7 +44,7 @@ function applyThemeColor(color) {
   // iOS Safari re-evaluates its status bar / URL bar tint at the END
   // of a user gesture (touchend). Nudging a 1px scroll provokes the
   // re-tint pass; without this, the chrome stays on the previous
-  // theme's color until the next scroll/tap. Re-entrant: the baseline
+  // hour's color until the next scroll/tap. Re-entrant: the baseline
   // is captured once per settled position and the pending restore is
   // cancelled, so back-to-back nudges always restore to where the page
   // actually started.
@@ -94,17 +60,11 @@ function applyThemeColor(color) {
 }
 
 export function ThemeProvider({ children }) {
-  const [theme, setThemeState] = useState(() => {
-    if (typeof localStorage === 'undefined') return DEFAULT_THEME;
-    return migrateStoredTheme(localStorage.getItem(STORAGE_KEY));
-  });
-
   // The site's sky clock. `liveHour` tracks the real Eastern hour; the
-  // override (driven by the temporary test button in the bottom bar)
-  // freezes it on an arbitrary hour so each step can be inspected.
-  // Leaving sky mode drops the override. The hour drives the sky
-  // theme's palette AND the chrome-bar avatar mark (which follows the
-  // hourly sky frames in every theme).
+  // override (driven by the time-switcher chip in the bottom bar)
+  // freezes it on an arbitrary hour so each step can be inspected. The
+  // hour drives the sky palette AND the chrome-bar avatar mark (which
+  // follows the hourly sky frames).
   const [liveHour, setLiveHour] = useState(() => easternHour());
   const [skyOverride, setSkyOverride] = useState(null);
   const skyHour = skyOverride ?? liveHour;
@@ -112,28 +72,23 @@ export function ThemeProvider({ children }) {
   const skyHourRef = useRef(skyHour);
   skyHourRef.current = skyHour;
 
-  // What applyTheme last painted. The click handlers below apply
-  // synchronously (for the iOS same-gesture theme-color) and then set
-  // state; without this guard the state-driven effect would re-apply the
-  // identical theme+hour right after — a second scroll nudge per tap.
+  // What applyTheme last painted. advanceSkyHour applies synchronously
+  // (for the iOS same-gesture theme-color) and then sets state; without
+  // this guard the state-driven effect would re-apply the identical hour
+  // right after — a second scroll nudge per tap.
   const appliedRef = useRef(null);
-  const applySig = (t, h) => (t === 'sky' ? `sky:${h}` : t);
 
   useEffect(() => {
-    const sig = applySig(theme, skyHour);
+    const sig = `sky:${skyHour}`;
     if (appliedRef.current !== sig) {
-      applyTheme(theme, skyHour);
+      applyTheme(skyHour);
       appliedRef.current = sig;
     }
-    try {
-      localStorage.setItem(STORAGE_KEY, theme);
-    } catch {}
-  }, [theme, skyHour]);
+  }, [skyHour]);
 
   // Tick the clock over at the top of each Eastern hour (minutes/seconds
-  // track UTC, so the boundary is computable locally). Runs in EVERY
-  // theme — the avatar mark follows the hour even when the palette is a
-  // static light/dark. Timers sleep in background tabs, so
+  // track UTC, so the boundary is computable locally). The avatar mark
+  // and palette follow the hour. Timers sleep in background tabs, so
   // visibility-return also re-reads the clock.
   useEffect(() => {
     let timer;
@@ -156,50 +111,26 @@ export function ThemeProvider({ children }) {
     };
   }, []);
 
-  const setTheme = useCallback((next) => {
-    if (!VALID.includes(next)) return;
-    // Apply synchronously inside the click handler so iOS Safari sees
-    // the updated theme-color meta during the same user gesture.
-    applyTheme(next, skyHourRef.current);
-    appliedRef.current = applySig(next, skyHourRef.current);
-    setThemeState(next);
-    if (next !== 'sky') setSkyOverride(null);
-  }, []);
-
-  const cycle = useCallback(() => {
-    setThemeState((prev) => {
-      const idx = VALID.indexOf(prev);
-      const next = VALID[(idx + 1) % VALID.length];
-      applyTheme(next, skyHourRef.current);
-      appliedRef.current = applySig(next, skyHourRef.current);
-      if (next !== 'sky') setSkyOverride(null);
-      return next;
-    });
-  }, []);
-
-  // TEMPORARY (sky-theme testing): step the sky palette forward one hour
-  // per call, wrapping at midnight. Wired to the hour chip in the bottom
-  // chrome bar so each of the 24 increments can be eyeballed in place.
+  // Time switcher: step the sky palette forward one hour per call,
+  // wrapping at midnight. Wired to the hour chip in the bottom chrome
+  // bar so each of the 24 increments can be walked through in place.
   const advanceSkyHour = useCallback(() => {
     const next = (skyHourRef.current + 1) % 24;
-    // Sync apply for the same iOS theme-color gesture reason as setTheme.
-    applyTheme('sky', next);
-    appliedRef.current = applySig('sky', next);
+    // Sync apply for the same iOS theme-color gesture reason as above.
+    applyTheme(next);
+    appliedRef.current = `sky:${next}`;
     setSkyOverride(next);
   }, []);
 
   const value = useMemo(
     () => ({
-      theme,
-      setTheme,
-      cycle,
-      options: VALID,
+      theme: THEME,
       skyHour,
       skyHourKey: skyHourKey(skyHour),
       skyOverridden: skyOverride != null,
       advanceSkyHour,
     }),
-    [theme, setTheme, cycle, skyHour, skyOverride, advanceSkyHour],
+    [skyHour, skyOverride, advanceSkyHour],
   );
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,30 +10,16 @@ import './styles/typography.css';
 import './styles/app.css';
 import './styles/paper.css';
 
-// Theme selection happens here (before React mounts) so the first
-// paint is in the correct palette. Three themes (light / dark / the
-// hour-tracking sky mode); retired monochrome variants alias to their
-// color equivalent, and legacy/missing values fall to sky. Keep
-// VALID_THEMES + THEME_COLORS + THEME_ALIASES in sync with useTheme.jsx.
-const VALID_THEMES = ['light', 'dark', 'sky'];
-const THEME_ALIASES = { 'light-mono': 'light', 'dark-mono': 'dark' };
-const THEME_COLORS = {
-  light: '#e3d8ba',
-  dark: '#13180f',
-};
-const storedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.theme') : null;
-const resolvedStoredTheme = THEME_ALIASES[storedTheme] || storedTheme;
-// Default to the sky theme for new visitors (and legacy `system` /
-// other invalid values). Keep in sync with DEFAULT_THEME in useTheme.
-const initialTheme = VALID_THEMES.includes(resolvedStoredTheme) ? resolvedStoredTheme : 'sky';
-document.documentElement.setAttribute('data-theme', initialTheme);
+// The site runs a single, always-on theme: the hour-tracking sky mode.
+// Set it here (before React mounts) so the first paint is in the right
+// palette. The retired static light/dark themes are no longer selectable.
+// Keep in sync with useTheme.jsx.
+document.documentElement.setAttribute('data-theme', 'sky');
 
-// Sky mode's palette is computed, not static — derive this hour's tokens
-// before the first paint, and take the browser-chrome tint from them.
-let initialThemeColor = THEME_COLORS[initialTheme];
-if (initialTheme === 'sky') {
-  initialThemeColor = applySkyTheme(easternHour()).themeColor;
-}
+// Sky mode's palette is computed per hour, not static — derive this
+// hour's tokens before the first paint and take the browser-chrome tint
+// from them.
+const initialThemeColor = applySkyTheme(easternHour()).themeColor;
 
 document.querySelectorAll('meta[name="theme-color"]').forEach((m) => m.remove());
 const themeColorMeta = document.createElement('meta');


### PR DESCRIPTION
The static light/dark themes and the swatch-book theme toggle are hidden from the bottom chrome — the site now always runs the hour-tracking sky theme. The sky-hour chip stays as the permanent **time switcher** (step the palette through the day by hand), rather than a temporary test control.

## Changes

- **`src/hooks/useTheme.jsx`** — Pin the theme to `sky`. Remove the light/dark switching machinery (`VALID` list, monochrome aliases, `cycle`, `setTheme`, stored-theme migration, `THEME_COLOR`). Keep the hourly Eastern-time clock, the iOS re-tint scroll nudge, and `advanceSkyHour`. A returning visitor whose stored preference was light/dark now lands on sky.
- **`src/components/ChromeBar.jsx`** — Remove the theme-toggle button and its `SwatchBook` import. The hour chip always renders now (it was gated on `theme === 'sky'`); its labels/comments describe it as the time switcher.
- **`src/main.jsx`** — Force `data-theme="sky"` before first paint and derive the browser-chrome tint from this hour's computed palette, so there's no flash of a stale light/dark palette on load.
- **`src/components/ChromeBar.css`** — Refresh the sky-hour chip comment.

The `[data-theme='light']` / `[data-theme='dark']` blocks in `theme.css` are left in place — inert while `data-theme` is always `sky`, but kept (rather than deleted) so the static themes remain trivial to re-enable.

Verified with `vite build` (compiles clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dEYLWy1pckfXQb6dfaPQ9)_