### PR TITLE
Make serif-only the default font mode; hide the font switcher

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -9,7 +9,7 @@ import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
-import { useFont } from '../hooks/useFont.jsx';
+import { useFont, FONT_SWITCHER_ENABLED } from '../hooks/useFont.jsx';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
 import { ME_DID } from '../config.js';
@@ -516,19 +516,22 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 >
                   {skyHourKey}
                 </button>
-                {/* Font switcher. Toggles serif-only mode, which folds the
-                    monospace ledger/metadata accent into the serif voice
-                    (code stays monospace). Default is the mixed voice. */}
-                <button
-                  type="button"
-                  className={`chrome-nav chrome-font-toggle ${serifOnly ? 'is-open' : ''}`}
-                  onClick={toggleFont}
-                  aria-pressed={serifOnly}
-                  aria-label={serifOnly ? 'Use the default serif + monospace type' : 'Use serif-only type'}
-                  title={serifOnly ? 'Serif-only type — tap to restore mono accents' : 'Mono accents — tap for serif-only type'}
-                >
-                  <Type className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-                </button>
+                {/* Font switcher. Hidden for now — the site runs serif-only
+                    (see FONT_SWITCHER_ENABLED in useFont.jsx). Flip that flag
+                    back on to restore this toggle between serif-only and the
+                    mono-accented mix. */}
+                {FONT_SWITCHER_ENABLED && (
+                  <button
+                    type="button"
+                    className={`chrome-nav chrome-font-toggle ${serifOnly ? 'is-open' : ''}`}
+                    onClick={toggleFont}
+                    aria-pressed={serifOnly}
+                    aria-label={serifOnly ? 'Use the default serif + monospace type' : 'Use serif-only type'}
+                    title={serifOnly ? 'Serif-only type — tap to restore mono accents' : 'Mono accents — tap for serif-only type'}
+                  >
+                    <Type className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                  </button>
+                )}
                 {filterAvailable && (
                   <button
                     type="button"

--- a/src/hooks/useFont.jsx
+++ b/src/hooks/useFont.jsx
@@ -3,18 +3,27 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 const FontContext = createContext(null);
 const STORAGE_KEY = 'dame.font';
 
+// Feature flag. The font switcher is hidden for now and the site runs
+// serif-only. Flip this to `true` to bring the toggle back (see
+// ChromeBar): the stored preference is honoured again (it's never
+// overwritten while disabled, so a returning visitor keeps their old
+// choice) and the bottom-chrome button reappears. Serif is the default
+// either way. Keep in sync with main.jsx.
+export const FONT_SWITCHER_ENABLED = false;
+
 // Two font modes:
-//   - mixed : the default. Serif body (Crimson Pro) with a monospace
-//             technical accent (--mono) on gutters, ledger columns, and
-//             metadata — the tabular, ledger-like voice.
-//   - serif : folds that monospace accent into the serif voice so the
-//             whole reading surface is one typeface. Code and raw data
-//             (--code) stay monospace either way — see theme.css.
+//   - mixed : serif body (Crimson Pro) with a monospace technical accent
+//             (--mono) on gutters, ledger columns, and metadata — the
+//             tabular, ledger-like voice.
+//   - serif : the default. Folds that monospace accent into the serif
+//             voice so the whole reading surface is one typeface (and
+//             scales those elements up a touch — see --mono-scale). Code
+//             and raw data (--code) stay monospace either way.
 // The CSS lives in theme.css under [data-font='serif']; this hook just
 // owns the preference and paints data-font onto <html>. Keep VALID +
 // DEFAULT in sync with the pre-paint block in main.jsx.
 const VALID = ['mixed', 'serif'];
-const DEFAULT = 'mixed';
+const DEFAULT = 'serif';
 
 function applyFont(font) {
   document.documentElement.setAttribute('data-font', font);
@@ -27,9 +36,15 @@ function readInitial() {
 }
 
 export function FontProvider({ children }) {
-  const [font, setFontState] = useState(readInitial);
+  const [font, setFontState] = useState(() => (FONT_SWITCHER_ENABLED ? readInitial() : 'serif'));
 
   useEffect(() => {
+    // While the switcher is disabled, always render serif-only and leave
+    // the stored preference untouched so it comes back if it's re-enabled.
+    if (!FONT_SWITCHER_ENABLED) {
+      applyFont('serif');
+      return;
+    }
     applyFont(font);
     try {
       localStorage.setItem(STORAGE_KEY, font);
@@ -45,9 +60,16 @@ export function FontProvider({ children }) {
     setFontState((prev) => (prev === 'serif' ? 'mixed' : 'serif'));
   }, []);
 
+  const effectiveFont = FONT_SWITCHER_ENABLED ? font : 'serif';
   const value = useMemo(
-    () => ({ font, setFont, toggle, serifOnly: font === 'serif', options: VALID }),
-    [font, setFont, toggle],
+    () => ({
+      font: effectiveFont,
+      setFont,
+      toggle,
+      serifOnly: effectiveFont === 'serif',
+      options: VALID,
+    }),
+    [effectiveFont, setFont, toggle],
   );
   return <FontContext.Provider value={value}>{children}</FontContext.Provider>;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import { PAPER_ENABLED } from './hooks/usePaper.jsx';
+import { FONT_SWITCHER_ENABLED } from './hooks/useFont.jsx';
 import { applySkyTheme, easternHour } from './lib/skyTheme.js';
 import './styles/reset.css';
 import './styles/theme.css';
@@ -39,15 +40,16 @@ document.documentElement.setAttribute(
   PAPER_ENABLED && VALID_PAPER.includes(storedPaper) ? storedPaper : 'blank',
 );
 
-// Font mode (serif-only vs the default mono-accented mix). Set before the
-// first paint so a serif-only visitor doesn't flash the monospace ledger
-// columns before they fold into the serif voice. Keep in sync with
-// useFont.jsx.
+// Font mode. The switcher is hidden and the site runs serif-only, so this
+// resolves to 'serif' regardless of any stored preference. Set before the
+// first paint so the ledger columns render in the serif voice from the
+// start. When FONT_SWITCHER_ENABLED is flipped back on in useFont.jsx the
+// stored preference is honoured again (default serif). Keep in sync.
 const VALID_FONTS = ['mixed', 'serif'];
 const storedFont = typeof localStorage !== 'undefined' ? localStorage.getItem('dame.font') : null;
 document.documentElement.setAttribute(
   'data-font',
-  VALID_FONTS.includes(storedFont) ? storedFont : 'mixed',
+  FONT_SWITCHER_ENABLED && VALID_FONTS.includes(storedFont) ? storedFont : 'serif',
 );
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
The site now runs serif-only for everyone, and the bottom-chrome font switcher is hidden. This mirrors the paper feature's pause pattern (`PAPER_ENABLED`) so it's one flag to reverse.

## Changes

- **`src/hooks/useFont.jsx`** — Add `FONT_SWITCHER_ENABLED` (false), change the default to `serif`, and while disabled force the serif voice and skip persistence — the stored preference is left untouched so it returns intact if the flag is flipped back on. A returning visitor who had picked the mono-accented mix now gets serif too.
- **`src/components/ChromeBar.jsx`** — Gate the font-toggle button behind `FONT_SWITCHER_ENABLED` so it no longer renders.
- **`src/main.jsx`** — Pre-paint `data-font="serif"` while the switcher is disabled, regardless of any stored value.

The serif-only CSS (`[data-font='serif']` overrides, `--mono-scale` compensation, `--code` staying monospace) is untouched — it's just always on now. Flip `FONT_SWITCHER_ENABLED` to `true` to bring the switcher back with serif as the default.

Verified in Chromium: a fresh visitor gets `data-font=serif`, no toggle button, gutter text serif and scaled to 13.2px; a returning visitor who had explicitly chosen `mixed` is forced to serif with their stored pref left intact; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dEYLWy1pckfXQb6dfaPQ9)_