### PR TITLE
Give record OG routes their own card, sky palette, and at:// head

### DIFF
--- a/api/og.js
+++ b/api/og.js
@@ -16,8 +16,9 @@
 import { ImageResponse } from '@vercel/og';
 import { FONTS } from '../og/assets/fonts.js';
 import { ICONS } from '../og/assets/icons.js';
-import { currentAvatarKey, secondsUntilNextHour, folio } from '../og/time.js';
-import { ogElement } from '../og/design.js';
+import { easternHour, avatarKeys, secondsUntilNextHour, folio } from '../og/time.js';
+import { ogElement, themeFromSky } from '../og/design.js';
+import { paletteForHour } from '../src/lib/skyTheme.js';
 import { pageMeta, segsFor, cleanPath, HOME_INDEX, DEFAULT } from '../og/pages.js';
 
 // The card uses two families: Crimson Pro (serif) for the breadcrumb / title /
@@ -39,27 +40,50 @@ const FONT_SET = [
 export default async function handler(req, res) {
   try {
     const q = req.query || {};
-    const theme = q.theme === 'dark' ? 'dark' : 'light';
+    const now = new Date();
 
-    // Copy + routing: an explicit `page` wins (canonical per-page card),
-    // otherwise ad-hoc title/subtitle params, otherwise the home index card.
+    // Which hour drives the card. Normally the current Eastern hour (in
+    // lockstep with the live avatar + favicon); an explicit `hour=0..23`
+    // param lets us preview any point in the day (used by the sample renderer).
+    const hourParam = q.hour != null && q.hour !== '' ? Number(q.hour) : NaN;
+    const hour = Number.isFinite(hourParam) ? ((hourParam % 24) + 24) % 24 : easternHour(now);
+
+    // Palette: the dynamic SKY theme for this hour by default, so cards match
+    // the site's own hour-tracking palette. `theme=light|dark` forces the
+    // fixed warm-paper fallbacks (handled inside ogElement).
+    const theme = q.theme === 'light' || q.theme === 'dark'
+      ? q.theme
+      : themeFromSky(paletteForHour(hour));
+
+    // Copy + routing: an explicit `page` wins (canonical per-page card), then a
+    // `section`+`label` record card, then ad-hoc title/subtitle, else the home
+    // index card.
     let pathname = '/';
     let label = '';
     let subtitle = '';
     let nsid = DEFAULT.nsid;
+    let record = false;
     if (q.page) {
       pathname = cleanPath(String(q.page));
       const meta = pageMeta(pathname);
       label = meta.label;
       subtitle = meta.desc;
       nsid = meta.nsid;
+    } else if (q.section) {
+      // Per-record card: breadcrumb = /{section}, headline = the record title.
+      const sectionSeg = String(q.section).replace(/^\/+|\/+$/g, '');
+      pathname = `/${sectionSeg}`;
+      label = String(q.label || '');
+      subtitle = String(q.subtitle || '');
+      nsid = String(q.nsid || DEFAULT.nsid);
+      record = true;
     } else if (q.title || q.subtitle) {
       label = String(q.title || '');
       subtitle = String(q.subtitle || '');
       pathname = label ? `/${label.toLowerCase().replace(/\s+/g, '-')}` : '/';
     }
 
-    const key = currentAvatarKey();
+    const key = avatarKeys()[hour];
     const avatarUri = ICONS[key] ? `data:image/png;base64,${ICONS[key]}` : null;
 
     const element = ogElement({
@@ -67,9 +91,10 @@ export default async function handler(req, res) {
       label,
       subtitle,
       nsid,
+      record,
       segs: segsFor(pathname),
       avatarUri,
-      folio: folio(),
+      folio: folio(now),
       theme,
       homeIndex: HOME_INDEX,
     });

--- a/middleware.js
+++ b/middleware.js
@@ -14,8 +14,29 @@
 
 import { pageMeta, SITE, cleanPath, segsFor } from './og/pages.js';
 import { recordMeta } from './og/records.js';
+import { ME_DID, COLLECTIONS } from './src/config.js';
 
 const ORIGIN = 'https://dame.is';
+
+// Top-level surfaces backed by an is.dame.page record (keyed by rkey), mirroring
+// the client's src/hooks/useAtUri.js `pageRkeyForPath`. Used to give crawlers
+// the same canonical at:// URI the SPA advertises via <AtUriHead>.
+const TOP_LEVEL_PAGE_RKEY = {
+  '/blogging': 'blogging',
+  '/creating': 'creating',
+  '/posting': 'posting',
+  '/logging': 'logging',
+  '/sharing': 'sharing',
+  '/listening': 'listening',
+};
+
+/** The at:// URI backing a top-level surface, or null. */
+function topLevelAtUri(path) {
+  const rkey = TOP_LEVEL_PAGE_RKEY[path];
+  if (rkey) return `at://${ME_DID}/${COLLECTIONS.page}/${rkey}`;
+  if (path === '/themself') return `at://${ME_DID}/${COLLECTIONS.profile}/self`;
+  return null;
+}
 
 export const config = {
   matcher: [
@@ -55,6 +76,19 @@ function setMeta(html, keyAttr, keyVal, content) {
   return html.replace(/<\/head>/i, `    <meta ${keyAttr}="${keyVal}" content="${esc}" />\n  </head>`);
 }
 
+// Inject the atmospheric <head> hints that let AT clients discover the record(s)
+// backing this view — the crawler-facing mirror of <AtUriHead> (which only runs
+// client-side, so JS-less crawlers never saw it). Marked data-atproto="ssr" so
+// the client strips these on boot and stays the single source of truth in-app.
+function injectAtprotoHead(html, atUri, cid) {
+  const uri = escapeAttr(atUri);
+  let tags =
+    `    <link rel="alternate" type="application/at-record+json" href="${uri}" data-atproto="ssr" />\n` +
+    `    <meta name="atproto:uri" content="${uri}" data-atproto="ssr" />\n`;
+  if (cid) tags += `    <meta name="atproto:cid" content="${escapeAttr(cid)}" data-atproto="ssr" />\n`;
+  return html.replace(/<\/head>/i, `${tags}  </head>`);
+}
+
 export default async function middleware(request) {
   try {
     const url = new URL(request.url);
@@ -63,25 +97,50 @@ export default async function middleware(request) {
 
     // Two title conventions:
     //   • top-level surfaces → the page's own "dame.is {label}" (from pages.js)
-    //   • record/leaf pages   → "{record title} — dame.is", resolved live from
-    //     the PDS; the OG image falls back to the parent section's card.
-    // A record route whose record can't be fetched degrades to the section's
+    //   • record/leaf pages   → "{record title} — dame.is" + a per-record OG
+    //     card, resolved by slug from the /data snapshots (with a live PDS
+    //     fallback; see og/records.js).
+    // A record route whose record can't be resolved degrades to the section's
     // own card + title, so crawlers never see the generic home card there.
     let title;
     let desc;
     let ogImage;
+    let atUri = null;
+    let cid = null;
     if (segs.length === 2) {
-      const sectionPath = `/${segs[0]}`;
+      const sectionSeg = segs[0];
+      const sectionPath = `/${sectionSeg}`;
       const section = pageMeta(sectionPath);
-      const rec = await recordMeta(path);
-      title = rec ? `${rec.title} — ${SITE.domain}` : section.title;
-      desc = (rec && rec.description) || section.desc;
-      ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(sectionPath)}`;
+      const rec = await recordMeta(path, url.origin);
+      if (rec) {
+        // The record resolved: its own title/description, its own OG card
+        // (breadcrumb = section, headline = the record title), and its at://
+        // URI for the head. Falls back below only when it can't be resolved.
+        title = `${rec.title} — ${SITE.domain}`;
+        desc = rec.description || section.desc;
+        const params = new URLSearchParams({
+          section: sectionSeg,
+          label: rec.title,
+          subtitle: desc,
+          nsid: rec.nsid || section.nsid,
+        });
+        ogImage = `${ORIGIN}/api/og?${params.toString()}`;
+        atUri = rec.atUri;
+        cid = rec.cid;
+      } else {
+        // A record route whose record can't be fetched degrades to the
+        // section's own card + title, so crawlers never see the generic home
+        // card there.
+        title = section.title;
+        desc = section.desc;
+        ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(sectionPath)}`;
+      }
     } else {
       const meta = pageMeta(path);
       title = meta.title;
       desc = meta.desc;
       ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(path)}`;
+      atUri = topLevelAtUri(path);
     }
 
     // Pull the built SPA shell. The matcher never matches /index.html, so this
@@ -104,6 +163,10 @@ export default async function middleware(request) {
     html = setMeta(html, 'name', 'twitter:title', title);
     html = setMeta(html, 'name', 'twitter:description', desc);
     html = setMeta(html, 'name', 'twitter:image', ogImage);
+
+    // Record/leaf pages (and the top-level surfaces) advertise their canonical
+    // at:// URI so AT-aware crawlers can find the backing record.
+    if (atUri) html = injectAtprotoHead(html, atUri, cid);
 
     return new Response(html, {
       status: 200,

--- a/og/design.js
+++ b/og/design.js
@@ -27,10 +27,40 @@ const HOME_LAYOUT = 'h4';
 const SHOW_AVATAR = true;
 
 // ── palettes (light + dark, from theme.css) ─────────────────────────────────
+// These fixed warm-paper palettes are the fallback / debug themes; the live
+// cards derive their palette from the current hour's SKY theme instead (see
+// themeFromSky below and api/og.js), so a card drifts through the day in
+// lockstep with the site, the favicon, and the baked-in sky-avatar.
 export const THEMES = {
   light: { page: '#f1ead4', ink: '#1d2419', inkSoft: '#364034', inkMuted: '#6f6e58', inkFaint: '#9d9784', rule: '#cabf9f', accent: '#5e7a47', tan: '#a88c5f', grid: 'rgba(29,36,25,0.14)', gridStrong: 'rgba(29,36,25,0.24)', gridFine: 'rgba(29,36,25,0.09)' },
   dark: { page: '#1d2419', ink: '#ece4cb', inkSoft: '#d2c9ac', inkMuted: '#9a9377', inkFaint: '#6a6450', rule: '#3a4232', accent: '#a3b486', tan: '#c9a87a', grid: 'rgba(236,228,203,0.12)', gridStrong: 'rgba(236,228,203,0.22)', gridFine: 'rgba(236,228,203,0.09)' },
 };
+
+// Map a sky-theme palette (src/lib/skyTheme.js → paletteForHour) onto the card's
+// design tokens, so the OG card uses the exact same hour-derived colors the app
+// paints with. The sky palette already ships hex tokens for page/ink/accent/…;
+// the visible baseline grid is drawn from the ink color at the same alphas the
+// fixed themes use (a touch stronger by day, when the page is light).
+export function themeFromSky(palette) {
+  const v = (palette && palette.vars) || {};
+  const ink = v['--sky-ink'] || '#1d2419';
+  const [ir, ig, ib] = hexRgb(ink);
+  const inkA = (a) => `rgba(${ir},${ig},${ib},${a})`;
+  const day = Boolean(palette && palette.day);
+  return {
+    page: v['--sky-page'] || THEMES.light.page,
+    ink,
+    inkSoft: v['--sky-ink-soft'] || THEMES.light.inkSoft,
+    inkMuted: v['--sky-ink-muted'] || THEMES.light.inkMuted,
+    inkFaint: v['--sky-ink-faint'] || THEMES.light.inkFaint,
+    rule: v['--sky-rule'] || THEMES.light.rule,
+    accent: v['--sky-accent'] || THEMES.light.accent,
+    tan: v['--sky-tan'] || THEMES.light.tan,
+    grid: inkA(day ? 0.14 : 0.12),
+    gridStrong: inkA(day ? 0.24 : 0.22),
+    gridFine: inkA(0.09),
+  };
+}
 
 // ── geometry ────────────────────────────────────────────────────────────────
 const W = 1200, H = 630;
@@ -124,6 +154,24 @@ function titleSize(label, base, maxChars) {
   return n <= maxChars ? base : Math.max(70, Math.round(base * (maxChars / n)));
 }
 
+// A record card's title is a real headline (a full sentence, not a one-word
+// gerund), so it wraps across lines. Shrink the size until it fits within
+// `maxLines`, then hard-truncate with an ellipsis if it still overflows.
+function fitHeadline(text, maxWidth, maxLines, base = 58, min = 40) {
+  let size = base;
+  let lines = wrapText(text, size, maxWidth);
+  while (lines.length > maxLines && size > min) {
+    size -= 2;
+    lines = wrapText(text, size, maxWidth);
+  }
+  if (lines.length > maxLines) {
+    lines = lines.slice(0, maxLines);
+    const last = lines[maxLines - 1].replace(/\s+\S*$/, '');
+    lines[maxLines - 1] = `${last}…`;
+  }
+  return { size, lines };
+}
+
 function shell(t, children, opts) {
   return h('div', { style: { position: 'relative', display: 'flex', width: W, height: H, background: t.page, fontFamily: 'Crimson Pro' } },
     gridLayer(t, opts), ...children.flat().filter(Boolean));
@@ -160,6 +208,49 @@ function subCardS4(t, { segs, label, subtitle, nsid, avatarUri, folio }) {
     ...descLines.map((l, i) => at(l, { size: 25, by: 5 * P + i * HP - 8, left: CX, color: t.inkSoft, weight: 400 })),
     at(nsid, { size: 22, by: 8 * P - LE, left: CX, mono: true, color: t.inkMuted }),
   ], { verticals: [PAD, { x: DIV, strong: true }, W - PAD], halfBands: [{ from: 4 * P + HP, to: bandTo }] });
+}
+
+// ── RECORD: a single blog post / creative work / channel ────────────────────
+// Same gutter+divider frame as S4, but the big accent gerund is replaced by
+// the record's own title as a wrapped serif headline (mirroring the site's
+// .page-title: serif 600, roman ink, with only the section term accent-italic
+// in the breadcrumb — the .gerund treatment). The description sits below on the
+// half-pitch rules, exactly like a section card.
+function recordCard(t, { segs, title, subtitle, nsid, avatarUri, folio }) {
+  const DIV = 320, CX = DIV, bcBy = P - LE;
+  const colW = W - PAD - CX; // headline / description column width
+  const { size, lines } = fitHeadline(title || '', colW, 3);
+  const descAll = wrapText(subtitle || '', 24, colW);
+  const descLines = descAll.slice(0, 3);
+  if (descAll.length > descLines.length && descLines.length) {
+    const last = descLines[descLines.length - 1].replace(/\s+\S*$/, '');
+    descLines[descLines.length - 1] = `${last}…`;
+  }
+  // Headline lines land on coarse rules from row 3 down; the description
+  // follows a coarse row below the last headline line, on half-pitch rules.
+  const headBase = 3 * P - 8;
+  const descBase = (3 + lines.length) * P - 8;
+  const bandTo = descBase + descLines.length * HP;
+  // Breadcrumb "dame.is / {section}" with the section term echoing .gerund.
+  const section = segs[segs.length - 1] || '';
+  const crumb = [
+    h('div', { style: { color: t.inkFaint } }, 'dame.is'),
+    h('div', { style: { color: t.inkFaint } }, '/'),
+    h('div', { style: { color: t.accent, fontStyle: 'italic', fontWeight: 600 } }, section),
+  ];
+  return shell(t, [
+    at('day', { size: 23, by: 3 * P - LE, left: PAD, mono: true, color: t.inkFaint, ls: '0.12em' }),
+    at(folio, { size: 44, by: 4 * P - 10, left: PAD, mono: true, color: t.inkSoft }),
+    avatarMark(t, avatarUri, { textBaseline: bcBy, left: CX }),
+    rowAt(crumb, { size: 28, by: bcBy, left: avatarUri ? CX + 46 + 18 : CX }),
+    ...lines.map((l, i) =>
+      at(l, { size, by: headBase + i * P, left: CX, weight: 600, color: t.ink, ls: '-0.01em' }),
+    ),
+    ...descLines.map((l, i) =>
+      at(l, { size: 24, by: descBase + i * HP, left: CX, color: t.inkSoft, weight: 400 }),
+    ),
+    at(nsid, { size: 22, by: 8 * P - LE, left: CX, mono: true, color: t.inkMuted }),
+  ], { verticals: [PAD, { x: DIV, strong: true }, W - PAD], halfBands: [{ from: 3 * P + HP, to: bandTo }] });
 }
 
 // ── HOME: H4 (index of surfaces, cascade-fade, tighter half-pitch rows) ─────
@@ -212,12 +303,13 @@ function homeCardH1(t, { avatarUri, folio, nsid, hero }) {
  * @param {string[]} [o.segs]    breadcrumb segments (derived from pathname if omitted)
  * @param {string|null} [o.avatarUri] data: URI for the current sky-avatar tile
  * @param {string}  o.folio      day-of-life string ('12,115')
- * @param {'light'|'dark'} [o.theme]
+ * @param {'light'|'dark'|object} [o.theme] palette key, or a resolved token map (e.g. themeFromSky)
+ * @param {boolean} [o.record]   render the per-record card (title = o.label as a wrapped headline)
  * @param {Array}   [o.homeIndex] [{label,nsid}] for the home index card
  * @param {Array}   [o.hero]      [{text,color}] for the home hero card
  */
 export function ogElement(o = {}) {
-  const t = THEMES[o.theme] || THEMES.light;
+  const t = (o.theme && typeof o.theme === 'object') ? o.theme : (THEMES[o.theme] || THEMES.light);
   const pathname = (o.pathname || '/').replace(/\/+$/, '') || '/';
   const segs = o.segs || pathname.split('/').filter(Boolean);
   const avatarUri = SHOW_AVATAR ? (o.avatarUri || null) : null;
@@ -227,6 +319,9 @@ export function ogElement(o = {}) {
   if (isHome) {
     if (HOME_LAYOUT === 'h1') return homeCardH1(t, { avatarUri, folio, nsid: o.nsid || 'is.dame.page', hero: o.hero });
     return homeCardH4(t, { avatarUri, folio, nsid: o.nsid || 'is.dame.page', homeIndex: o.homeIndex || [] });
+  }
+  if (o.record) {
+    return recordCard(t, { segs, title: o.label, subtitle: o.subtitle || '', nsid: o.nsid || '', avatarUri, folio });
   }
   const args = { segs, label: o.label, subtitle: o.subtitle || '', nsid: o.nsid || '', avatarUri, folio };
   return SUBPAGE_LAYOUT === 's0' ? subCardS0(t, args) : subCardS4(t, args);

--- a/og/records.js
+++ b/og/records.js
@@ -1,29 +1,47 @@
 // Edge-safe resolver for per-record page metadata (blog posts, creative works,
 // curated channels). middleware.js uses this to give record routes a real
-// "<record title> — dame.is" <title> + OG tags for crawlers, instead of the
-// generic site card. Plain fetch only, so it runs in the Edge runtime.
+// "<record title> — dame.is" <title>, a per-record OG card, and the record's
+// own at:// URI in the crawler-facing <head>, instead of the generic section
+// card. Plain fetch only, so it runs in the Edge runtime.
 //
-// A record route is /{section}/{rkey} where {section} maps to one or more AT
-// Protocol collections to try (the site addresses these by slug=rkey). We
-// resolve Dame's PDS via the PLC directory, then getRecord until one hits.
-// Everything is defensive: any failure returns null and the caller falls back
-// to the section card, so a slow/broken PDS never blocks the page.
+// A record route is /{section}/{slug}. The slug is NOT always an rkey:
+//   • /blogging/:id      → id is the rkey of a site.standard.document (or a
+//                          pub.leaflet.document)
+//   • /creating/:slug    → slug is the doc's human `path` (e.g. "how-i-made-…"),
+//                          matched against portfolio-homed standard docs — the
+//                          rkey rarely equals the slug, which is exactly why the
+//                          old getRecord-by-rkey lookup silently missed and
+//                          every work fell back to the /creating section card
+//   • /curating/:slug    → slug is the channel rkey
+//
+// Resolution mirrors the SPA (src/hooks/useAtUri.js): match against the static
+// JSON snapshots the site already ships under /data/*.json (fast, edge-cached,
+// and they carry uri + cid), falling back to a time-boxed live PDS lookup for
+// records too fresh to be in the latest snapshot. Everything is defensive: any
+// failure returns null and the caller falls back to the section card, so a
+// slow/broken PDS never blocks the page.
 
-const ME_DID = 'did:plc:gq4fo3u6tqzzdkjlwzpb23tj'; // mirrors src/config.js ME_DID
-const PLC_DIRECTORY = 'https://plc.directory';
-const TIMEOUT_MS = 2500;
+import { ME_DID, COLLECTIONS } from '../src/config.js';
+import { resolvePds, getRecord, listRecords, rkeyFromAtUri } from '../src/lib/atproto.js';
+import { workSlug, showOnCreating, showOnBlog, isDraft } from '../src/lib/publications.js';
 
-// section (first path segment) → collections to try, in order. Mirrors the
-// slug-addressed record routes in src/App.jsx / src/lib/recordRoutes.js.
-const RECORD_COLLECTIONS = {
-  blogging: ['site.standard.document', 'pub.leaflet.document'],
-  creating: ['is.dame.creating.work'],
-  curating: ['is.dame.arena.channel'],
-};
+const SNAPSHOT_TIMEOUT_MS = 2000;
+const PDS_TIMEOUT_MS = 2500;
 
-async function fetchJson(url) {
+// Sections whose leaf pages render a single AT-Protocol record.
+const RECORD_SECTIONS = new Set(['blogging', 'creating', 'curating']);
+
+/** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */
+function withTimeout(promise, ms) {
+  return Promise.race([
+    Promise.resolve(promise).catch(() => null),
+    new Promise((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+async function fetchJson(url, ms) {
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const timer = setTimeout(() => ctrl.abort(), ms);
   try {
     const res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
     if (!res.ok) return null;
@@ -35,50 +53,128 @@ async function fetchJson(url) {
   }
 }
 
-async function resolvePds(did) {
-  const doc = await fetchJson(`${PLC_DIRECTORY}/${did}`);
-  const services = doc?.service || [];
-  const pds = services.find((s) => s.id === '#atproto_pds')?.serviceEndpoint || services[0]?.serviceEndpoint;
-  return pds ? pds.replace(/\/$/, '') : null;
+async function fetchSnapshot(origin, name) {
+  if (!origin) return null;
+  const json = await fetchJson(`${origin}/data/${name}.json`, SNAPSHOT_TIMEOUT_MS);
+  return Array.isArray(json) ? json : null;
 }
 
-async function getRecordValue(pds, collection, rkey) {
-  const params = new URLSearchParams({ repo: ME_DID, collection, rkey });
-  const json = await fetchJson(`${pds}/xrpc/com.atproto.repo.getRecord?${params}`);
-  return json?.value || null;
+function endsWithRkey(uri, rkey) {
+  if (!uri || !rkey) return false;
+  const m = String(uri).match(/\/([^/]+)$/);
+  return Boolean(m) && m[1] === rkey;
+}
+
+function collectionFromUri(uri) {
+  const m = String(uri || '').match(/^at:\/\/[^/]+\/([^/]+)\//);
+  return m ? m[1] : null;
 }
 
 /** True if `pathname` looks like a slug-addressed record route we can resolve. */
 export function isRecordRoute(pathname) {
   const segs = (pathname || '').split('/').filter(Boolean);
-  return segs.length === 2 && Boolean(RECORD_COLLECTIONS[segs[0]]);
+  return segs.length === 2 && RECORD_SECTIONS.has(segs[0]);
+}
+
+// ── resolvers: snapshot-first, then a time-boxed live PDS fallback ───────────
+
+// /blogging/:id — id is the rkey; standard docs first, then leaflets.
+async function resolveBlog(origin, slug) {
+  const blogs = await fetchSnapshot(origin, 'blogs');
+  const std = Array.isArray(blogs)
+    ? blogs.find((r) => endsWithRkey(r?.uri, slug) && !isDraft(r?.value) && showOnBlog(r?.value))
+    : null;
+  if (std) return std;
+  const leaflets = await fetchSnapshot(origin, 'leaflets');
+  const leaf = Array.isArray(leaflets) ? leaflets.find((r) => endsWithRkey(r?.uri, slug)) : null;
+  if (leaf) return leaf;
+  return withTimeout(liveByRkey(slug, [COLLECTIONS.blogging, COLLECTIONS.leaflet]), PDS_TIMEOUT_MS);
+}
+
+// /creating/:slug — slug is the doc's `path` (or an rkey); portfolio-homed
+// standard docs first, then legacy is.dame.creating.work.
+async function resolveWork(origin, slug) {
+  const blogs = await fetchSnapshot(origin, 'blogs');
+  const std = Array.isArray(blogs)
+    ? blogs.find(
+        (r) =>
+          !isDraft(r?.value) &&
+          showOnCreating(r?.value) &&
+          (workSlug(r?.value) === slug || rkeyFromAtUri(r?.uri) === slug),
+      )
+    : null;
+  if (std) return std;
+  const works = await fetchSnapshot(origin, 'creations');
+  const legacy = Array.isArray(works)
+    ? works.find((r) => !isDraft(r?.value) && workSlug(r?.value) === slug)
+    : null;
+  if (legacy) return legacy;
+  return withTimeout(liveWorkBySlug(slug), PDS_TIMEOUT_MS);
+}
+
+// /curating/:slug — slug is the channel rkey.
+async function resolveChannel(origin, slug) {
+  return withTimeout(liveByRkey(slug, [COLLECTIONS.arenaChannel]), PDS_TIMEOUT_MS);
+}
+
+async function liveByRkey(rkey, collections) {
+  const pds = await resolvePds(ME_DID).catch(() => null);
+  if (!pds) return null;
+  for (const collection of collections) {
+    const rec = await getRecord(pds, { repo: ME_DID, collection, rkey }).catch(() => null);
+    if (rec?.value) return rec;
+  }
+  return null;
+}
+
+async function liveWorkBySlug(slug) {
+  const pds = await resolvePds(ME_DID).catch(() => null);
+  if (!pds) return null;
+  const std = await listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.blogging, max: 200 }).catch(() => []);
+  const byStd = std.find(
+    (r) =>
+      !isDraft(r?.value) &&
+      showOnCreating(r?.value) &&
+      (workSlug(r?.value) === slug || rkeyFromAtUri(r?.uri) === slug),
+  );
+  if (byStd) return byStd;
+  const legacy = await listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.creating, max: 200 }).catch(() => []);
+  return legacy.find((r) => !isDraft(r?.value) && workSlug(r?.value) === slug) || null;
+}
+
+function shapeMeta(record, section) {
+  const v = (record && record.value) || {};
+  const title = String(v.title || v.name || '').trim();
+  if (!title) return null;
+  const description = String(v.description || v.summary || v.subtitle || '').trim();
+  const atUri = record.uri || null;
+  const cid = record.cid || null;
+  return { title, description, section, atUri, cid, nsid: collectionFromUri(atUri) };
 }
 
 /**
- * Resolve a record route to `{ title, description, section }`, or null if it's
- * not a record route or the record can't be fetched. `title` is the record's
- * own title; `description` is its summary/subtitle when present.
+ * Resolve a record route to
+ * `{ title, description, section, atUri, cid, nsid }`, or null if it's not a
+ * record route or the record can't be resolved. `title` is the record's own
+ * title; `description` is its summary/subtitle when present; `atUri`/`cid`
+ * point at the canonical record; `nsid` is its collection.
  */
-export async function recordMeta(pathname) {
+export async function recordMeta(pathname, origin) {
   const segs = (pathname || '').split('/').filter(Boolean);
   if (segs.length !== 2) return null;
-  const [section, rawRkey] = segs;
-  const collections = RECORD_COLLECTIONS[section];
-  if (!collections) return null;
+  const [section, rawSlug] = segs;
+  if (!RECORD_SECTIONS.has(section)) return null;
 
-  let rkey = rawRkey;
-  try { rkey = decodeURIComponent(rawRkey); } catch {}
+  let slug = rawSlug;
+  try { slug = decodeURIComponent(rawSlug); } catch {}
 
-  const pds = await resolvePds(ME_DID);
-  if (!pds) return null;
-
-  for (const collection of collections) {
-    const value = await getRecordValue(pds, collection, rkey);
-    const title = value && (value.title || value.name);
-    if (title) {
-      const description = value.description || value.summary || value.subtitle || '';
-      return { title: String(title).trim(), description: String(description).trim(), section };
-    }
+  let record = null;
+  try {
+    if (section === 'blogging') record = await resolveBlog(origin, slug);
+    else if (section === 'creating') record = await resolveWork(origin, slug);
+    else if (section === 'curating') record = await resolveChannel(origin, slug);
+  } catch {
+    record = null;
   }
-  return null;
+  return record ? shapeMeta(record, section) : null;
 }

--- a/src/components/AtUriHead.jsx
+++ b/src/components/AtUriHead.jsx
@@ -26,6 +26,11 @@ export default function AtUriHead({ atUri, cid, title }) {
     const head = document.head;
     const cleanups = [];
 
+    // Drop any server-injected (crawler-facing) atproto hints from middleware.js
+    // so the client is the single source of truth once JS runs — otherwise a
+    // stale SSR tag would linger across SPA navigations.
+    head.querySelectorAll('[data-atproto="ssr"]').forEach((n) => n.remove());
+
     if (effectiveAtUri) {
       const link = document.createElement('link');
       link.rel = 'alternate';


### PR DESCRIPTION
Three fixes to the dynamic Open Graph pipeline.

## 1. Per-record metadata + image
Record/leaf routes (`/creating/:slug`, `/blogging/:slug`, `/curating/:slug`) were showing the parent **section's** title, description, and card. `og/records.js` resolved records with `getRecord`-by-rkey, but creating works are addressed by their human `path` slug (rarely the rkey), so every one silently missed and fell back to the `/creating` section card.

- Rewrote the resolver to match by slug against the site's `/data/*.json` snapshots (same match logic as the SPA — `workSlug`/`showOnCreating`/`showOnBlog`/`isDraft`), with a time-boxed live PDS fallback for records too fresh to be in a snapshot.
- `middleware.js` now builds a **per-record** card (`/api/og?section=…&label=<title>&subtitle=<desc>&nsid=…`) and passes the record's own title/description through, falling back to the section card only when the record can't be resolved.

## 2. Sky palette
The cards used the fixed warm-paper light theme. New `themeFromSky()` maps `src/lib/skyTheme.js` `paletteForHour(currentHour)` onto the card's design tokens, so a card drifts through the day in lockstep with the live avatar and favicon. `theme=light|dark` still force the fixed fallbacks.

## 3. at:// URI in the head for crawlers
`<AtUriHead>` only runs client-side, so JS-less crawlers never saw the canonical record URI. `middleware.js` now injects `atproto:uri` + `atproto:cid` + the `at-record+json` alternate link into the served shell — the real record URI for the standard-site leaf docs, plus the `is.dame.page`/`is.dame.profile` URIs for top-level surfaces. The client strips these `data-atproto="ssr"` tags on boot so it stays the single source of truth in-app.

Adds a record card layout (wrapped serif headline + description on the ruled grid) and `section`/`label`/`subtitle`/`nsid` params to `/api/og`.

## Verification
- Rendered cards to PNG through the exact `api/og.js` code path (record / section / home; 2am / 7am / 1pm / 6pm; short + overflowing titles — headline and description both ellipsize cleanly).
- Drove the full `middleware.js` flow with mocked snapshots: confirmed record resolution, per-record image URL, injected `at://` tags, graceful section fallback when unresolvable, and correct top-level URIs.
- `npm run build` (client) passes; all modified modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb)_