### PR TITLE
Cap creating/portfolio work pages at the reading measure

### DIFF
--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -82,18 +82,30 @@
   text-align: right;
 }
 
-.blog-article {
-  /* `width: 100%` is load-bearing: `.page` is a flex column, and the auto
-     margins below otherwise defeat flex stretch, letting the article size to
-     its max-content (clamped to --measure) and overflow narrow viewports.
-     Pinning width to the column keeps --measure a cap, not a floor. Mirrors
-     the same fix already applied to the sibling `.page-title` below. */
+/* Long-form document column — the single reading measure shared by blog posts
+   and creating/portfolio works (both render <LeafletDocument>, and a
+   site.standard.document can surface on either route). Capping the whole
+   ARTICLE here, at the page/container level, is what keeps the text AND every
+   media block — images, video embeds, galleries, link cards, code — aligned to
+   one column. The global `p { max-width: var(--measure) }` only reins in
+   paragraphs; without this container cap the media escapes to the full `.main`
+   width (72rem) while the prose stays at the measure, so images and embeds jut
+   out past the text on both sides.
+
+   `width: 100%` is load-bearing: `.page` is a flex column, and the auto margins
+   below otherwise defeat flex stretch, letting the article size to its
+   max-content (clamped to --measure) and overflow narrow viewports. Pinning
+   width to the column keeps --measure a cap, not a floor. Mirrors the same fix
+   applied to the sibling `.page-title` below. */
+.blog-article,
+.creating-work-page {
   width: 100%;
   max-width: var(--measure);
   margin: 0 auto;
 }
 
-.page:has(> .blog-article) > .page-title {
+.page:has(> .blog-article) > .page-title,
+.page:has(> .creating-work-page) > .page-title {
   max-width: var(--measure);
   margin-left: auto;
   margin-right: auto;

--- a/src/pages/Creating.css
+++ b/src/pages/Creating.css
@@ -84,6 +84,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+  /* The reading-measure width cap (max-width + centering) is shared with
+     .blog-article in Blogging.css — imported here — so text and media align to
+     one column. This rule only owns the internal vertical layout. */
 }
 
 .creating-work-media {


### PR DESCRIPTION
## Problem

Blog posts constrain the whole `.blog-article` to `var(--measure)` and center it, so text **and** media share one reading column. Creating/portfolio work pages (`.creating-work-page`) had **no** container cap — only the global `p { max-width: var(--measure) }` reined in paragraphs, so images, video embeds, galleries, and link cards spilled to the full `.main` width (72rem) while the prose stayed narrow.

Because the same `site.standard.document` renders through `<LeafletDocument>` on both routes, a doc looked correct at `/blogging/:id` but broke at `/creating/:slug`.

## Fix

Enforce the width cap at the page/container level (not per-element) by applying the proven `.blog-article` column rules — plus the matching `.page-title` cap — to `.creating-work-page`. The shared rule lives in `Blogging.css`, which both pages import.

The global `p { max-width }` is intentionally left in place — it's a readability baseline used across feeds, cards, and comments; the container cap is what brings the non-paragraph media into the measure too.

## Verification

Rendered the exact DOM against the real CSS (Playwright + Chromium):

| element | before | after | measure |
|---|---|---|---|
| video embed | 998px | **520px** | 520px |
| link card | 998px | **520px** | 520px |
| 2-up gallery | 998px | **520px** | 520px |
| paragraph | 545px | 520px | 520px |

- Desktop (1280px): media now aligns with the text column.
- Mobile (390px): everything fills the width uniformly (358px) — no regression.
- `npm run build:offline` passes.
- Blog posts are untouched (identical properties; only the selector list and comment changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gtX1sU9WQ5AYd9jtpUsp5

---
_Generated by [Claude Code](https://claude.ai/code/session_015gtX1sU9WQ5AYd9jtpUsp5)_