### PR TITLE
Guestbook form: handle-only signer line, explicit "signing from" with coarse region detection

### DIFF
--- a/lexicons/GUESTBOOK.md
+++ b/lexicons/GUESTBOOK.md
@@ -72,4 +72,9 @@ site can host its own book with the same two lexicons.
   `/guestbook` (the owner's pencil button — each signature grows hide/unhide)
   and the **Guestbook panel** in `/admin` (`?view=guestbook`).
 - Nothing sensitive is collected: no email, no IP, no structured location —
-  `location` is a free-text field the signer types (or leaves empty).
+  `location` is a free-text field the signer types (or leaves empty). The
+  form's optional **"Use my region"** button asks the browser for location
+  (an explicit click behind the browser's own permission prompt), blurs the
+  coordinates to ~11 km before they leave the device, and fills the field
+  with only *state/region + country* — never a town, city, or coordinates.
+  The label is editable before signing; nothing auto-submits.

--- a/lexicons/is.dame.guestbook.entry.json
+++ b/lexicons/is.dame.guestbook.entry.json
@@ -37,7 +37,7 @@
             "type": "string",
             "maxLength": 640,
             "maxGraphemes": 64,
-            "description": "Optional free-text 'signing from…' — a city, a website, 'the bus', anything."
+            "description": "Optional free-text 'signing from…' — a place in the signer's own words: a region, a website, 'the bus', anything. Never structured geo data. The reference UI can suggest a coarse label via browser geolocation, but it only ever offers state/region + country — towns and coordinates are never stored."
           },
           "createdAt": { "type": "string", "format": "datetime" }
         }

--- a/src/lib/guestbook.js
+++ b/src/lib/guestbook.js
@@ -230,6 +230,64 @@ export async function deleteGuestbookEntry(agent, rkey) {
   });
 }
 
+// --- coarse location ("signing from") ------------------------------------------
+
+/**
+ * Ask the browser for location and resolve it to a coarse, town-free label —
+ * "North Carolina, United States", "Bavaria, Germany", or just a country.
+ * Privacy posture, matching the site's no-location rule elsewhere:
+ *   - runs only on an explicit click; the browser permission prompt is the consent,
+ *   - coordinates are blurred to ~11 km before they leave the device,
+ *   - only state/region + country are kept — never a town, city, or coordinates,
+ *   - the label lands in the form input for review; nothing auto-submits.
+ * Reverse geocoding via BigDataCloud's free client endpoint (keyless, CORS).
+ */
+export async function detectCoarseRegion() {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) {
+    throw new Error('Location is not available in this browser.');
+  }
+  const pos = await new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      resolve,
+      (err) => {
+        reject(
+          new Error(
+            err?.code === 1
+              ? 'Location permission was declined.'
+              : 'Could not read your location.',
+          ),
+        );
+      },
+      { enableHighAccuracy: false, timeout: 10_000, maximumAge: 600_000 },
+    );
+  });
+  const lat = Math.round(pos.coords.latitude * 10) / 10;
+  const lon = Math.round(pos.coords.longitude * 10) / 10;
+  const res = await fetch(
+    `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lon}&localityLanguage=en`,
+  );
+  if (!res.ok) throw new Error('Could not look up a region.');
+  const data = await res.json();
+  const region = String(data?.principalSubdivision || '').trim();
+  // Country: prefer the tidy Intl name for the ISO code over the endpoint's
+  // formal styling ("United States of America (the)").
+  let country = '';
+  const code = String(data?.countryCode || '').trim();
+  if (code) {
+    try {
+      country = new Intl.DisplayNames(['en'], { type: 'region' }).of(code) || '';
+    } catch {
+      // Intl.DisplayNames missing — fall through to countryName.
+    }
+  }
+  if (!country || country === code) {
+    country = String(data?.countryName || '').replace(/\s*\(the\)\s*$/i, '').trim();
+  }
+  const parts = [region, country].filter(Boolean);
+  if (parts.length === 0) throw new Error('Could not resolve a region.');
+  return parts.join(', ');
+}
+
 // --- moderation (host only) ---------------------------------------------------
 
 /**

--- a/src/pages/Guestbook.css
+++ b/src/pages/Guestbook.css
@@ -35,18 +35,7 @@
 }
 
 .guestbook-form-signer {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
   color: var(--ink);
-}
-
-.guestbook-form-avatar {
-  width: 1.4em;
-  height: 1.4em;
-  object-fit: cover;
-  border: 1px solid var(--rule);
-  align-self: center;
 }
 
 .guestbook-textarea {
@@ -115,9 +104,63 @@
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
+/* "Signing from" — its own labelled block so it's obvious what the field
+   is, with the locate button and the never-your-town promise beside it. */
+.guestbook-location-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.guestbook-location-label {
+  color: var(--ink-faint);
+  letter-spacing: 0.18em;
+  font-size: var(--text-xs);
+}
+
+.guestbook-location-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .guestbook-location {
-  flex: 1 1 12rem;
-  max-width: 18rem;
+  flex: 1 1 14rem;
+  max-width: 22rem;
+}
+
+.guestbook-locate {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-family: var(--sans);
+  font-variant: all-small-caps;
+  letter-spacing: 0.14em;
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  padding: 0.45em 0.8em;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.guestbook-locate:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+.guestbook-locate:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.guestbook-location-hint {
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+  max-width: 52ch;
 }
 
 .guestbook-form-actions {

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { LocateFixed } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
 import GuestbookEntryRow from '../components/GuestbookEntryRow.jsx';
 import { CommentsSkeleton } from '../components/Skeleton.jsx';
@@ -11,6 +12,7 @@ import {
   signGuestbook,
   deleteGuestbookEntry,
   setEntryHidden,
+  detectCoarseRegion,
   graphemeLength,
   ENTRY_TEXT_MAX_GRAPHEMES,
 } from '../lib/guestbook.js';
@@ -223,15 +225,32 @@ function SignForm({ agent, did, profile, onSigned }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
   const [signedAt, setSignedAt] = useState(null);
+  const [locating, setLocating] = useState(false);
+  const [locError, setLocError] = useState(null);
 
   const remaining = ENTRY_TEXT_MAX_GRAPHEMES - graphemeLength(text);
   const canSign = !busy && (text.trim() || mark);
 
+  // Identity in the book is the handle, so that's what the form shows —
+  // no avatar, no display name.
   const signingAs = useMemo(() => {
-    if (profile?.displayName?.trim()) return profile.displayName.trim();
     if (profile?.handle && profile.handle !== 'handle.invalid') return `@${profile.handle}`;
-    return did || '';
+    if (!did) return '';
+    return did.length > 24 ? `${did.slice(0, 12)}…${did.slice(-6)}` : did;
   }, [profile, did]);
+
+  async function detectRegion() {
+    if (locating) return;
+    setLocating(true);
+    setLocError(null);
+    try {
+      setLocation(await detectCoarseRegion());
+    } catch (err) {
+      setLocError(err?.message || String(err));
+    } finally {
+      setLocating(false);
+    }
+  }
 
   async function handleSubmit(event) {
     event.preventDefault();
@@ -256,10 +275,7 @@ function SignForm({ agent, did, profile, onSigned }) {
     <form className="guestbook-form" onSubmit={handleSubmit}>
       <div className="guestbook-form-head">
         <span className="small-caps guestbook-form-eyebrow">Signing as</span>
-        <span className="guestbook-form-signer">
-          {profile?.avatar && <img className="guestbook-form-avatar" src={profile.avatar} alt="" />}
-          {signingAs}
-        </span>
+        <span className="guestbook-form-signer">{signingAs}</span>
       </div>
 
       <textarea
@@ -291,15 +307,39 @@ function SignForm({ agent, did, profile, onSigned }) {
             </button>
           ))}
         </div>
-        <input
-          className="guestbook-location signin-input"
-          type="text"
-          placeholder="signing from… (optional)"
-          value={location}
-          onChange={(e) => setLocation(e.target.value)}
-          maxLength={64}
-          disabled={busy}
-        />
+      </div>
+
+      <div className="guestbook-location-field">
+        <label className="small-caps guestbook-location-label" htmlFor="guestbook-location">
+          Signing from
+        </label>
+        <div className="guestbook-location-row">
+          <input
+            id="guestbook-location"
+            className="guestbook-location signin-input"
+            type="text"
+            placeholder="a place, in your own words — optional"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            maxLength={64}
+            disabled={busy}
+          />
+          <button
+            type="button"
+            className="guestbook-locate"
+            onClick={detectRegion}
+            disabled={busy || locating}
+          >
+            <LocateFixed size={14} strokeWidth={1.75} aria-hidden="true" />
+            {locating ? 'Locating…' : 'Use my region'}
+          </button>
+        </div>
+        <span className="guestbook-location-hint">
+          Shown beside your signature. Write anything — or let &ldquo;Use my region&rdquo; ask
+          your browser for location and fill in only your state/region and country, never your
+          town or coordinates.
+        </span>
+        {locError && <p className="signin-error">{locError}</p>}
       </div>
 
       <div className="guestbook-form-actions">


### PR DESCRIPTION
## What

Three refinements to the guestbook's sign form:

- **"Signing as" shows just the handle** (`@dame.is`) — no avatar, no display name; truncated DID as fallback.
- **"Signing from" is now an explicit labelled block** — small-caps label, clearer placeholder, and a hint explaining the field appears beside the signature.
- **Opt-in "Use my region" button** — an explicit click triggers the browser's location permission prompt, coordinates are blurred to ~11 km before leaving the device, then reverse-geocoded via BigDataCloud's keyless client endpoint into **state/region + country only** ("North Carolina, United States") — never a town, city, or coordinates, matching the site's no-location rule for iNaturalist data. The label lands in the editable input; nothing auto-submits.

## Verified

Unit tests of `detectCoarseRegion` (coordinate blurring, city discarding, tidy country names via `Intl.DisplayNames`, permission-denied error, country-only fallback) plus a Chromium run with emulated geolocation: clicking the button sent only blurred coords to the stubbed geocoder and filled the field with "North Carolina, United States". Lexicon `location` description and GUESTBOOK.md privacy section updated to document the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL)_