### PR TITLE
Match atmosphere row height to the timestamp/NSID strip

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -96,11 +96,22 @@
      atmosphere row reads as its own layer (matches the nav sheet). */
   background: var(--surface-deep);
   overflow: hidden;
+  /* Drop the --chrome-h (56px) floor this row inherits from
+     `.chrome-bar-row`. That floor is for the primary bars; this is an
+     expanding panel that should size to its content, exactly like the
+     tertiary breadcrumb strip below (which also zeroes it). Left in, the
+     floor made the LISTENING TO / FOLLOWED BY row stand noticeably taller
+     than the timestamp/NSID strip — its `.chrome-signals` padding now sets
+     the height so the two expansions match. */
+  min-height: 0;
 }
 
 .chrome-bar-secondary > .chrome-signals {
   width: 100%;
-  padding: var(--space-3) 0;
+  /* Same vertical padding as the tertiary strip's crumbs (--space-2) so
+     this row and the timestamp/NSID strip stand the same height when each
+     is a single row. */
+  padding: var(--space-2) 0;
 }
 
 /* Tertiary chrome: the scroll-driven breadcrumb strip. It's absolutely


### PR DESCRIPTION
## What

The top chrome's expanding **LISTENING TO / FOLLOWED BY** row and the **timestamp/NSID breadcrumb strip** now stand the same height.

## Why

Both expansions are built from the shared `.chrome-bar-row` base, which carries `min-height: var(--chrome-h)` (56px) — a floor intended for the primary bars. The tertiary breadcrumb strip already opted out (`min-height: 0`) and sized to its content, but the atmosphere row never did, so it stayed pinned at 56px and read as noticeably taller. It also used a larger vertical content padding (`--space-3` = 12px vs the strip's `--space-2` = 8px).

## Changes (`src/components/ChromeBar.css`)

- Added `min-height: 0` to `.chrome-bar-secondary` so the expanding panel sizes to its content like the strip already does.
- Aligned `.chrome-bar-secondary > .chrome-signals` vertical padding to `--space-2`, matching the strip's crumb padding.

Both rows render single-line `--text-xs` / `--sans` text, so with the floor removed and padding aligned they now stand equal height. The height-animated wrapper has no CSS height of its own (motion animates it to `height: auto`), so it simply follows the child's new content height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEJ7zQjQ6drk7cTzZ66mki

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEJ7zQjQ6drk7cTzZ66mki)_