### PR TITLE
Show top 5 instead of top 6 on listening page

### DIFF
--- a/src/components/ListeningStats.jsx
+++ b/src/components/ListeningStats.jsx
@@ -18,7 +18,7 @@ const WINDOWS = [
   { days: 30, label: '30 days' },
 ];
 
-const TOP_N = 6;
+const TOP_N = 5;
 
 export default function ListeningStats({ items }) {
   const [days, setDays] = useState(7);


### PR DESCRIPTION
Changes the ranked lists on the `/listening` page to show the top 5 of each category (Top Tracks, Top Artists, Top Albums) instead of the top 6.

This is a one-line change to the `TOP_N` constant in `src/components/ListeningStats.jsx`, which drives all three lists via the shared `topN()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmPpuJYmQTYGNJjFPNDNac

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmPpuJYmQTYGNJjFPNDNac)_