### PR TITLE
Scale up serif-only ledger text to match the mono footprint

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -277,7 +277,7 @@ a.feed-item-verb:focus-visible .feed-item-verb-label {
    scale from a stretched grid/flex ancestor when min-width was wrong. */
 article.post-card > footer.post-card-stats {
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
   font-weight: 400;
   letter-spacing: 0.02em;
   line-height: var(--leading-tight);
@@ -1581,7 +1581,7 @@ a.reference-card-profile:focus-visible {
 /* Day stats sit at the same scale as the rows' gerund/time labels. */
 .feed-ledger .day-header-meta {
   font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.85);
+  font-size: calc(var(--text-xs) * 0.85 * var(--mono-scale));
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-align: right;
@@ -1621,7 +1621,7 @@ a.reference-card-profile:focus-visible {
 
 .ledger-verb {
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-decoration: none;
@@ -1639,7 +1639,7 @@ a.ledger-verb:focus-visible {
 
 .ledger-time {
   font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.85);
+  font-size: calc(var(--text-xs) * 0.85 * var(--mono-scale));
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   /* formatTime yields "9:41 AM"; the ledger reads lowercase. */

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -226,6 +226,10 @@
 
 .record-page-meta-nsid {
   font-family: var(--mono);
+  /* No explicit base size (inherits from .record-page-meta); scale the
+     inherited size so serif-only mode compensates like the other --mono
+     elements. calc(1em * 1) is a no-op in the default mono voice. */
+  font-size: calc(1em * var(--mono-scale));
   letter-spacing: 0;
 }
 

--- a/src/pages/Mothing.css
+++ b/src/pages/Mothing.css
@@ -250,7 +250,7 @@
 .mothing-ledger-time {
   flex: 0 0 auto;
   font-family: var(--mono);
-  font-size: calc(var(--text-xs) * 0.85);
+  font-size: calc(var(--text-xs) * 0.85 * var(--mono-scale));
   letter-spacing: 0.02em;
   color: var(--ink-faint);
   text-transform: lowercase;

--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -151,7 +151,7 @@
 
 .resume-record-link {
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
   color: var(--ink-faint);
   text-decoration: none;
   opacity: 0;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -56,6 +56,11 @@
      serif voice so the chrome matches the rest of the site, while real
      code surfaces (<code>, <pre>) keep --code. */
   --mono-ui: var(--font-crimson);
+  /* Apparent-size compensation for the --mono ledger/metadata accent.
+     Monospace glyphs look larger than the serif's at the same font-size,
+     so serif-only mode (below) scales those elements up a touch to keep
+     their on-screen size. 1 = no change — the default mono voice. */
+  --mono-scale: 1;
 
   --measure: 65ch;
   --leading: 1.6;
@@ -97,6 +102,11 @@
    after the :root block to win the cascade. */
 [data-font='serif'] {
   --mono: var(--serif);
+  /* Crimson Pro reads noticeably smaller than IBM Plex Mono at a given
+     font-size (lower x-height), so nudge the flipped ledger/metadata
+     text up ~10% to hold the footprint it had in the mono voice. Tune
+     here — it flows into every --mono element's font-size via calc(). */
+  --mono-scale: 1.1;
 }
 
 [data-theme='dark'] {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -97,7 +97,7 @@ blockquote {
 
 .gutter {
   font-family: var(--mono);
-  font-size: var(--text-xs);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
   color: var(--ink-faint);
   letter-spacing: 0.02em;
 }


### PR DESCRIPTION
Follow-up to the serif-only font switcher. Crimson Pro reads noticeably smaller than IBM Plex Mono at the same font-size (lower x-height), so the ledger/metadata columns looked undersized once serif-only mode folded them out of monospace.

## Changes

- **`src/styles/theme.css`** — Add a `--mono-scale` factor: `1` by default (mixed mode, no change) and `1.1` under `[data-font='serif']`. One place to tune the compensation.
- Fold `* var(--mono-scale)` into the `font-size` of every element that flips from `--mono` to serif: `.gutter`, `.ledger-verb`, `.ledger-time`, `.day-header-meta`, `.post-card-stats`, `.resume-record-link`, `.mothing-ledger-time`, and `.record-page-meta-nsid` (which had no explicit size, so it scales its inherited size via `calc(1em * var(--mono-scale))`).

Serif-only mode now renders those columns ~10% larger to hold the on-screen footprint they had in the mono voice. Mixed mode is unchanged (×1), and code/data (`--code`) is unaffected.

Verified in Chromium: mixed mode unchanged (gutter 12px mono, ledger-time 10.2px mono); serif mode flips to Crimson Pro and grows exactly ×1.10 (12→13.2px, 10.2→11.22px); code stays 15.2px monospace throughout; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dEYLWy1pckfXQb6dfaPQ9)_