### PR TITLE
Add a serif-only font switcher to the bottom chrome

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import RouteTransition from './components/RouteTransition.jsx';
 import { ActionDockProvider } from './hooks/useActionDock.jsx';
 import { ChromePanelProvider } from './hooks/useChromePanel.jsx';
 import { ThemeProvider } from './hooks/useTheme.jsx';
+import { FontProvider } from './hooks/useFont.jsx';
 import { FeedLayoutProvider } from './hooks/useFeedLayout.jsx';
 import { PaperProvider } from './hooks/usePaper.jsx';
 import { ChromeBarProvider } from './hooks/useChromeBar.jsx';
@@ -84,6 +85,7 @@ function generatedRecordRoutes() {
 export default function App() {
   return (
     <ThemeProvider>
+      <FontProvider>
       <FeedLayoutProvider>
       <PaperProvider>
       <ChromeBarProvider>
@@ -165,6 +167,7 @@ export default function App() {
       </ChromeBarProvider>
       </PaperProvider>
       </FeedLayoutProvider>
+      </FontProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, Type, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { skyAvatarUrl } from '../lib/skyAvatars.js';
@@ -9,6 +9,7 @@ import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
+import { useFont } from '../hooks/useFont.jsx';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { ME_DID } from '../config.js';
@@ -356,6 +357,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const footerRef = useRef(null);
   const { available: filterAvailable } = useFeedFilter();
   const { skyHourKey, advanceSkyHour } = useTheme();
+  const { serifOnly, toggle: toggleFont } = useFont();
   // The edit-mode toggle only exists for the site owner. It sits beside the
   // Info button and flips the site into a selectable "edit mode" (see
   // EditModeBar + useEditMode).
@@ -513,6 +515,19 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                   title={`Time of day — tap to advance the sky one hour (showing ${skyHourKey})`}
                 >
                   {skyHourKey}
+                </button>
+                {/* Font switcher. Toggles serif-only mode, which folds the
+                    monospace ledger/metadata accent into the serif voice
+                    (code stays monospace). Default is the mixed voice. */}
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-font-toggle ${serifOnly ? 'is-open' : ''}`}
+                  onClick={toggleFont}
+                  aria-pressed={serifOnly}
+                  aria-label={serifOnly ? 'Use the default serif + monospace type' : 'Use serif-only type'}
+                  title={serifOnly ? 'Serif-only type — tap to restore mono accents' : 'Mono accents — tap for serif-only type'}
+                >
+                  <Type className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
                 {filterAvailable && (
                   <button

--- a/src/components/DebugOverlay.css
+++ b/src/components/DebugOverlay.css
@@ -96,7 +96,7 @@
 }
 
 .debug-overlay-json {
-  font-family: var(--mono);
+  font-family: var(--code);
   font-size: var(--text-xs);
   background: var(--page-edge);
   border: 1px solid var(--rule-soft);

--- a/src/components/LeafletDocument.css
+++ b/src/components/LeafletDocument.css
@@ -89,7 +89,7 @@
 }
 
 .leaflet-code {
-  font-family: var(--mono);
+  font-family: var(--code);
   font-size: var(--text-sm);
   background: var(--page-edge);
   border: 1px solid var(--rule-soft);

--- a/src/hooks/useFont.jsx
+++ b/src/hooks/useFont.jsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const FontContext = createContext(null);
+const STORAGE_KEY = 'dame.font';
+
+// Two font modes:
+//   - mixed : the default. Serif body (Crimson Pro) with a monospace
+//             technical accent (--mono) on gutters, ledger columns, and
+//             metadata — the tabular, ledger-like voice.
+//   - serif : folds that monospace accent into the serif voice so the
+//             whole reading surface is one typeface. Code and raw data
+//             (--code) stay monospace either way — see theme.css.
+// The CSS lives in theme.css under [data-font='serif']; this hook just
+// owns the preference and paints data-font onto <html>. Keep VALID +
+// DEFAULT in sync with the pre-paint block in main.jsx.
+const VALID = ['mixed', 'serif'];
+const DEFAULT = 'mixed';
+
+function applyFont(font) {
+  document.documentElement.setAttribute('data-font', font);
+}
+
+function readInitial() {
+  if (typeof localStorage === 'undefined') return DEFAULT;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return VALID.includes(stored) ? stored : DEFAULT;
+}
+
+export function FontProvider({ children }) {
+  const [font, setFontState] = useState(readInitial);
+
+  useEffect(() => {
+    applyFont(font);
+    try {
+      localStorage.setItem(STORAGE_KEY, font);
+    } catch {}
+  }, [font]);
+
+  const setFont = useCallback((next) => {
+    if (!VALID.includes(next)) return;
+    setFontState(next);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setFontState((prev) => (prev === 'serif' ? 'mixed' : 'serif'));
+  }, []);
+
+  const value = useMemo(
+    () => ({ font, setFont, toggle, serifOnly: font === 'serif', options: VALID }),
+    [font, setFont, toggle],
+  );
+  return <FontContext.Provider value={value}>{children}</FontContext.Provider>;
+}
+
+export function useFont() {
+  const ctx = useContext(FontContext);
+  if (!ctx) throw new Error('useFont must be used inside <FontProvider>');
+  return ctx;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -39,6 +39,17 @@ document.documentElement.setAttribute(
   PAPER_ENABLED && VALID_PAPER.includes(storedPaper) ? storedPaper : 'blank',
 );
 
+// Font mode (serif-only vs the default mono-accented mix). Set before the
+// first paint so a serif-only visitor doesn't flash the monospace ledger
+// columns before they fold into the serif voice. Keep in sync with
+// useFont.jsx.
+const VALID_FONTS = ['mixed', 'serif'];
+const storedFont = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.font') : null;
+document.documentElement.setAttribute(
+  'data-font',
+  VALID_FONTS.includes(storedFont) ? storedFont : 'mixed',
+);
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -45,7 +45,7 @@
 }
 
 .admin-mono {
-  font-family: var(--mono);
+  font-family: var(--code);
   font-size: 0.8125rem;
 }
 

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -239,7 +239,7 @@
 }
 
 .record-page-aturi code {
-  font-family: var(--mono);
+  font-family: var(--code);
 }
 
 /* Parent-of-reply chain on the post record page */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -44,10 +44,17 @@
      an available stack, not wired to any role. */
   --serif:  var(--font-crimson);
   --sans:   var(--font-crimson);
+  /* --mono is the tabular "ledger" accent: gutters, ledger columns, and
+     metadata. It's a real monospace by default, but serif-only font mode
+     (see [data-font='serif'] below) folds it into the serif voice. */
   --mono:   'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* --code is for genuine code and raw data (<code>/<pre>, JSON dumps,
+     at-uris) where alignment carries meaning — it stays monospace in
+     every font mode, unlike --mono. */
+  --code:   'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   /* UI-chrome mono (paths, kbd badges, identifiers, etc.) reads in the
      serif voice so the chrome matches the rest of the site, while real
-     code surfaces (<code>, <pre>) keep --mono. */
+     code surfaces (<code>, <pre>) keep --code. */
   --mono-ui: var(--font-crimson);
 
   --measure: 65ch;
@@ -80,6 +87,16 @@
   --text-4xl: 3rem;
 
   color-scheme: light;
+}
+
+/* Serif-only font mode. Folds the tabular monospace accent (--mono:
+   gutters, ledger columns, metadata) into the serif voice so the whole
+   reading surface is one typeface. Genuine code/data (--code) is left
+   monospace. Toggled from the bottom chrome — see useFont.jsx — and set
+   pre-paint in main.jsx. Same specificity as :root, so this must stay
+   after the :root block to win the cascade. */
+[data-font='serif'] {
+  --mono: var(--serif);
 }
 
 [data-theme='dark'] {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -49,7 +49,7 @@ a:hover {
 }
 
 code, pre {
-  font-family: var(--mono);
+  font-family: var(--code);
   font-size: 0.95em;
 }
 


### PR DESCRIPTION
The site pairs a serif body (Crimson Pro) with a monospace "ledger" accent on gutters, ledger columns (`.ledger-verb`, `.ledger-time`, `.day-header-meta`), and metadata. This adds a font switcher next to the time switcher in the bottom chrome that folds that monospace accent into the serif voice, so the whole reading surface can be one typeface.

## Changes

- **`src/styles/theme.css`** — Split the technical font into two roles: `--mono` (the ledger/metadata accent, remapped to the serif stack under `[data-font='serif']`) and a new `--code` (genuine code + raw data — `code`/`pre`, JSON dumps, at-uris — always monospace). Add the `[data-font='serif']` override.
- Route genuine code/data surfaces to `--code` so they stay monospace in serif-only mode: `code`/`pre` (`typography.css`), `.leaflet-code`, `.debug-overlay-json`, `.record-page-aturi code`, `.admin-mono`.
- **`src/hooks/useFont.jsx`** — New preference hook/provider (`mixed` | `serif`), persisted to `localStorage` under `dame.font`. Wired into `App.jsx` and pre-painted in `main.jsx` so a serif-only visitor never flashes the monospace ledger columns on load.
- **`src/components/ChromeBar.jsx`** — A `Type`-glyph toggle button beside the time switcher, with `aria-pressed` reflecting serif-only state.

Default stays the current mixed voice; serif-only is opt-in.

Verified end-to-end in Chromium: default → `--mono` is IBM Plex Mono; serif-only → `--mono` becomes Crimson Pro while `--code` stays monospace; persists to `localStorage`; toggles back cleanly; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dEYLWy1pckfXQb6dfaPQ9)_