### PR TITLE
Admin: hidden-state chips, bulk hide/unhide, timestamps; fix curating edit mode

### DIFF
--- a/src/lib/recordVisibility.js
+++ b/src/lib/recordVisibility.js
@@ -1,0 +1,68 @@
+// How each collection expresses "hidden from the public site", so the admin
+// record list can flag hidden records with a chip and flip their visibility in
+// bulk. Every PDS record is technically public — this is *site display intent*,
+// the same notion the public surfaces already honor:
+//
+//   - site.standard.document → `draft: true` keeps a work off /creating and
+//     /blogging (see lib/publications.js `isDraft`).
+//   - is.dame.arena.channel  → `enabled: false` pulls a gallery off /curating
+//     (see pages/Curating.jsx, pages/CuratingChannel.jsx).
+//   - is.dame.hero.phrase    → `enabled: false` drops a phrase from the home
+//     hero rotation (see components/HeroSentence.jsx).
+//   - is.dame.resume         → `visibility` other than "public" keeps a resume
+//     off the listed /for-hire surface (see lib/resumeHelpers.js).
+//
+// Collections without a visibility concept (logging, posting, profile, …)
+// return null and simply get no chip or hide/unhide controls.
+
+import { COLLECTIONS } from '../config.js';
+
+const STANDARD_DOC = 'site.standard.document';
+
+const MODELS = {
+  [STANDARD_DOC]: {
+    isHidden: (v) => v?.draft === true,
+    chipLabel: () => 'draft',
+    setHidden: (v, hidden) => {
+      const next = { ...v };
+      if (hidden) next.draft = true;
+      else delete next.draft;
+      return next;
+    },
+  },
+
+  [COLLECTIONS.arenaChannel]: {
+    isHidden: (v) => v?.enabled === false,
+    chipLabel: () => 'hidden',
+    setHidden: (v, hidden) => ({ ...v, enabled: !hidden }),
+  },
+
+  [COLLECTIONS.heroPhrase]: {
+    isHidden: (v) => v?.enabled === false,
+    chipLabel: () => 'disabled',
+    setHidden: (v, hidden) => ({ ...v, enabled: !hidden }),
+  },
+
+  [COLLECTIONS.resume]: {
+    // Match the admin resume selector's convention: a missing visibility reads
+    // as private. Anything short of "public" counts as hidden from the listing.
+    isHidden: (v) => (v?.visibility || 'private') !== 'public',
+    chipLabel: (v) => v?.visibility || 'private',
+    // Hiding forces private; unhiding promotes to public. The three-state
+    // "unlisted" middle ground stays reachable through the full editor.
+    setHidden: (v, hidden) => ({ ...v, visibility: hidden ? 'private' : 'public' }),
+  },
+};
+
+/**
+ * The visibility model for a collection, or null when the collection has no
+ * public-visibility concept. A model is `{ isHidden, chipLabel, setHidden }`:
+ *
+ *   - isHidden(value)          → is this record hidden from the site?
+ *   - chipLabel(value)         → short word for the status chip (e.g. "draft")
+ *   - setHidden(value, hidden) → a new record value with the flag applied
+ *                                (shallow copy; callers pass a plain object)
+ */
+export function visibilityModelFor(collection) {
+  return MODELS[collection] || null;
+}

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -224,6 +224,7 @@
 
 .admin-record-link {
   display: flex;
+  align-items: baseline;
   gap: var(--space-4);
   padding: var(--space-3) 0;
   text-decoration: none;
@@ -242,10 +243,57 @@
   color: var(--ink-faint);
 }
 
+/* Name + status chip, between the rkey and the far-right timestamp. */
+.admin-record-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
+}
+
 .admin-record-preview {
-  flex: 1;
   font-family: var(--serif);
   color: var(--ink);
+  min-width: 0;
+}
+
+/* "hidden / draft / disabled" status chip — an outlined tan tag flagging a
+   record that isn't shown on the public site. */
+.admin-record-chip {
+  flex-shrink: 0;
+  font-family: var(--sans);
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  line-height: 1.3;
+  padding: 0 0.5em;
+  color: var(--tan);
+  border: 1px solid var(--tan);
+  white-space: nowrap;
+}
+
+/* Record timestamp, pinned to the far right of the row. */
+.admin-record-time {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+/* "Select" toggle sits apart from the primary toolbar buttons. */
+.admin-select-toggle {
+  margin-left: auto;
+}
+
+/* Bulk hide / unhide / delete cluster in the multi-select toolbar. */
+.admin-multiselect-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 /* Active resume selector: pick the single version shown at /for-hire. */

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -14,6 +14,7 @@ import { LEXICONS, lexiconFor, knownCollections } from '../lib/lexicons.js';
 const STANDARD_DOC = 'site.standard.document';
 import { knownPageSlugs, pageSlugForCollection } from '../lib/pageRegistry.js';
 import { LEGACY_POSTS, migratedSlugs, migratePost } from '../lib/legacyBlog.js';
+import { visibilityModelFor } from '../lib/recordVisibility.js';
 import { formatDateLong } from '../lib/time.js';
 import './Admin.css';
 
@@ -374,7 +375,14 @@ function RecordList({
   const [done, setDone] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  // Multi-select bulk editing: off by default so the list reads as plain
+  // navigable rows; toggling it on turns each row into a checkbox and reveals
+  // the bulk hide / unhide / delete bar.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState(() => new Set()); // rkeys
+  const [busy, setBusy] = useState(false);
   const lex = lexiconFor(collection);
+  const visModel = visibilityModelFor(collection);
   const pageSlug =
     pageSlugOverride !== undefined ? pageSlugOverride : pageSlugForCollection(collection);
   const isHero = collection === COLLECTIONS.heroPhrase;
@@ -410,6 +418,7 @@ function RecordList({
     setRecords([]);
     setCursor(undefined);
     setDone(false);
+    setSelected(new Set());
     loadPage(undefined);
   }, [loadPage]);
 
@@ -420,6 +429,90 @@ function RecordList({
   const visibleRecords = recordFilter
     ? records.filter((rec) => recordFilter(rec.value))
     : records;
+
+  const toggle = useCallback((rkey) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(rkey)) next.delete(rkey);
+      else next.add(rkey);
+      return next;
+    });
+  }, []);
+
+  const visibleRkeys = visibleRecords.map((rec) => rkeyFromUri(rec.uri));
+  const allSelected =
+    visibleRkeys.length > 0 && visibleRkeys.every((k) => selected.has(k));
+
+  function toggleAll() {
+    setSelected((prev) => {
+      if (visibleRkeys.length > 0 && visibleRkeys.every((k) => prev.has(k))) return new Set();
+      return new Set(visibleRkeys);
+    });
+  }
+
+  // Selected records whose hidden state would actually change — the set the
+  // Hide / Unhide buttons operate on (and count).
+  const selectedRecords = visibleRecords.filter((rec) => selected.has(rkeyFromUri(rec.uri)));
+
+  async function bulkSetHidden(hidden) {
+    if (!visModel) return;
+    const targets = selectedRecords.filter((rec) => visModel.isHidden(rec.value) !== hidden);
+    if (targets.length === 0) return;
+    setBusy(true);
+    setError(null);
+    const updated = new Map(); // rkey -> new value
+    try {
+      for (const rec of targets) {
+        const r = rkeyFromUri(rec.uri);
+        // JSON round-trip first so any BlobRef instances (e.g. a document's
+        // coverImage) collapse to their plain wire form before we re-put them.
+        const plain = JSON.parse(JSON.stringify(rec.value ?? {}));
+        const next = stampAutoTimestamps(lex, visModel.setHidden(plain, hidden));
+        // eslint-disable-next-line no-await-in-loop
+        await agent.com.atproto.repo.putRecord({ repo: did, collection, rkey: r, record: next });
+        updated.set(r, next);
+      }
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      if (updated.size) {
+        setRecords((prev) =>
+          prev.map((rec) => {
+            const r = rkeyFromUri(rec.uri);
+            return updated.has(r) ? { ...rec, value: updated.get(r) } : rec;
+          }),
+        );
+      }
+      setBusy(false);
+    }
+  }
+
+  async function bulkDelete() {
+    const rkeys = selectedRecords.map((rec) => rkeyFromUri(rec.uri));
+    if (rkeys.length === 0) return;
+    const noun = rkeys.length === 1 ? 'record' : 'records';
+    if (!window.confirm(`Delete ${rkeys.length} ${noun}? This cannot be undone.`)) return;
+    setBusy(true);
+    setError(null);
+    const deleted = new Set();
+    try {
+      for (const rkey of rkeys) {
+        // eslint-disable-next-line no-await-in-loop
+        await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey });
+        deleted.add(rkey);
+      }
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setRecords((prev) => prev.filter((rec) => !deleted.has(rkeyFromUri(rec.uri))));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const k of deleted) next.delete(k);
+        return next;
+      });
+      setBusy(false);
+    }
+  }
 
   return (
     <PageShell
@@ -439,6 +532,20 @@ function RecordList({
         {isHero && (
           <HeroSeedButton agent={agent} did={did} existingCount={records.length} onSeeded={reload} />
         )}
+        {visibleRecords.length > 0 && (
+          <button
+            type="button"
+            className="admin-link-subtle admin-select-toggle"
+            onClick={() =>
+              setSelectMode((on) => {
+                if (on) setSelected(new Set());
+                return !on;
+              })
+            }
+          >
+            {selectMode ? 'Done' : 'Select'}
+          </button>
+        )}
       </div>
 
       {pageSlug && <PageContentPanel agent={agent} did={did} slug={pageSlug} />}
@@ -449,6 +556,53 @@ function RecordList({
 
       {error && <p className="admin-error">{error}</p>}
 
+      {selectMode && (
+        <div className="admin-multiselect-toolbar">
+          <label className="admin-checkbox">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              disabled={visibleRecords.length === 0}
+            />
+            <span>{allSelected ? 'Deselect all' : 'Select all loaded'}</span>
+          </label>
+          <span className="admin-multiselect-count">
+            {selected.size > 0 ? `${selected.size} selected` : `${visibleRecords.length} loaded`}
+          </span>
+          <div className="admin-multiselect-actions">
+            {visModel && (
+              <>
+                <button
+                  type="button"
+                  className="admin-gate-button admin-gate-button-tight"
+                  onClick={() => bulkSetHidden(true)}
+                  disabled={busy || selected.size === 0}
+                >
+                  Hide
+                </button>
+                <button
+                  type="button"
+                  className="admin-gate-button admin-gate-button-tight"
+                  onClick={() => bulkSetHidden(false)}
+                  disabled={busy || selected.size === 0}
+                >
+                  Unhide
+                </button>
+              </>
+            )}
+            <button
+              type="button"
+              className="admin-gate-button admin-gate-button-tight admin-danger"
+              onClick={bulkDelete}
+              disabled={busy || selected.size === 0}
+            >
+              {busy ? 'Working…' : `Delete${selected.size ? ` (${selected.size})` : ''}`}
+            </button>
+          </div>
+        </div>
+      )}
+
       {loading && records.length === 0 ? (
         <AdminRecordListSkeleton rows={8} />
       ) : visibleRecords.length === 0 && !error ? (
@@ -457,14 +611,30 @@ function RecordList({
         <ul className="admin-record-list reveal-stagger">
           {visibleRecords.map((rec) => {
             const r = rkeyFromUri(rec.uri);
+            const hidden = visModel ? visModel.isHidden(rec.value) : false;
+            const chip = hidden ? visModel.chipLabel(rec.value) || 'hidden' : null;
+            const instant = recordInstant(rec.value);
+            if (selectMode) {
+              const checked = selected.has(r);
+              return (
+                <li
+                  key={rec.uri}
+                  className={`admin-record-row admin-multiselect-row${checked ? ' is-selected' : ''}`}
+                >
+                  <label className="admin-checkbox admin-multiselect-check">
+                    <input type="checkbox" checked={checked} onChange={() => toggle(r)} />
+                    <RecordRowBody rkey={r} preview={previewFor(rec.value, lex)} chip={chip} instant={instant} />
+                  </label>
+                </li>
+              );
+            }
             return (
               <li key={rec.uri} className="admin-record-row">
                 <Link
                   to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(r)}`}
                   className="admin-record-link"
                 >
-                  <code className="admin-record-rkey">{r}</code>
-                  <span className="admin-record-preview">{previewFor(rec.value, lex)}</span>
+                  <RecordRowBody rkey={r} preview={previewFor(rec.value, lex)} chip={chip} instant={instant} />
                 </Link>
               </li>
             );
@@ -484,6 +654,56 @@ function RecordList({
       )}
     </PageShell>
   );
+}
+
+/**
+ * Shared record-row content: rkey, preview text with an optional "hidden"
+ * status chip, and the record's timestamp on the far right. Rendered inside a
+ * link (browse mode) or a checkbox label (select mode).
+ */
+function RecordRowBody({ rkey, preview, chip, instant }) {
+  return (
+    <>
+      <code className="admin-record-rkey">{rkey}</code>
+      <span className="admin-record-main">
+        <span className="admin-record-preview">{preview}</span>
+        {chip && <span className="admin-record-chip small-caps">{chip}</span>}
+      </span>
+      {instant && (
+        <time className="admin-record-time small-caps" dateTime={instant} title={instant}>
+          {formatDateLong(instant)}
+        </time>
+      )}
+    </>
+  );
+}
+
+/**
+ * The record's own timestamp for display. Different lexicons name their primary
+ * instant differently — standard docs use `publishedAt`, is.dame.* records use
+ * `createdAt`, teal.fm plays use `playedTime` — so prefer a "published" instant,
+ * then creation, then last-update.
+ */
+function recordInstant(value) {
+  if (!value || typeof value !== 'object') return null;
+  return (
+    value.publishedAt || value.createdAt || value.playedTime || value.updatedAt || null
+  );
+}
+
+/**
+ * Stamp any `autoOnEdit` datetime fields (e.g. `updatedAt`) to now, mirroring
+ * what the full record editor does on save so a bulk visibility flip records
+ * the same freshness bump.
+ */
+function stampAutoTimestamps(lex, value) {
+  if (!lex?.fields) return value;
+  const next = { ...value };
+  const nowIso = new Date().toISOString();
+  for (const f of lex.fields) {
+    if (f.autoOnEdit && f.type === 'datetime') next[f.key] = nowIso;
+  }
+  return next;
 }
 
 function previewFor(value, lex) {

--- a/src/pages/CuratingChannel.jsx
+++ b/src/pages/CuratingChannel.jsx
@@ -5,7 +5,7 @@ import Lightbox from '../components/Lightbox.jsx';
 import { CreatingGridSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
-import { resolvePds, getRecord } from '../lib/atproto.js';
+import { resolvePds, getRecord, toAtUri } from '../lib/atproto.js';
 import { fetchChannelMeta, fetchAllBlocks, arenaText } from '../lib/arena.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Curating.css';
@@ -75,13 +75,21 @@ export default function CuratingChannel() {
         },
         truncated,
         blocks,
+        // Carry the record cid so the page can hint at its backing record; the
+        // at-uri itself is derived from the slug (the rkey is the slug).
+        recordCid: record?.cid || null,
       };
     },
     mapItems: (d) => {
       if (!d) return null;
       if (d.notFound) return d;
       if (!d.gallery) return null;
-      return { gallery: d.gallery, blocks: d.blocks || [], truncated: !!d.truncated };
+      return {
+        gallery: d.gallery,
+        blocks: d.blocks || [],
+        truncated: !!d.truncated,
+        recordCid: d.recordCid || null,
+      };
     },
     deps: [slug],
   });
@@ -113,7 +121,7 @@ export default function CuratingChannel() {
     );
   }
 
-  const { gallery, blocks, truncated } = items;
+  const { gallery, blocks, truncated, recordCid } = items;
   // Only image/link blocks are lightbox-navigable; text tiles are not.
   const visualBlocks = blocks.filter((b) => b.type !== 'text');
 
@@ -121,6 +129,11 @@ export default function CuratingChannel() {
     <PageShell
       title={arenaText(gallery.title) || undefined}
       intro={arenaText(gallery.description) || undefined}
+      // Register the backing arena-channel record so owner edit mode offers
+      // "Edit page" for this gallery. The rkey is the slug, so the at-uri is
+      // deterministic even before the live fetch resolves.
+      atUri={toAtUri({ did: ME_DID, collection: COLLECTIONS.arenaChannel, rkey: slug })}
+      cid={recordCid || undefined}
       headTitle={`${gallery.title} — dame.is`}
     >
       <div className="curating-channel-meta gutter">


### PR DESCRIPTION
Adds visibility affordances to the admin record list and fixes an edit-mode gap on individual curating pages.

## Admin record list (the generic `RecordList` used by Creating / Blogging / Logging / Posting / Curating / hero phrases / resume)

- **Hidden-state chip** next to a record's name when it's hidden from the public site. A new shared `src/lib/recordVisibility.js` maps each collection to how it expresses "hidden":
  - `site.standard.document` → `draft` → chip **draft**
  - `is.dame.arena.channel` → `enabled: false` → chip **hidden**
  - `is.dame.hero.phrase` → `enabled: false` → chip **disabled**
  - `is.dame.resume` → `visibility` ≠ public → chip **unlisted** / **private**
  - Collections with no visibility concept get no chip.
- **Bulk multi-select editing.** A "Select" toggle turns each row into a checkbox and reveals a bulk **Hide / Unhide / Delete** bar (with select-all). Hiding flips the collection's own visibility flag and re-puts each record; Delete works on any collection.
- **Timestamps** — each row shows its published/created date on the far right, full ISO on hover.

## Curating edit mode

An individual `/curating/<slug>` gallery page never registered its backing record, so owner edit mode offered no way to edit the arena-channel record. It now passes the channel's at-uri (derived from the slug, which is the rkey) to `PageShell`, so **Edit page** appears and opens the record in the quick-edit sheet — the same flow blog posts and creative works already use.

For resumes, bulk **Hide** sets `private` / **Unhide** sets `public`; the three-state "unlisted" middle ground stays reachable through the full record editor.

## Verification

- `npm run build:offline` compiles cleanly.
- 30 unit assertions on the visibility model (isHidden / chipLabel / setHidden across all four collections + the no-model cases) pass.
- Rendered the list at desktop + mobile widths against the real `Admin.css`; confirmed the existing Listening-manager rows still truncate with "Edit →" pinned right (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MnG5PFf2YfYiQRDVQekD7

---
_Generated by [Claude Code](https://claude.ai/code/session_019MnG5PFf2YfYiQRDVQekD7)_