### PR TITLE
Show feed images at their true aspect ratio, no letterbox

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1888,8 +1888,10 @@ a.ledger-time:focus-visible {
   max-width: 20rem;
 }
 
-.ledger-embed .post-embed-images[data-count='1'] .post-embed-image img {
-  max-height: 10rem;
+/* A lone image sizes its frame from --embed-image-max-h (see PostEmbed.css);
+   in the condensed ledger that cap drops from a full 520px to a thumbnail. */
+.ledger-embed .post-embed-images[data-count='1'] {
+  --embed-image-max-h: 10rem;
 }
 
 /* Multi-image grids get uniform landscape crops so two rows of images

--- a/src/components/PostEmbed.css
+++ b/src/components/PostEmbed.css
@@ -26,12 +26,15 @@
 }
 
 /* Embed wrapper — keep all embed types on a consistent rhythm regardless
-   of which type rendered. */
+   of which type rendered. The top margin also sets the breathing room
+   between stacked embeds (e.g. a quote sitting below an image, as in a
+   record-with-media post), so it's a touch more generous than the card's
+   own inter-row gap. */
 .post-embed-images,
 .post-embed-video,
 .post-embed-link-card,
 .post-embed-quote {
-  margin-top: var(--space-3);
+  margin-top: var(--space-4);
   max-width: var(--measure);
 }
 
@@ -89,11 +92,44 @@
   object-fit: cover;
 }
 
-.post-embed-images[data-count='1'] .post-embed-image img {
-  object-fit: contain;
-  max-height: 520px;
-  height: auto;
+/* A lone image is shown at its true aspect ratio, never letterboxed against
+   a background. PostEmbed.jsx sets --img-ar (width / height) on the frame, so
+   the frame itself carries the picture's ratio: it reserves the correct box
+   before the file loads (no shift) and keeps a tall image in check by capping
+   its *width* — the image scales down whole, staying true to ratio, instead
+   of shrinking inside a fixed-height frame and leaving bars down either side.
+   `cover` on a frame that already matches the picture never crops. */
+.post-embed-images[data-count='1'] {
+  --embed-image-max-h: 520px;
+}
+
+.post-embed-images[data-count='1'] .post-embed-image[data-sized='true'] {
   width: 100%;
+  aspect-ratio: var(--img-ar);
+  max-width: calc(var(--embed-image-max-h) * var(--img-ar));
+}
+
+.post-embed-images[data-count='1'] .post-embed-image[data-sized='true'] img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Fallback for the rare image whose record carries no aspectRatio: the frame
+   shrink-wraps the picture (so no background can show) and the height cap just
+   makes a tall one narrower. No pre-load reservation is possible without a
+   known ratio, but there's still no letterbox. */
+.post-embed-images[data-count='1'] .post-embed-image:not([data-sized='true']) {
+  width: fit-content;
+  max-width: 100%;
+}
+
+.post-embed-images[data-count='1'] .post-embed-image:not([data-sized='true']) img {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: var(--embed-image-max-h);
+  object-fit: contain;
 }
 
 /* Video. Same border treatment as images so the row reads cohesively. */

--- a/src/components/PostEmbed.jsx
+++ b/src/components/PostEmbed.jsx
@@ -154,33 +154,46 @@ function ImageGrid({ images }) {
     width: im.aspectRatio?.width || undefined,
     height: im.aspectRatio?.height || undefined,
   }));
+  const single = list.length === 1;
   return (
     <>
       <div
         className="post-embed-images"
         data-count={list.length}
       >
-        {list.map((im, i) => (
-          <button
-            key={i}
-            type="button"
-            className="post-embed-image"
-            onClick={() => setLightbox({ open: true, index: i })}
-            aria-label={im.alt ? `Open image: ${im.alt}` : 'Open image'}
-          >
-            <img
-              src={im.thumb || im.fullsize}
-              alt={im.alt || ''}
-              loading="lazy"
-              decoding="async"
-              style={
-                im.aspectRatio
-                  ? { aspectRatio: `${im.aspectRatio.width} / ${im.aspectRatio.height}` }
-                  : undefined
-              }
-            />
-          </button>
-        ))}
+        {list.map((im, i) => {
+          const ar = im.aspectRatio;
+          const hasAr = ar?.width > 0 && ar?.height > 0;
+          // For a lone image, hand its own aspect ratio to the frame (see
+          // PostEmbed.css). The frame then reserves the right box before the
+          // file loads and caps a tall image by its *width* — so it scales
+          // down whole, true to ratio, rather than letterboxing against a
+          // background inside a fixed-height frame.
+          const framed = single && hasAr;
+          return (
+            <button
+              key={i}
+              type="button"
+              className="post-embed-image"
+              data-sized={framed ? 'true' : undefined}
+              style={framed ? { '--img-ar': ar.width / ar.height } : undefined}
+              onClick={() => setLightbox({ open: true, index: i })}
+              aria-label={im.alt ? `Open image: ${im.alt}` : 'Open image'}
+            >
+              <img
+                src={im.thumb || im.fullsize}
+                alt={im.alt || ''}
+                loading="lazy"
+                decoding="async"
+                style={
+                  hasAr
+                    ? { aspectRatio: `${ar.width} / ${ar.height}` }
+                    : undefined
+                }
+              />
+            </button>
+          );
+        })}
       </div>
       <Lightbox
         open={lightbox.open}


### PR DESCRIPTION
## What

A lone image in a post embed was wrapped in a fixed-height frame (`max-height: 520px`) using `object-fit: contain` over a `--page-edge` background. Any image taller than the frame was painted narrower than its box, so the page-edge colour showed as bars down either side — the "weird additional background," most visible on portrait images and in the sky theme.

This sizes the frame from the picture's own aspect ratio instead, and adds a little more breathing room between stacked embeds.

## Changes

- **`PostEmbed.jsx`** — a lone image with known `aspectRatio` gets `--img-ar` (width / height) and `data-sized` on its frame button.
- **`PostEmbed.css`** — the frame now carries the picture's ratio, so it reserves the correct box before load (no layout shift) and caps a tall image by its *width* (`max-width: calc(var(--embed-image-max-h) * var(--img-ar))`). The image scales down whole, true to ratio, instead of letterboxing. `object-fit: cover` on a matching frame never crops. Images without `aspectRatio` metadata fall back to a shrink-wrapped frame, so they don't letterbox either. Bumped the embed top-margin `space-3 → space-4` so a quote below an image (record-with-media) gets clearer separation.
- **`Feed.css`** — the single-image height cap now flows through `--embed-image-max-h`, which the ledger view overrides (520px → 10rem) in place of the old `img` max-height.

## Verification

Rendered the real edited CSS in a browser across every case — portrait, landscape, near-square, extreme 9:16, the no-metadata fallback, multi-image grids (2/3/4, untouched), and the ledger view. Confirmed the frame hugs the image with no background bars, the height cap keeps tall images from dominating, and space is reserved before load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tHktVA2C4sMq8tjsLr7pn

---
_Generated by [Claude Code](https://claude.ai/code/session_016tHktVA2C4sMq8tjsLr7pn)_