### PR TITLE
Close the edit action bar when another bottom-chrome sheet opens

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -60,7 +60,9 @@
 .chrome-bar-row {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  /* The compact button gap holds at every width — the chrome's controls
+     don't spread out on larger screens. */
+  gap: var(--space-2);
   width: 100%;
   /* Shared inset that keeps chrome content on the same centered column as
      `.main` and the nav dock while the bar itself is full-bleed — see
@@ -574,7 +576,7 @@
 .chrome-bottom-row {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   width: 100%;
   padding: 0 var(--chrome-pad-x);
   min-height: var(--chrome-h);
@@ -600,7 +602,7 @@
 .chrome-bottom-cluster {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 /* Push the right-hand action cluster (filter + menu) away from the
@@ -652,15 +654,6 @@
 }
 
 @media (max-width: 700px) {
-  .chrome-bar-row {
-    gap: var(--space-2);
-  }
-  .chrome-bottom-row {
-    gap: var(--space-2);
-  }
-  .chrome-bottom-cluster {
-    gap: var(--space-2);
-  }
   .chrome-signals-secondary {
     flex-direction: column;
     align-items: stretch;

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useActionDock } from './useActionDock.jsx';
+import { useChromePanel } from './useChromePanel.jsx';
 
 const EditModeContext = createContext(null);
 
@@ -53,6 +54,7 @@ export function EditModeProvider({ children }) {
   const [pageEditor, setPageEditor] = useState(null);
   const location = useLocation();
   const { open: dockOpen } = useActionDock();
+  const { panel } = useChromePanel();
 
   const clearSelection = useCallback(() => {
     setSelected((prev) => (prev.size === 0 ? prev : new Map()));
@@ -100,14 +102,17 @@ export function EditModeProvider({ children }) {
     setEditSheet(null);
   }, [location.pathname, clearSelection]);
 
-  // The nav dock and the quick-edit sheet share the bottom-chrome slot, and
-  // the dock opens on top of everything — so opening the dock folds the
-  // quick-edit sheet away (it would otherwise sit hidden behind the dock).
-  // Mirrors useChromePanel's dock↔panel rule; edit MODE (and its action bar)
-  // stays put — the dock rides above the bar via --edit-bar-h.
+  // The nav dock and the transient chrome panels (search / filter / info) are
+  // the site's other bottom-chrome sheets — the surfaces that expand out of
+  // the same edge as the edit action bar. That slot is one-at-a-time, so
+  // opening any of them closes the edit action bar rather than leaving it
+  // stacked underneath: exit edit mode entirely, which folds the bar away,
+  // clears the selection, and drops any open quick-edit sheet. (The quick-edit
+  // sheet is itself part of edit mode and rides above the bar, so opening it
+  // isn't counted here — only the competing sheets are.)
   useEffect(() => {
-    if (dockOpen) setEditSheet(null);
-  }, [dockOpen]);
+    if (dockOpen || panel) exit();
+  }, [dockOpen, panel, exit]);
 
   const toggleSelect = useCallback((item) => {
     const uri = item?.atUri;


### PR DESCRIPTION
Two bottom-chrome refinements.

## Edit action bar closes when another sheet opens

The bottom chrome hosts several surfaces that expand out of the same edge — the nav dock (menu), the transient search/filter/info panels, the quick-edit sheet, and the owner edit action bar. Opening the nav menu (or a panel) while edit mode was active left the edit action bar **stacked beneath** the new sheet, riding below it via `--edit-bar-h`.

Those surfaces are meant to own that slot one at a time, so opening the nav dock **or** a transient panel now exits edit mode — folding the action bar away, clearing the selection, and dropping any open quick-edit sheet:

```js
useEffect(() => {
  if (dockOpen || panel) exit();
}, [dockOpen, panel, exit]);
```

`EditModeProvider` already watched the dock to fold the quick-edit sheet away; it now also watches `useChromePanel` and calls `exit()` for the whole family. The quick-edit sheet is itself part of edit mode (it rides *above* the bar and hosts its Save/Delete/Close), so opening it is intentionally excluded. This completes the symmetry with the pencil button, which already closes any open panel when *entering* edit mode.

## Compact chrome bar gap at every width

`.chrome-bar-row`, `.chrome-bottom-row`, and `.chrome-bottom-cluster` widened their button gap from `--space-2` to `--space-3` above 700px. The controls don't need to spread out on larger screens, so the compact `--space-2` gap is now the base and the redundant `max-width: 700px` overrides are removed (the unrelated `.chrome-signals-secondary` column rule in that media query stays).

## Testing

- `vite build` passes.
- Headless Chromium smoke test: the app mounts (confirming the new `useChromePanel` wiring in `EditModeProvider` — a provider-nesting error would blank the page), the nav dock opens and closes, and there are no console/page errors. The full owner edit-mode flow needs ATProto owner auth (unavailable in CI), so it was verified by reasoning through each flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH9tAk6D6n7r39rk3pfHT4)_