### PR TITLE
Ledger feed: gap between stacked embeds, images fill the column

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1898,15 +1898,27 @@ a.ledger-time:focus-visible {
   margin-top: 0;
 }
 
+/* ...but a record-with-media post stacks the media embed and the quote
+   inside one ledger cell, so restore a small gap between the two — the
+   block's top margin (above) is owned by .ledger-embed, which would
+   otherwise leave the pair touching. */
+.ledger-embed .post-embed-images + .post-embed-quote,
+.ledger-embed .post-embed-video + .post-embed-quote,
+.ledger-embed .post-embed-link-card + .post-embed-quote {
+  margin-top: var(--space-3);
+}
+
 .ledger-embed .post-embed-images {
   gap: var(--space-1);
   max-width: 20rem;
 }
 
-/* A lone image sizes its frame from --embed-image-max-h (see PostEmbed.css);
-   in the condensed ledger that cap drops from a full 520px to a thumbnail. */
+/* A lone image sizes its frame from --embed-image-max-h (see PostEmbed.css).
+   In the ledger the picture fills the 20rem column at its true ratio; the
+   height cap only bounds very tall images so a portrait can't run away (it
+   matches the 20rem column width, so images fit within a 20rem square). */
 .ledger-embed .post-embed-images[data-count='1'] {
-  --embed-image-max-h: 10rem;
+  --embed-image-max-h: 20rem;
 }
 
 /* Multi-image grids get uniform landscape crops so two rows of images


### PR DESCRIPTION
## What

Two ledger-layout follow-ups to the aspect-ratio work in #218.

- **Gap between stacked embeds.** A record-with-media post stacks the image and the quote inside one `.ledger-embed` cell, but the ledger zeroes every embed's top margin (the block's gap is owned by `.ledger-embed`), so the pair sat flush. Restore a small gap between a media embed and a quote that follows it.
- **Ledger images fill the column.** The single-image height cap had dropped to `10rem` in the ledger, shrinking images to small thumbnails — narrower than the quote beneath. Raise it to `20rem` so a lone image fills the 20rem column at its true aspect ratio, with the cap only bounding very tall portraits (images fit within a 20rem square).

Both changes are scoped to `.ledger-embed`; the cards layout is untouched.

## Verification

Reproduced the exact ledger DOM with the real merged CSS and rendered near-square (320×287, fills the column), tall 9:16 (bounded at 180×320), and wide landscape (320×180) — all with the gap between image and quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tHktVA2C4sMq8tjsLr7pn

---
_Generated by [Claude Code](https://claude.ai/code/session_016tHktVA2C4sMq8tjsLr7pn)_