### PR TITLE
Auto-reveal the home feed on scroll instead of a "Load more" button

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -830,9 +830,20 @@ a.post-card-author-link:focus-visible {
   }
 }
 
-/* "Load more" CTA at the foot of the home feed. Pagination is purely
-   client-side — the next batch is already in memory, so the button only
-   reveals it, no spinner needed. */
+/* Foot of the home feed. Pagination is purely client-side — the next batch
+   is already in memory. By default an invisible sentinel auto-reveals it as
+   the reader nears the bottom; the "Load more" button is the fallback when
+   IntersectionObserver isn't available, so no spinner is needed either way. */
+
+/* The sentinel carries no visual weight of its own; a hair of height keeps
+   it a real box the observer can track, and the top margin gives the reveal
+   a little runway below the last row. */
+.feed-load-sentinel {
+  height: 1px;
+  margin-top: var(--space-5);
+  pointer-events: none;
+}
+
 .feed-load-more {
   display: flex;
   justify-content: center;

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Auto-reveal-on-scroll. Watches a sentinel element and calls `onReach`
+ * whenever it scrolls within `rootMargin` of the viewport, as long as
+ * `enabled` is true. Returns a ref to attach to the sentinel.
+ *
+ * The home feed uses this to grow its client-side visible window as the
+ * reader nears the bottom, in place of the old "Load more" button. That
+ * pagination is purely client-side — the next batch is already in memory —
+ * so each reveal is instant: no spinner, no fetch. `rootMargin` fires the
+ * callback a screenful early so the next window is in place before the
+ * reader actually reaches the end.
+ *
+ * `onReach` is read through a ref so a fresh closure each render doesn't
+ * tear down and rebuild the observer; only `enabled`/`rootMargin` do.
+ * Callers should bump the window by a step comfortably taller than a
+ * viewport (the feed adds ~100 items), so one reveal pushes the sentinel
+ * back out of range — the observer then re-fires only on the next scroll,
+ * never in a runaway loop.
+ */
+export function useInfiniteScroll(
+  onReach,
+  { enabled = true, rootMargin = '600px 0px' } = {},
+) {
+  const sentinelRef = useRef(null);
+  const onReachRef = useRef(onReach);
+  onReachRef.current = onReach;
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !enabled) return undefined;
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            onReachRef.current?.();
+            break;
+          }
+        }
+      },
+      { rootMargin },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [enabled, rootMargin]);
+
+  return sentinelRef;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -30,6 +30,7 @@ import { subscribeRefreshTick } from '../lib/refreshTick.js';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll.js';
 import { ME_DID } from '../config.js';
 import '../components/Feed.css';
 
@@ -38,10 +39,12 @@ const CACHE_TTL_MS = 30_000;
 // First-paint cap per collection — matches AT Proto's per-request
 // listRecords ceiling, so each collection lands in a single round trip
 // with no extra pagination. Background polls keep the same cap; deeper
-// history isn't fetched, only `Load more` reveals what's already there.
+// history isn't fetched — scrolling only reveals what's already in memory.
 const INITIAL_FETCH_MAX = 100;
-// How many items the feed renders before showing the "Load more" CTA,
-// and how many additional items each click reveals.
+// How many items the feed renders on first paint, and how many more each
+// auto-reveal adds as the reader nears the bottom. The step is kept well
+// taller than a viewport so one reveal pushes the scroll sentinel back out
+// of range — it re-fires on the next scroll, never in a runaway loop.
 const INITIAL_VISIBLE = 100;
 const LOAD_MORE_STEP = 100;
 // Snapshot is now a fallback only (shown when the live fetch errors).
@@ -189,15 +192,20 @@ export default function Home() {
   const reduce = useReducedMotion();
 
   // How many items the feed is currently rendering. Starts at
-  // INITIAL_VISIBLE and grows by LOAD_MORE_STEP each click of the
-  // "Load more" CTA at the bottom of the feed. Resets when the active
-  // filter set changes so the user always starts from the top of the
-  // new view.
+  // INITIAL_VISIBLE and grows by LOAD_MORE_STEP as the reader nears the
+  // bottom (an IntersectionObserver sentinel auto-reveals the next window;
+  // see below). Resets when the active filter set changes so the user
+  // always starts from the top of the new view.
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
   const filterSig = params.toString();
   useEffect(() => {
     setVisibleCount(INITIAL_VISIBLE);
   }, [filterSig]);
+
+  // Whether the browser can auto-reveal on scroll. When IntersectionObserver
+  // is unavailable we fall back to rendering the manual "Load more" button so
+  // those readers can still page through the feed.
+  const [ioSupported] = useState(() => typeof IntersectionObserver !== 'undefined');
 
   // URIs we've already shown the user. Anything missing on a refresh is
   // a "new arrival" and gets the slide-in animation. Seeded from cache
@@ -451,12 +459,22 @@ export default function Home() {
     if (!removedUris || removedUris.size === 0) return base;
     return base.filter((item) => !removedUris.has(item.atUri));
   }, [safeFeed, params, removedUris]);
-  // "Load more" pagination — the user only sees the first `visibleCount`
+  // Client-side pagination — the user only sees the first `visibleCount`
   // filtered items at a time. Slicing here (before threading / day
   // grouping) means thread chains never get split mid-conversation: each
   // visible window is a clean prefix of the filtered timeline.
   const visible = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
   const hasMore = filtered.length > visible.length;
+
+  // Grow the visible window as the reader nears the bottom. The extra items
+  // are already in memory, so this is an instant reveal rather than a fetch;
+  // the bottom sentinel drives it via IntersectionObserver, with the manual
+  // button kept only as a no-observer fallback (see the feed foot below).
+  const loadMore = useCallback(
+    () => setVisibleCount((n) => n + LOAD_MORE_STEP),
+    [],
+  );
+  const sentinelRef = useInfiniteScroll(loadMore, { enabled: hasMore });
 
   // Photographed iNaturalist observations (mothing + observing) currently in
   // view, shaped for the in-feed image lightbox. Tapping an observation row
@@ -620,15 +638,21 @@ export default function Home() {
           )}
         </div>
         {!loading && hasMore && (
-          <div className="feed-load-more">
-            <button
-              type="button"
-              className="feed-load-more-btn"
-              onClick={() => setVisibleCount((n) => n + LOAD_MORE_STEP)}
-            >
-              Load more
-            </button>
-          </div>
+          ioSupported ? (
+            // Invisible tripwire: as it scrolls into range the visible window
+            // grows (client-side, instant — the next batch is already loaded).
+            <div ref={sentinelRef} className="feed-load-sentinel" aria-hidden="true" />
+          ) : (
+            <div className="feed-load-more">
+              <button
+                type="button"
+                className="feed-load-more-btn"
+                onClick={loadMore}
+              >
+                Load more
+              </button>
+            </div>
+          )
         )}
       </section>
 


### PR DESCRIPTION
The home feed's pagination is purely client-side — the next batch is already in memory — so the "Load more" button only revealed it. This swaps that click for an `IntersectionObserver` sentinel that grows the visible window as the reader nears the bottom, for a seamless infinite scroll.

## Changes
- **`src/hooks/useInfiniteScroll.js`** (new) — a small hook that watches a sentinel element and fires a callback when it scrolls within ~600px of the viewport, so the next window is in place before the reader reaches the end.
- **`src/pages/Home.jsx`** — replaced the button with an invisible sentinel that grows the visible window (`+INITIAL_VISIBLE` per reveal). The step is kept well taller than a viewport, so one reveal pushes the sentinel back out of range and it re-fires only on the next scroll — never in a runaway loop. The manual "Load more" button is retained as a fallback for browsers without `IntersectionObserver`.
- **`src/components/Feed.css`** — styles for the 1px sentinel.

Because pagination was already client-side (capped per collection, already in memory), each reveal is instant — no new network fetch, no spinner. It stays bounded: once everything is shown the sentinel retires and the footer is reachable.

## Verification
Drove the real `Home` component in Chromium (Playwright) with 250 items:

| | initial | scroll 1 | scroll 2 | end |
|---|---|---|---|---|
| **Auto-load (IntersectionObserver)** | 100 items, sentinel present, no button | 200 | 250 | sentinel retired |
| **Fallback (no IntersectionObserver)** | 100 items, button present | scroll alone → still 100 | click → 200 | — |

No page errors in either scenario; the 100→200→250 stepping confirms one reveal per scroll. Offline production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rKjg3F8bd12Fmos9VzFgi

---
_Generated by [Claude Code](https://claude.ai/code/session_019rKjg3F8bd12Fmos9VzFgi)_