### PR TITLE
Add extra bottom padding to feed filter sheet panel

### DIFF
--- a/src/components/FeedFilters.css
+++ b/src/components/FeedFilters.css
@@ -115,6 +115,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  /* Extra breathing room below the last row so the sheet doesn't feel
+     cramped against its bottom edge. Overrides the shorthand's bottom pad. */
+  padding-bottom: var(--space-6);
 }
 
 .feed-filter-modal-header {


### PR DESCRIPTION
Adds `padding-bottom: var(--space-6);` to `.feed-filter-sheet-panel` in `src/components/FeedFilters.css`.

Since it comes after the `padding` shorthand, it overrides the shorthand's bottom value — the panel keeps `--space-4` on top/left/right but gets the larger `--space-6` below the last row, giving the sheet more breathing room against its bottom edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCKonVf2S6aRjcSuReDEjz)_