### PR TITLE
Make chrome full-bleed on wide screens; widen flat-ledger column gap

### DIFF
--- a/src/components/ActionDock.css
+++ b/src/components/ActionDock.css
@@ -13,7 +13,7 @@
 }
 
 /* .dock-sheet-wrap: the animated clip box, pinned directly on top of
-   the bottom bar and centered on the same 65rem card. Framer animates
+   the bottom bar and spanning the same full-bleed width. Framer animates
    its height 0 ↔ auto; overflow:hidden means the panel inside unfurls
    upward out of the bar. Sits above the bars (z 31) so its top edge
    and shadow overlap the page cleanly. */
@@ -26,8 +26,6 @@
   left: 0;
   right: 0;
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   z-index: 31;
   overflow: hidden;
   /* Bottom-anchor the panel inside the height-animating clip: the panel is
@@ -80,15 +78,6 @@
   align-content: end;
   overflow-y: auto;
   overscroll-behavior: contain;
-}
-
-/* On wide screens the chrome bars float as a 65rem card with side
-   hairlines; the sheet closes its box to match. */
-@media (min-width: 65rem) {
-  .dock-panel {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 .dock-section {

--- a/src/components/BottomSheet.css
+++ b/src/components/BottomSheet.css
@@ -15,7 +15,7 @@
 
 /* The animated clip box, pinned directly on top of the bottom bar — and
    above the owner edit action bar when it's open (--edit-bar-h, else 0) —
-   centered on the same 65rem card. Framer animates its height 0 ↔ auto;
+   spanning the same full-bleed width. Framer animates its height 0 ↔ auto;
    overflow:hidden means the panel inside unfurls upward out of the bar.
    Sits above the bars (z 31) so its top edge overlaps the page cleanly. */
 .bottom-sheet-wrap {
@@ -24,8 +24,6 @@
   left: 0;
   right: 0;
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   z-index: 31;
   overflow: hidden;
   /* Bottom-anchor the panel inside the height-animating clip so its
@@ -76,11 +74,3 @@
   overscroll-behavior: contain;
 }
 
-/* On wide screens the chrome bars float as a 65rem card with side hairlines;
-   the panel closes its box to match. */
-@media (min-width: 65rem) {
-  .bottom-sheet-panel {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
-}

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -1,34 +1,33 @@
-/* Horizontal inset shared by every chrome surface — the top/bottom bars,
-   the atmosphere & breadcrumb rows, and the nav dock sheet — so their
-   content columns line up with each other AND with the page body (`.main`)
-   and its nav menu items. The bars/sheet cap at 65rem while `.main` caps at
-   72rem, so each side of the bar sits 3.5rem inside the main column;
-   subtracting 3.5rem from `.main`'s own `6vw` padding lands chrome content
-   on the same column (`6vw - 3.5rem`, clamped with a small floor + 2.5rem
-   cap for the narrow + max-width extremes). Below the 65rem cap the bars are
-   full-bleed exactly like `.main`, so the inset tracks `.main`'s padding
-   directly at each of its breakpoints. Kept on :root — not the chrome
-   scope — because the dock sheet is portalled to <body>, outside .chrome-bar. */
-:root {
-  --chrome-pad-x: clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
-}
+/* Horizontal inset shared by every chrome surface — the top/bottom bars, the
+   atmosphere & breadcrumb rows, the nav dock sheet, and the bottom sheets — so
+   their content columns line up with each other AND with the page body
+   (`.main`) and its nav menu items.
 
-@media (max-width: 65rem) {
-  :root {
-    --chrome-pad-x: clamp(var(--space-5), 6vw, var(--space-9));
-  }
+   Every chrome surface spans the FULL viewport width (its background + top/
+   bottom hairlines run edge to edge at every breakpoint); this inset is what
+   keeps their CONTENT on `.main`'s centered 72rem column. It's `.main`'s own
+   horizontal padding (--chrome-pad-base), plus — once the viewport passes
+   72rem — half the overflow, which recentres the content box exactly like
+   `.main`'s `margin: 0 auto`. Below 72rem that second term clamps to 0, so
+   content is full-bleed with the same padding as the page body. Consumers
+   apply it as horizontal padding on a full-width surface, so the `100%`
+   resolves against the viewport. Kept on :root — not the chrome scope —
+   because the dock sheet is portalled to <body>, outside .chrome-bar. */
+:root {
+  --chrome-pad-base: clamp(var(--space-5), 6vw, var(--space-9));
+  --chrome-pad-x: calc(var(--chrome-pad-base) + max(0px, (100% - 72rem) / 2));
 }
 
 @media (max-width: 700px) {
   :root {
-    --chrome-pad-x: var(--space-4);
+    --chrome-pad-base: var(--space-4);
   }
 }
 
 .chrome-bar {
-  /* Background lives on the inner top/bottom containers below, not
-     here — the wide-screen treatment caps them at 72rem so the page
-     background shows through on either side. */
+  /* Background lives on the inner top/bottom containers below
+     (`.chrome-bar-top` / `.chrome-bar-bottom`), which span the full
+     viewport width edge to edge. */
   font-style: normal;
 }
 
@@ -52,12 +51,10 @@
      instead of being clipped. The secondary/atmosphere wrap still clips
      its own height animation via its inline `overflow: hidden`. */
   overflow: visible;
+  /* Full-bleed: the bar's surface + top/bottom hairlines span the whole
+     viewport at every width. Its content is held on `.main`'s centered
+     72rem column by the shared `--chrome-pad-x` inset on `.chrome-bar-row`. */
   width: 100%;
-  /* Chrome bar caps at 65rem — narrower than the page's 72rem main
-     column, so on wide screens the bar sits as a tighter strip
-     visually distinct from the content beneath it. */
-  max-width: 65rem;
-  margin: 0 auto;
 }
 
 .chrome-bar-row {
@@ -65,10 +62,9 @@
   align-items: center;
   gap: var(--space-3);
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
-  /* Shared inset that keeps chrome content on the same column as `.main`
-     and the nav dock — see `--chrome-pad-x` at the top of this file. */
+  /* Shared inset that keeps chrome content on the same centered column as
+     `.main` and the nav dock while the bar itself is full-bleed — see
+     `--chrome-pad-x` at the top of this file. */
   padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
 }
@@ -139,9 +135,6 @@
   /* Promote to its own compositor layer so the slide is a pure transform —
      no layout, no repaint of the page, nothing that can stall scrolling. */
   will-change: transform;
-  /* Side hairlines (≥65rem) come from the shared `.chrome-bar-row` rule near
-     the bottom of this file, so they land at the exact same x as the header's
-     own side hairlines rather than inset by the bar's border. */
 }
 
 .chrome-breadcrumb {
@@ -537,26 +530,7 @@
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-
-/* On wide screens the chrome bars float as a 65rem-wide card with the page
-   background showing on either side; left/right hairlines close the box
-   visually. They live on the INNER rows (`.chrome-bar-row` for the top,
-   `.chrome-bottom-row` for the bottom) — not the outer bar — so they sit at
-   the true 65rem edge and line up with the scroll-revealed strips
-   (`.chrome-bar-tertiary` breadcrumb, `.chrome-bar-footer`), which carry
-   their own side hairlines one layer in. Putting them on the outer bar would
-   inset those strips' borders by the bar's own 1px border and leave a
-   hairline jog. The bars still own the top/bottom hairlines. */
-@media (min-width: 65rem) {
-  .chrome-bar-row,
-  .chrome-bottom-row {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 /* Footer strip: the bottom-bar mirror of the top bar's tertiary breadcrumb.
@@ -565,7 +539,7 @@
    beneath never shifts mid-scroll. The strip slides up from behind the bar
    inside this fixed clip; the wrap is transparent, so while the strip is
    tucked away the page content shows through. Anchored to the bar, it
-   inherits the bar's 65rem card + stacking context automatically. */
+   inherits the bar's full-bleed width + stacking context automatically. */
 .chrome-bar-footer-wrap {
   position: absolute;
   bottom: 100%;
@@ -597,20 +571,11 @@
   will-change: transform;
 }
 
-@media (min-width: 65rem) {
-  .chrome-bar-footer {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
-}
-
 .chrome-bottom-row {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
 }

--- a/src/components/EditModeBar.css
+++ b/src/components/EditModeBar.css
@@ -1,6 +1,6 @@
 /* Owner edit-mode action bar. Like the nav dock, it's a sheet that expands
    UPWARD out of the bottom chrome bar: the wrap is a fixed clip box pinned
-   directly on top of the bar and centered on the same 65rem card; Framer
+   directly on top of the bar and spanning the same full-bleed width; Framer
    animates its height 0 ↔ auto and `overflow: hidden` unfurls the surface
    inside upward so it reads as an extension of the bar rather than a floating
    panel. */
@@ -13,8 +13,6 @@
      sheet's reserved bottom strip so their seam never opens a gap. */
   z-index: 33;
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   overflow: hidden;
   /* Bottom-anchor the strip inside the height-animating clip so its top
      hairline holds steady during the reveal instead of being clipped away
@@ -44,15 +42,6 @@
   background: var(--surface-raised);
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
-}
-
-/* On wide screens the chrome bars float as a 65rem card with side hairlines;
-   close the strip's box to match. */
-@media (min-width: 65rem) {
-  .edit-mode-bar-inner {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 .edit-mode-bar-status {

--- a/src/components/EditSheet.css
+++ b/src/components/EditSheet.css
@@ -22,8 +22,6 @@
   left: 0;
   right: 0;
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   z-index: 32;
   overflow: hidden;
   /* Bottom-anchor the panel inside the height-animating clip so its bottom
@@ -54,13 +52,6 @@
   );
   padding-bottom: var(--edit-bar-h, 0px);
   overflow: hidden;
-}
-
-@media (min-width: 65rem) {
-  .edit-sheet-panel {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 /* Fixed header + footer with a scrolling body between them (flex column in a

--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1806,6 +1806,10 @@ a.ledger-verb:focus-visible {
    time sits flush right. */
 .feed-ledger-flat {
   gap: 0;
+  /* Roomier column gap between the title and its trailing time/count than the
+     dense day-grouped ledger uses — these single-type pages (creating,
+     blogging, …) have fewer columns and can afford the extra breathing room. */
+  --ledger-col-gap: var(--space-4);
 }
 
 .feed-ledger-flat .feed-item-ledger {

--- a/src/components/FeedFilters.css
+++ b/src/components/FeedFilters.css
@@ -105,7 +105,7 @@
 /* Interior of the filter bottom sheet. BottomSheet owns positioning, the
    surface, and the expand animation; only the interior layout (padding,
    internal spacing, header/grid) lives here. Full-width — it fills the
-   65rem chrome card rather than sitting as a narrow centered modal. */
+   full-bleed chrome rather than sitting as a narrow centered modal. */
 .feed-filter-sheet-panel {
   width: 100%;
   /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x)

--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -76,7 +76,7 @@
 }
 
 /* Control bar — sits exactly where the bottom chrome nav is (fixed to
-   the viewport bottom, same 65rem card, same raised surface + height)
+   the viewport bottom, same full-bleed width, same raised surface + height)
    so the nav appears to morph into the photo controls. Above the Modal
    scrim (z 60). Holds the source / reverse-search links (left), and the
    prev/counter/next + close cluster (right). */
@@ -87,19 +87,10 @@
   right: 0;
   z-index: 70;
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
   background: var(--surface-raised);
   border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
   padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-
-@media (min-width: 65rem) {
-  .lightbox-controls {
-    border-left: 1px solid var(--rule);
-    border-right: 1px solid var(--rule);
-  }
 }
 
 .lightbox-controls-row {
@@ -107,9 +98,9 @@
   align-items: center;
   gap: var(--space-3);
   width: 100%;
-  max-width: 65rem;
-  margin: 0 auto;
-  padding: 0 clamp(var(--space-3), calc(6vw - 3.5rem), 2.5rem);
+  /* Shared chrome inset (see --chrome-pad-x) so the controls land on the same
+     centered column as the bottom-bar buttons the bar morphs out of. */
+  padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
 }
 


### PR DESCRIPTION
## Full-bleed chrome on wide screens

The top/bottom chrome bars — and every surface that expands from them (nav dock, search/filter/info sheets, the owner edit bar + edit sheet, and the lightbox controls that morph out of the bottom nav) — previously capped at `65rem` and floated as a centered card above ~1040px, visually distinct from the `72rem` page body beneath. This extends the full-bleed treatment used below that breakpoint to **every** width: the surfaces now span the viewport edge to edge at all sizes, with only top/bottom hairlines.

Content still lands on `.main`'s centered 72rem column via the shared `--chrome-pad-x` inset, redefined as *`.main`'s own padding + half the overflow past 72rem* — so a full-width surface re-centers its content exactly like `.main`'s `margin: 0 auto`, and below 72rem it collapses to plain page padding. As a bonus this removes the minor content misalignment that existed in the 1040–1152px band, where the old card had capped but `.main` had not yet.

Drops the now-obsolete `max-width: 65rem` caps and the `min-width: 65rem` side-hairline rules across all the chrome surfaces (`ChromeBar`, `ActionDock`, `BottomSheet`, `EditModeBar`, `EditSheet`, `Lightbox`, `FeedFilters`).

Verified with screenshots at 700 / 1040 / 1440 / 1920px: bars full-width, the deep-background sub-rows (atmosphere row + breadcrumb strip) spanning edge to edge with no centered "shoulders," and content aligned throughout.

## Widen flat-ledger column gap

The single-type ledger pages (creating, blogging, …) have fewer columns than the dense day-grouped feed ledger, so `--ledger-col-gap` is bumped to `var(--space-4)` on `.feed-ledger-flat` (up from the shared `var(--space-3)` base) for more breathing room between a row's title and its trailing time/count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r)_