### PR TITLE
Overhaul the resume admin: studio, tailoring workbench, bullet forking

### DIFF
--- a/lexicons/RESUME.md
+++ b/lexicons/RESUME.md
@@ -9,7 +9,8 @@ them on the site at all.
 ```
 is.dame.resume            (a resume version — "primary", "product-design", …)
  ├─ entries[]   ──at://──▶ is.dame.resume.job        (canonical job; owns the bullets)
- │   └─ highlightIds[]      ─▶ picks specific job.highlights[].id to show
+ │   └─ highlightIds[]      ─▶ picks job.highlights[].id — or "h3#v2" to pick a
+ │                             forked phrasing from that highlight's variants[]
  ├─ education[] ──at://──▶ is.dame.resume.education   (canonical degree/program)
  ├─ skills[]                  (inline skill groups — the audience-specific part)
  └─ contact                   (inline, or fall back to the site profile)
@@ -23,6 +24,16 @@ and the **highlights** (achievement bullets). Each highlight has a stable `id`
 so resumes can reference it. Edit a bullet here once and every resume that
 selected it updates. Record key is a readable slug, e.g.
 `at://…/is.dame.resume.job/ipfs-content-manager`.
+
+A highlight can also carry **variants** — forked phrasings of the same
+achievement (`variants: [{ id, text, label }]`). The canonical `text` is what a
+bare selection shows; a resume opts into a fork with a `"<highlightId>#<variantId>"`
+ref (e.g. `"h3#v2"`) in its `highlightIds`. Variants live on the job record, so
+a fork is still edited in one place and every resume that picked it stays in
+sync; the `label` ("design-focused", "one-pager") is admin-only naming.
+Variants share the parent bullet's flags (visibility, featured, metric, tags) —
+they are the *same point*, differently worded. If two phrasings diverge into
+genuinely different claims, make a second highlight instead.
 
 ### `is.dame.resume.education` — the canonical education entry
 Same idea for schooling. Reuses the job's `#highlight` shape for honors /
@@ -91,5 +102,13 @@ straightforward resolve-the-backlinks-and-rename pass.
   record (resolving the job/education backlinks for you). It uses `putRecord`
   with the slugs as record keys, so re-running it updates in place instead of
   duplicating.
-- Edit individual records afterward in `/admin` (templated forms live in
-  `src/lib/lexicons.js`; nested arrays use the raw-JSON field).
+- Day-to-day editing happens in the **Resume studio** (`/admin?view=resume`):
+  an overview of every version, job, and education record, with per-version
+  **Duplicate** (fork a whole resume) and the **tailoring workbench**
+  (`/admin?view=resume-tailor&r=<rkey>`) — a resume-centric editor where you
+  reorder jobs, toggle/reorder/fork individual bullets, pick variants, and edit
+  bullet copy inline. Copy edits stage onto the owning job records and save
+  together with the resume in one pass.
+- The templated per-record forms (`src/lib/lexicons.js` +
+  `src/components/resumeFields.jsx`) remain the escape hatch for anything the
+  studio doesn't cover, with raw JSON below that.

--- a/lexicons/is.dame.resume.job.json
+++ b/lexicons/is.dame.resume.job.json
@@ -44,7 +44,7 @@
       "required": ["id", "text"],
       "properties": {
         "id":         { "type": "string", "maxLength": 64, "description": "Stable id, unique within this job. Referenced from is.dame.resume entries[].highlightIds." },
-        "text":       { "type": "string", "maxLength": 2000 },
+        "text":       { "type": "string", "maxLength": 2000, "description": "The canonical phrasing — what a resume shows when it selects this bullet without naming a variant." },
         "visibility": { "type": "string", "enum": ["public", "unlisted", "private"], "default": "public", "description": "Display intent for the website. NOT a privacy control — every PDS record is publicly fetchable. \"private\" bullets are never rendered on the site; \"unlisted\" render only when a resume explicitly selects them." },
         "featured":   { "type": "boolean", "default": false, "description": "Emphasis flag — surfaced first / styled as a lead achievement." },
         "metric":     { "type": "boolean", "default": false, "description": "Marks a quantified, outcome-bearing bullet (useful for impact-first resumes)." },
@@ -53,7 +53,23 @@
           "maxLength": 20,
           "items": { "type": "string", "maxLength": 64 },
           "description": "Free-form labels (e.g. \"growth\", \"leadership\", \"writing\") used to filter/tailor which bullets a given resume pulls in."
+        },
+        "variants":   {
+          "type": "array",
+          "maxLength": 20,
+          "items": { "type": "ref", "ref": "#highlightVariant" },
+          "description": "Forked phrasings of this same bullet — the one achievement re-framed for different audiences. A resume selects a variant with a \"<highlightId>#<variantId>\" ref in entries[].highlightIds; selecting the bare highlight id shows the canonical text. Variants share the parent's flags (visibility, featured, metric, tags)."
         }
+      }
+    },
+    "highlightVariant": {
+      "type": "object",
+      "description": "One alternate phrasing of a highlight. Lives on the canonical job record so a fork is edited once and every resume that selected it stays in sync.",
+      "required": ["id", "text"],
+      "properties": {
+        "id":    { "type": "string", "maxLength": 64, "description": "Stable id, unique within the parent highlight (e.g. \"v1\"). Addressed from resumes as \"<highlightId>#<id>\"." },
+        "text":  { "type": "string", "maxLength": 2000 },
+        "label": { "type": "string", "maxLength": 80, "description": "What this phrasing is for, e.g. \"design-focused\" or \"one-pager\" — shown in the admin variant picker, never rendered on the site." }
       }
     }
   }

--- a/lexicons/is.dame.resume.json
+++ b/lexicons/is.dame.resume.json
@@ -51,8 +51,8 @@
         "highlightIds": {
           "type": "array",
           "maxLength": 50,
-          "items": { "type": "string", "maxLength": 64 },
-          "description": "Which of the job's highlight ids to include, in this order. Omit to include every non-private highlight in its natural order."
+          "items": { "type": "string", "maxLength": 130 },
+          "description": "Which of the job's highlight ids to include, in this order. Each item is either a bare highlight id (\"h3\" — shows the canonical text) or \"<highlightId>#<variantId>\" (\"h3#v2\" — shows that forked phrasing from the highlight's variants). Omit to include every non-private highlight in its natural order."
         },
         "titleOverride":   { "type": "string", "maxLength": 200, "description": "Optional per-resume retitling of the role (e.g. condensing for a one-pager). Falls back to the job's title." },
         "summaryOverride": { "type": "string", "maxLength": 2000, "description": "Optional per-resume role summary. Falls back to the job's summary." }
@@ -66,7 +66,8 @@
         "highlightIds": {
           "type": "array",
           "maxLength": 50,
-          "items": { "type": "string", "maxLength": 64 }
+          "items": { "type": "string", "maxLength": 130 },
+          "description": "Same shape as entry.highlightIds — bare highlight ids or \"<highlightId>#<variantId>\" variant refs."
         }
       }
     },

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { COLLECTIONS } from '../config.js';
 import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { resolvePds } from '../lib/atproto.js';
@@ -391,6 +392,8 @@ const RecordEditor = forwardRef(function RecordEditor({
           onChange={updateField}
           agent={agent}
           did={did}
+          collection={collection}
+          rkey={rkey}
           coverPreview={coverPreview}
           onSetCover={(key, blob, previewUrl) => {
             updateField(key, blob);
@@ -437,7 +440,7 @@ export default RecordEditor;
 /* Field renderers                                                      */
 /* ------------------------------------------------------------------ */
 
-function FormEditor({ lex, value, onChange, agent, did, coverPreview, onSetCover }) {
+function FormEditor({ lex, value, onChange, agent, did, collection, rkey, coverPreview, onSetCover }) {
   // If this record type carries a top-level image field (e.g. a document's
   // coverImage), link cards can offer to reuse their preview image as it.
   const coverField = lex.fields.find((f) => f.type === 'image');
@@ -456,6 +459,8 @@ function FormEditor({ lex, value, onChange, agent, did, coverPreview, onSetCover
           onChange={(v) => onChange(f.key, v)}
           agent={agent}
           did={did}
+          collection={collection}
+          rkey={rkey}
           onSetCover={f.type === 'blocks' ? setCover : undefined}
           externalPreview={coverField && f.key === coverField.key ? coverPreview : undefined}
         />
@@ -522,7 +527,7 @@ function RecordPreview({ lex, record }) {
   );
 }
 
-function Field({ field, value, record, onChange, agent, did, onSetCover, externalPreview }) {
+function Field({ field, value, record, onChange, agent, did, collection, rkey, onSetCover, externalPreview }) {
   const id = `record-editor-field-${field.key}`;
   let control;
   switch (field.type) {
@@ -632,7 +637,22 @@ function Field({ field, value, record, onChange, agent, did, onSetCover, externa
       control = <JsonField id={id} value={value} onChange={onChange} />;
       break;
     case 'highlights':
-      control = <HighlightsField value={value} onChange={onChange} />;
+      control = (
+        <HighlightsField
+          value={value}
+          onChange={onChange}
+          agent={agent}
+          did={did}
+          // Existing records get "used by <resume>" chips + delete guards;
+          // a record still being created has no URI to scan for yet.
+          recordUri={rkey ? `at://${did}/${collection}/${rkey}` : null}
+          usageKeys={
+            collection === COLLECTIONS.resumeEducation
+              ? { listKey: 'education', refKey: 'education' }
+              : { listKey: 'entries', refKey: 'job' }
+          }
+        />
+      );
       break;
     case 'recordRefs':
       control = (

--- a/src/components/resume/ResumeStudio.jsx
+++ b/src/components/resume/ResumeStudio.jsx
@@ -1,0 +1,337 @@
+import { useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Copy, PenLine, ExternalLink, Plus } from 'lucide-react';
+import PageShell from '../PageShell.jsx';
+import { AdminRecordListSkeleton } from '../Skeleton.jsx';
+import { rkeyFromUri } from '../RecordEditor.jsx';
+import { COLLECTIONS } from '../../config.js';
+import {
+  formatDateRange,
+  duplicateResumeValue,
+  slugifyResumeTitle,
+} from '../../lib/resumeHelpers.js';
+import { useResumeBundle } from './useResumeBundle.js';
+import './resumeStudio.css';
+
+/**
+ * Resume studio — the admin home for everything resume-shaped.
+ *
+ * One page that shows every resume *version* (with tailor / duplicate /
+ * set-active actions) above the canonical *jobs* and *education* records they
+ * draw from. The per-version "Tailor" link opens the workbench
+ * (`/admin?view=resume-tailor&r=<rkey>`), which is where bullets get selected,
+ * reordered, forked into variants, and re-worded per version.
+ */
+export default function ResumeStudio({ agent, did }) {
+  const { resumes, jobs, education, loading, error, reload } = useResumeBundle(agent, did);
+  const [actionError, setActionError] = useState(null);
+
+  const jobsByUri = useMemo(() => {
+    const m = new Map();
+    for (const r of jobs || []) m.set(r.uri, r);
+    return m;
+  }, [jobs]);
+
+  const sortedJobs = useMemo(
+    () => [...(jobs || [])].sort((a, b) => String(b.value?.startDate || '').localeCompare(String(a.value?.startDate || ''))),
+    [jobs],
+  );
+  const sortedEducation = useMemo(
+    () => [...(education || [])].sort((a, b) => String(b.value?.startDate || '').localeCompare(String(a.value?.startDate || ''))),
+    [education],
+  );
+
+  return (
+    <PageShell
+      title="Resume studio"
+      intro="Every version of the resume, and the canonical jobs and education records they draw from. Tailor a version to choose, reorder, re-word, and fork its bullets; edit a job to change the shared facts and bullet pool."
+      headTitle="Resume studio — Admin — dame.is"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <code className="admin-collection-nsid">{COLLECTIONS.resume}</code>
+        <Link
+          to={`/admin?c=${encodeURIComponent(COLLECTIONS.resume)}&mode=new`}
+          className="admin-gate-button admin-gate-button-tight"
+        >
+          New version
+        </Link>
+      </div>
+
+      {(error || actionError) && <p className="admin-error">{error || actionError}</p>}
+
+      {loading ? (
+        <AdminRecordListSkeleton rows={6} label="Loading resume records" />
+      ) : (
+        <>
+          <VersionsSection
+            agent={agent}
+            did={did}
+            resumes={resumes}
+            jobsByUri={jobsByUri}
+            onChanged={reload}
+            onError={setActionError}
+          />
+          <RecordsSection
+            heading="Jobs"
+            note="Canonical positions — each owns its facts and the shared pool of bullets (and their forked phrasings)."
+            collection={COLLECTIONS.resumeJob}
+            records={sortedJobs}
+            labelFor={(v) => [v.title, v.organization].filter(Boolean).join(' · ')}
+            newLabel="New job"
+          />
+          <RecordsSection
+            heading="Education"
+            note="Canonical education entries, referenced by versions the same way jobs are."
+            collection={COLLECTIONS.resumeEducation}
+            records={sortedEducation}
+            labelFor={(v) => [v.institution, v.studyType || v.area].filter(Boolean).join(' · ')}
+            newLabel="New education entry"
+          />
+        </>
+      )}
+    </PageShell>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Versions                                                             */
+/* ------------------------------------------------------------------ */
+
+/** "5 jobs · 23 bullets" summary for one resume against the job pool. */
+function versionCounts(value, jobsByUri) {
+  const entries = Array.isArray(value?.entries) ? value.entries : [];
+  let bullets = 0;
+  for (const entry of entries) {
+    if (Array.isArray(entry.highlightIds)) {
+      bullets += entry.highlightIds.length;
+    } else {
+      const hs = jobsByUri.get(entry.job)?.value?.highlights || [];
+      bullets += hs.filter((h) => (h.visibility || 'public') !== 'private').length;
+    }
+  }
+  return { jobs: entries.length, bullets };
+}
+
+function VersionsSection({ agent, did, resumes, jobsByUri, onChanged, onError }) {
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState(null); // rkey being written
+
+  const activeRkey = useMemo(() => {
+    const found = (resumes || []).find((rec) => rec.value?.featured);
+    return found ? rkeyFromUri(found.uri) : null;
+  }, [resumes]);
+
+  // The one version shown at /for-hire: featured=true here, cleared elsewhere.
+  async function setActive(rkey) {
+    if (busy) return;
+    setBusy(rkey);
+    onError(null);
+    try {
+      for (const rec of resumes) {
+        const r = rkeyFromUri(rec.uri);
+        const shouldBeActive = r === rkey;
+        if (shouldBeActive === !!rec.value?.featured) continue;
+        await agent.com.atproto.repo.putRecord({
+          repo: did,
+          collection: COLLECTIONS.resume,
+          rkey: r,
+          record: { ...rec.value, featured: shouldBeActive, updatedAt: new Date().toISOString() },
+        });
+      }
+      onChanged?.();
+    } catch (err) {
+      onError(err?.message || String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  // Fork a whole version: copy the record under a new slug (never featured,
+  // private until published) and jump straight into tailoring it.
+  async function duplicate(rec) {
+    const srcRkey = rkeyFromUri(rec.uri);
+    const taken = new Set((resumes || []).map((r) => rkeyFromUri(r.uri)));
+    let suggestion = `${rec.value?.slug || srcRkey}-copy`;
+    while (taken.has(suggestion)) suggestion = `${suggestion}-2`;
+    const input = window.prompt(
+      'Slug for the new version (also its record key and /for-hire/<slug> URL):',
+      suggestion,
+    );
+    if (input == null) return;
+    const slug = slugifyResumeTitle(input);
+    if (!slug) {
+      onError('That slug is empty once cleaned up — use letters, numbers, and dashes.');
+      return;
+    }
+    if (taken.has(slug)) {
+      onError(`A version with the slug “${slug}” already exists.`);
+      return;
+    }
+    setBusy(srcRkey);
+    onError(null);
+    try {
+      const record = duplicateResumeValue(rec.value, {
+        slug,
+        title: `${rec.value?.title || srcRkey} (copy)`,
+      });
+      record.$type = COLLECTIONS.resume;
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: COLLECTIONS.resume,
+        rkey: slug,
+        record,
+      });
+      navigate(`/admin?view=resume-tailor&r=${encodeURIComponent(slug)}`);
+    } catch (err) {
+      onError(err?.message || String(err));
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="admin-page-section rs-section">
+      <h2 className="admin-collection-group-heading small-caps">Versions</h2>
+      <p className="admin-collection-group-note">
+        Each version selects, orders, and phrases its own view of the shared records. The
+        active one is what <code>/for-hire</code> shows.
+      </p>
+      {(resumes || []).length === 0 ? (
+        <p className="placeholder-card">
+          No resume versions yet. <Link to={`/admin?c=${encodeURIComponent(COLLECTIONS.resume)}&mode=new`}>Create the first one.</Link>
+        </p>
+      ) : (
+        <ul className="rs-version-list reveal-stagger">
+          {resumes.map((rec) => {
+            const r = rkeyFromUri(rec.uri);
+            const v = rec.value || {};
+            const isActive = r === activeRkey;
+            const counts = versionCounts(v, jobsByUri);
+            const vis = v.visibility || 'private';
+            const slug = v.slug || r;
+            return (
+              <li key={rec.uri} className={`rs-version${isActive ? ' is-active' : ''}`}>
+                <button
+                  type="button"
+                  className="rs-active-radio"
+                  onClick={() => !isActive && setActive(r)}
+                  disabled={!!busy}
+                  aria-pressed={isActive}
+                  title={isActive ? 'Active — shown at /for-hire' : 'Make this the active version'}
+                >
+                  <span className="rs-radio-dot" aria-hidden="true" />
+                </button>
+                <div className="rs-version-main">
+                  <div className="rs-version-head">
+                    <Link
+                      className="rs-version-title"
+                      to={`/admin?view=resume-tailor&r=${encodeURIComponent(r)}`}
+                    >
+                      {v.title || r}
+                    </Link>
+                    {isActive && <span className="rs-chip rs-chip-accent small-caps">active</span>}
+                    {vis !== 'public' && <span className="rs-chip small-caps">{vis}</span>}
+                    {busy === r && <span className="rs-chip small-caps">saving…</span>}
+                  </div>
+                  <div className="rs-version-meta">
+                    <code className="admin-record-rkey">{slug}</code>
+                    <span className="rs-dot">·</span>
+                    {counts.jobs} job{counts.jobs === 1 ? '' : 's'}
+                    <span className="rs-dot">·</span>
+                    {counts.bullets} bullet{counts.bullets === 1 ? '' : 's'}
+                  </div>
+                </div>
+                <div className="rs-version-actions">
+                  <Link
+                    className="admin-gate-button admin-gate-button-tight"
+                    to={`/admin?view=resume-tailor&r=${encodeURIComponent(r)}`}
+                  >
+                    <PenLine size={13} aria-hidden="true" /> Tailor
+                  </Link>
+                  <button
+                    type="button"
+                    className="admin-gate-button admin-gate-button-tight"
+                    onClick={() => duplicate(rec)}
+                    disabled={!!busy}
+                    title="Fork this version under a new slug"
+                  >
+                    <Copy size={13} aria-hidden="true" /> Duplicate
+                  </button>
+                  <Link
+                    className="admin-link-subtle rs-version-raw"
+                    to={`/admin?c=${encodeURIComponent(COLLECTIONS.resume)}&r=${encodeURIComponent(r)}`}
+                    title="Open the raw record editor"
+                  >
+                    record
+                  </Link>
+                  {vis !== 'private' && (
+                    <Link
+                      className="admin-link-subtle rs-version-raw"
+                      to={`/for-hire/${encodeURIComponent(slug)}`}
+                      title="View on the site"
+                    >
+                      <ExternalLink size={12} aria-hidden="true" /> view
+                    </Link>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Canonical record lists (jobs / education)                            */
+/* ------------------------------------------------------------------ */
+
+function RecordsSection({ heading, note, collection, records, labelFor, newLabel }) {
+  return (
+    <section className="admin-page-section rs-section">
+      <h2 className="admin-collection-group-heading small-caps">{heading}</h2>
+      <p className="admin-collection-group-note">{note}</p>
+      {(records || []).length === 0 ? (
+        <p className="placeholder-card">Nothing here yet.</p>
+      ) : (
+        <ul className="admin-record-list reveal-stagger">
+          {records.map((rec) => {
+            const r = rkeyFromUri(rec.uri);
+            const v = rec.value || {};
+            const highlights = Array.isArray(v.highlights) ? v.highlights : [];
+            const forks = highlights.reduce(
+              (n, h) => n + (Array.isArray(h.variants) ? h.variants.length : 0),
+              0,
+            );
+            const dates = formatDateRange(v);
+            return (
+              <li key={rec.uri} className="admin-record-row">
+                <Link
+                  to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(r)}`}
+                  className="admin-record-link"
+                >
+                  <code className="admin-record-rkey">{r}</code>
+                  <span className="admin-record-main">
+                    <span className="admin-record-preview">{labelFor(v) || r}</span>
+                    <span className="rs-record-counts">
+                      {highlights.length} bullet{highlights.length === 1 ? '' : 's'}
+                      {forks > 0 && ` · ${forks} fork${forks === 1 ? '' : 's'}`}
+                    </span>
+                  </span>
+                  {dates && <span className="admin-record-time small-caps">{dates}</span>}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <Link
+        className="rf-add rs-section-add"
+        to={`/admin?c=${encodeURIComponent(collection)}&mode=new`}
+      >
+        <Plus size={15} aria-hidden="true" /> {newLabel}
+      </Link>
+    </section>
+  );
+}

--- a/src/components/resume/ResumeWorkbench.jsx
+++ b/src/components/resume/ResumeWorkbench.jsx
@@ -1,0 +1,1069 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ChevronUp, ChevronDown, GitBranch, PenLine, Plus, RotateCcw, X } from 'lucide-react';
+import PageShell from '../PageShell.jsx';
+import { AdminEditorSkeleton } from '../Skeleton.jsx';
+import { SkillGroupsField, ContactField } from '../resumeFields.jsx';
+import { useEditMode } from '../../hooks/useEditMode.jsx';
+import { COLLECTIONS } from '../../config.js';
+import { rkeyFromAtUri } from '../../lib/atproto.js';
+import {
+  formatDateRange,
+  parseHighlightRef,
+  makeHighlightRef,
+  nextHighlightId,
+  nextVariantId,
+  resolveHighlightRef,
+  collectHighlightUsage,
+} from '../../lib/resumeHelpers.js';
+import { useResumeBundle } from './useResumeBundle.js';
+import './resumeStudio.css';
+
+/**
+ * The tailoring workbench — a resume-centric editor for one version.
+ *
+ * Everything you'd do to adapt a resume for an audience happens on this one
+ * page: reframe the headline/summary, pick and order jobs, and work the
+ * bullets — include/exclude, reorder, re-word, and fork a bullet into an
+ * alternate phrasing that only this version uses.
+ *
+ * Bullet copy lives on the canonical job/education records, so those edits are
+ * *staged* here (the touched records are listed next to Save) and written back
+ * together with the resume in one save. Forking creates a variant on the job
+ * (`highlights[].variants`) and points this resume's selection at it
+ * (`highlightIds: ["h3#v2"]`); the canonical text and every other version stay
+ * untouched.
+ */
+
+const KINDS = {
+  job: {
+    listKey: 'entries',
+    refKey: 'job',
+    collection: COLLECTIONS.resumeJob,
+    overrides: true,
+    heading: 'Experience',
+    noun: 'job',
+  },
+  education: {
+    listKey: 'education',
+    refKey: 'education',
+    collection: COLLECTIONS.resumeEducation,
+    overrides: false,
+    heading: 'Education',
+    noun: 'education entry',
+  },
+};
+
+/** Label a canonical record for card heads and pickers. */
+function recordLabel(kind, value) {
+  if (kind === 'job') {
+    return [value?.title, value?.organization].filter(Boolean).join(' · ');
+  }
+  return [value?.institution, value?.studyType || value?.area].filter(Boolean).join(' · ');
+}
+
+/** The refs an entry currently selects — explicit list, or the default set. */
+function refsFor(entry, value) {
+  if (Array.isArray(entry?.highlightIds)) return entry.highlightIds;
+  const hs = Array.isArray(value?.highlights) ? value.highlights : [];
+  return hs.filter((h) => (h.visibility || 'public') !== 'private').map((h) => h.id);
+}
+
+function moveItem(arr, from, to) {
+  if (to < 0 || to >= arr.length) return arr;
+  const next = arr.slice();
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
+export default function ResumeWorkbench({ agent, did, rkey }) {
+  const navigate = useNavigate();
+  const { setPageEditor } = useEditMode();
+  const { resumes, jobs, education, loading: bundleLoading, error: loadError } = useResumeBundle(agent, did);
+
+  // The resume value being tailored, plus staged drafts of every canonical
+  // job/education record (bullet copy edits and forks land on those).
+  const [draft, setDraft] = useState(null);
+  const [recordDrafts, setRecordDrafts] = useState(() => new Map()); // uri → value
+  const [dirtyUris, setDirtyUris] = useState(() => new Set());
+  const [resumeDirty, setResumeDirty] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [error, setError] = useState(null);
+  // One bullet's copy editor open at a time: `${listKey}:${uri}:${baseId}`.
+  const [editingKey, setEditingKey] = useState(null);
+
+  // Initialize drafts once per rkey, from the loaded bundle.
+  const initializedFor = useRef(null);
+  useEffect(() => {
+    if (bundleLoading || initializedFor.current === rkey) return;
+    const rec = (resumes || []).find((r) => rkeyFromAtUri(r.uri) === rkey);
+    if (!rec) {
+      setNotFound(true);
+      initializedFor.current = rkey;
+      return;
+    }
+    const m = new Map();
+    for (const r of [...(jobs || []), ...(education || [])]) {
+      m.set(r.uri, JSON.parse(JSON.stringify(r.value)));
+    }
+    setDraft(JSON.parse(JSON.stringify(rec.value)));
+    setRecordDrafts(m);
+    setDirtyUris(new Set());
+    setResumeDirty(false);
+    setNotFound(false);
+    initializedFor.current = rkey;
+  }, [bundleLoading, resumes, jobs, education, rkey]);
+
+  const isLoading = bundleLoading || (!draft && !notFound);
+  const dirty = resumeDirty || dirtyUris.size > 0;
+
+  // Other versions, for "also shown on …" context when editing shared copy.
+  const otherResumes = useMemo(
+    () => (resumes || []).filter((r) => rkeyFromAtUri(r.uri) !== rkey),
+    [resumes, rkey],
+  );
+
+  /* ---------------------------- mutations --------------------------- */
+
+  const patchDraft = useCallback((patch) => {
+    setDraft((prev) => ({ ...(prev || {}), ...patch }));
+    setResumeDirty(true);
+    setSavedFlash(false);
+  }, []);
+
+  const stageRecord = useCallback((uri, nextValue) => {
+    setRecordDrafts((prev) => {
+      const next = new Map(prev);
+      next.set(uri, nextValue);
+      return next;
+    });
+    setDirtyUris((prev) => new Set(prev).add(uri));
+    setSavedFlash(false);
+  }, []);
+
+  const patchEntry = useCallback((listKey, index, patch) => {
+    setDraft((prev) => {
+      const list = Array.isArray(prev?.[listKey]) ? prev[listKey].slice() : [];
+      list[index] = { ...list[index], ...patch };
+      // `undefined` values mean "drop the key" (e.g. clearing an override or
+      // resetting a selection to the default-all state).
+      for (const k of Object.keys(list[index])) {
+        if (list[index][k] === undefined) delete list[index][k];
+      }
+      return { ...prev, [listKey]: list };
+    });
+    setResumeDirty(true);
+    setSavedFlash(false);
+  }, []);
+
+  const moveEntry = useCallback((listKey, from, to) => {
+    setDraft((prev) => {
+      const list = Array.isArray(prev?.[listKey]) ? prev[listKey] : [];
+      return { ...prev, [listKey]: moveItem(list, from, to) };
+    });
+    setResumeDirty(true);
+  }, []);
+
+  const removeEntry = useCallback((listKey, index) => {
+    setDraft((prev) => {
+      const list = (prev?.[listKey] || []).slice();
+      list.splice(index, 1);
+      return { ...prev, [listKey]: list };
+    });
+    setResumeDirty(true);
+  }, []);
+
+  const addEntry = useCallback((listKey, refKey, uri) => {
+    setDraft((prev) => {
+      const list = Array.isArray(prev?.[listKey]) ? prev[listKey] : [];
+      return { ...prev, [listKey]: [...list, { [refKey]: uri }] };
+    });
+    setResumeDirty(true);
+  }, []);
+
+  /* ----------------------------- saving ----------------------------- */
+
+  const save = useCallback(async () => {
+    if (saving || !draft) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const now = new Date().toISOString();
+      // Canonical records first, so the resume never points at bullets that
+      // don't exist yet (freshly forked variants, added bullets).
+      for (const uri of dirtyUris) {
+        const parts = String(uri).replace(/^at:\/\//, '').split('/');
+        const [, collection, r] = parts;
+        const value = recordDrafts.get(uri);
+        if (!collection || !r || !value) continue;
+        await agent.com.atproto.repo.putRecord({
+          repo: did,
+          collection,
+          rkey: r,
+          record: { ...value, $type: value.$type || collection, updatedAt: now },
+        });
+      }
+      const record = { ...draft, $type: COLLECTIONS.resume, updatedAt: now };
+      if (!record.createdAt) record.createdAt = now;
+      for (const k of ['headline', 'summary']) {
+        if (!record[k]) delete record[k];
+      }
+      for (const k of ['entries', 'education', 'skills']) {
+        if (Array.isArray(record[k]) && record[k].length === 0) delete record[k];
+      }
+      if (!record.contact) delete record.contact;
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: COLLECTIONS.resume,
+        rkey,
+        record,
+      });
+      setDirtyUris(new Set());
+      setResumeDirty(false);
+      setSavedFlash(true);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [agent, did, rkey, draft, recordDrafts, dirtyUris, saving]);
+
+  const remove = useCallback(async () => {
+    if (deleting) return;
+    if (!window.confirm(`Delete this resume version (${rkey})? The jobs and their bullets stay — only the version is removed.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await agent.com.atproto.repo.deleteRecord({
+        repo: did,
+        collection: COLLECTIONS.resume,
+        rkey,
+      });
+      navigate('/admin?view=resume');
+    } catch (err) {
+      setError(err?.message || String(err));
+      setDeleting(false);
+    }
+  }, [agent, did, rkey, deleting, navigate]);
+
+  const close = useCallback(() => {
+    if (dirty && !window.confirm('Discard unsaved changes?')) return;
+    navigate('/admin?view=resume');
+  }, [dirty, navigate]);
+
+  // Ride the bottom-chrome edit bar (same contract as the record editor page).
+  const saveRef = useRef(null);
+  const removeRef = useRef(null);
+  const closeRef = useRef(null);
+  saveRef.current = save;
+  removeRef.current = remove;
+  closeRef.current = close;
+  useEffect(() => {
+    setPageEditor({
+      save: () => saveRef.current?.(),
+      remove: () => removeRef.current?.(),
+      close: () => closeRef.current?.(),
+      saving,
+      deleting,
+      loading: isLoading || notFound,
+      canDelete: true,
+      isNew: false,
+    });
+    return () => setPageEditor(null);
+  }, [setPageEditor, saving, deleting, isLoading, notFound]);
+
+  // Losing a workbench session to a stray tab-close hurts; warn while dirty.
+  useEffect(() => {
+    if (!dirty) return undefined;
+    const handler = (e) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [dirty]);
+
+  /* ----------------------------- render ----------------------------- */
+
+  const headTitle = `Tailor — ${draft?.title || rkey} — Admin — dame.is`;
+
+  if (notFound) {
+    return (
+      <PageShell title="Tailor resume" headTitle={headTitle}>
+        <p className="placeholder-card">
+          No resume version <code>{rkey}</code>.{' '}
+          <Link to="/admin?view=resume">Back to the studio.</Link>
+        </p>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell title={draft?.title ? `Tailor · ${draft.title}` : 'Tailor resume'} headTitle={headTitle}>
+      <div className="admin-toolbar">
+        <Link to="/admin?view=resume" className="admin-link-subtle">← Resume studio</Link>
+        <code className="admin-record-rkey">{rkey}</code>
+        {dirty && !saving && (
+          <span className="rs-chip rs-chip-warn small-caps" title={
+            dirtyUris.size > 0
+              ? 'Includes copy edits on the shared job records — saving writes those too.'
+              : undefined
+          }>
+            unsaved{dirtyUris.size > 0 ? ` · ${dirtyUris.size} shared record${dirtyUris.size === 1 ? '' : 's'}` : ''}
+          </span>
+        )}
+        {savedFlash && <span className="rs-chip rs-chip-accent small-caps">saved</span>}
+        <span className="rw-toolbar-links">
+          <Link
+            className="admin-link-subtle"
+            to={`/admin?c=${encodeURIComponent(COLLECTIONS.resume)}&r=${encodeURIComponent(rkey)}`}
+          >
+            raw record
+          </Link>
+          {draft && (draft.visibility || 'private') !== 'private' && (
+            <Link className="admin-link-subtle" to={`/for-hire/${encodeURIComponent(draft.slug || rkey)}`}>
+              view ↗
+            </Link>
+          )}
+        </span>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+      {loadError && <p className="admin-error">{loadError}</p>}
+
+      {isLoading ? (
+        <AdminEditorSkeleton fields={5} />
+      ) : (
+        <div className="rw reveal">
+          <FramingSection draft={draft} patchDraft={patchDraft} />
+
+          {['job', 'education'].map((kind) => (
+            <EntriesSection
+              key={kind}
+              kind={kind}
+              draft={draft}
+              records={kind === 'job' ? jobs : education}
+              recordDrafts={recordDrafts}
+              dirtyUris={dirtyUris}
+              otherResumes={otherResumes}
+              resumeSlug={draft?.slug || rkey}
+              editingKey={editingKey}
+              setEditingKey={setEditingKey}
+              patchEntry={patchEntry}
+              moveEntry={moveEntry}
+              removeEntry={removeEntry}
+              addEntry={addEntry}
+              stageRecord={stageRecord}
+            />
+          ))}
+
+          <section className="rw-section">
+            <h2 className="admin-collection-group-heading small-caps">Skills</h2>
+            <p className="admin-collection-group-note">
+              Skill groups live on the version itself — emphasis is the most audience-specific part.
+            </p>
+            <SkillGroupsField
+              value={draft?.skills}
+              onChange={(v) => patchDraft({ skills: v })}
+            />
+          </section>
+
+          <section className="rw-section">
+            <h2 className="admin-collection-group-heading small-caps">Contact</h2>
+            <p className="admin-collection-group-note">
+              Leave blank to fall back to the site profile.
+            </p>
+            <ContactField
+              value={draft?.contact}
+              onChange={(v) => patchDraft({ contact: v })}
+            />
+          </section>
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Framing (the version's own copy)                                     */
+/* ------------------------------------------------------------------ */
+
+function FramingSection({ draft, patchDraft }) {
+  return (
+    <section className="rw-section">
+      <h2 className="admin-collection-group-heading small-caps">Framing</h2>
+      <p className="admin-collection-group-note">
+        This version's own copy — name, headline, and summary. Job facts stay on the job records.
+      </p>
+      <div className="rw-framing">
+        <label className="rf-inline-field rf-inline-field-block">
+          <span className="rf-inline-label">Title (internal name)</span>
+          <input
+            className="admin-input"
+            type="text"
+            value={draft?.title ?? ''}
+            placeholder="Product & design résumé"
+            onChange={(e) => patchDraft({ title: e.target.value })}
+          />
+        </label>
+        <label className="rf-inline-field rf-inline-field-block">
+          <span className="rf-inline-label">Slug (URL at /for-hire/…)</span>
+          <input
+            className="admin-input"
+            type="text"
+            value={draft?.slug ?? ''}
+            onChange={(e) => patchDraft({ slug: e.target.value })}
+          />
+        </label>
+        <label className="rf-inline-field rf-inline-field-block rw-framing-wide">
+          <span className="rf-inline-label">Headline</span>
+          <input
+            className="admin-input"
+            type="text"
+            value={draft?.headline ?? ''}
+            placeholder="Creative Technologist & Product Designer"
+            onChange={(e) => patchDraft({ headline: e.target.value })}
+          />
+        </label>
+        <label className="rf-inline-field rf-inline-field-block rw-framing-wide">
+          <span className="rf-inline-label">Summary (Markdown)</span>
+          <textarea
+            className="admin-input admin-textarea"
+            rows={5}
+            value={draft?.summary ?? ''}
+            onChange={(e) => patchDraft({ summary: e.target.value })}
+          />
+        </label>
+        <label className="rf-inline-field">
+          <span className="rf-inline-label">Visibility</span>
+          <select
+            className="admin-input rf-select-sm"
+            value={draft?.visibility || 'private'}
+            onChange={(e) => patchDraft({ visibility: e.target.value })}
+          >
+            <option value="public">public — listed + rendered</option>
+            <option value="unlisted">unlisted — URL only</option>
+            <option value="private">private — not rendered</option>
+          </select>
+        </label>
+        <label className="admin-checkbox rf-checkbox">
+          <input
+            type="checkbox"
+            checked={Boolean(draft?.featured)}
+            onChange={(e) => patchDraft({ featured: e.target.checked })}
+          />
+          <span>Active — the default at /for-hire (keep to one version)</span>
+        </label>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Experience / education entries                                       */
+/* ------------------------------------------------------------------ */
+
+function EntriesSection({
+  kind,
+  draft,
+  records,
+  recordDrafts,
+  dirtyUris,
+  otherResumes,
+  resumeSlug,
+  editingKey,
+  setEditingKey,
+  patchEntry,
+  moveEntry,
+  removeEntry,
+  addEntry,
+  stageRecord,
+}) {
+  const { listKey, refKey, collection, heading, noun } = KINDS[kind];
+  const entries = Array.isArray(draft?.[listKey]) ? draft[listKey] : [];
+
+  const referenced = new Set(entries.map((e) => e?.[refKey]).filter(Boolean));
+  const available = (records || []).filter((r) => !referenced.has(r.uri));
+
+  return (
+    <section className="rw-section">
+      <h2 className="admin-collection-group-heading small-caps">{heading}</h2>
+      <p className="admin-collection-group-note">
+        {kind === 'job'
+          ? 'Which jobs this version shows, in order — and per job, exactly which bullets, in which phrasing.'
+          : 'Which education records this version shows, in order.'}
+      </p>
+
+      {entries.length === 0 && (
+        <p className="admin-field-hint">No {noun} on this version yet — add one below.</p>
+      )}
+
+      <div className="rw-entries">
+        {entries.map((entry, i) => (
+          <EntryCard
+            key={`${entry?.[refKey] || 'missing'}-${i}`}
+            kind={kind}
+            entry={entry}
+            index={i}
+            count={entries.length}
+            recordValue={recordDrafts.get(entry?.[refKey])}
+            recordUri={entry?.[refKey]}
+            recordDirty={dirtyUris.has(entry?.[refKey])}
+            otherResumes={otherResumes}
+            resumeSlug={resumeSlug}
+            editingKey={editingKey}
+            setEditingKey={setEditingKey}
+            patchEntry={patchEntry}
+            moveEntry={moveEntry}
+            removeEntry={removeEntry}
+            stageRecord={stageRecord}
+          />
+        ))}
+      </div>
+
+      <AddEntryRow
+        noun={noun}
+        kind={kind}
+        available={available}
+        collection={collection}
+        onAdd={(uri) => addEntry(listKey, refKey, uri)}
+      />
+    </section>
+  );
+}
+
+function AddEntryRow({ noun, kind, available, collection, onAdd }) {
+  const [pick, setPick] = useState('');
+  return (
+    <div className="rw-add-entry">
+      {available.length > 0 ? (
+        <>
+          <select
+            className="admin-input rf-ref-select"
+            value={pick}
+            onChange={(e) => setPick(e.target.value)}
+          >
+            <option value="">— add a {noun} to this version —</option>
+            {available.map((r) => (
+              <option key={r.uri} value={r.uri}>
+                {recordLabel(kind, r.value) || rkeyFromAtUri(r.uri)}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="admin-gate-button admin-gate-button-tight"
+            disabled={!pick}
+            onClick={() => {
+              onAdd(pick);
+              setPick('');
+            }}
+          >
+            <Plus size={13} aria-hidden="true" /> Add
+          </button>
+        </>
+      ) : (
+        <p className="admin-field-hint">
+          Every {noun} is already on this version.
+        </p>
+      )}
+      <Link
+        className="admin-link-subtle rw-add-entry-new"
+        to={`/admin?c=${encodeURIComponent(collection)}&mode=new`}
+      >
+        New {noun} record →
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * One job/education on this version: header facts, per-version overrides, and
+ * the bullet board (included bullets in this version's order, then the rest).
+ */
+function EntryCard({
+  kind,
+  entry,
+  index,
+  count,
+  recordValue,
+  recordUri,
+  recordDirty,
+  otherResumes,
+  resumeSlug,
+  editingKey,
+  setEditingKey,
+  patchEntry,
+  moveEntry,
+  removeEntry,
+  stageRecord,
+}) {
+  const { listKey, refKey, collection, overrides } = KINDS[kind];
+  const highlights = Array.isArray(recordValue?.highlights) ? recordValue.highlights : [];
+  const explicit = Array.isArray(entry?.highlightIds);
+  const refs = refsFor(entry, recordValue);
+  const refByBase = new Map(refs.map((r) => [parseHighlightRef(r).id, r]));
+  const excluded = highlights.filter((h) => !refByBase.has(h.id));
+  const rkey = rkeyFromAtUri(recordUri);
+
+  // How the *other* versions use this record's bullets — context for editing
+  // shared (canonical) copy.
+  const usage = useMemo(
+    () =>
+      collectHighlightUsage({
+        resumes: otherResumes,
+        recordUri,
+        listKey,
+        refKey,
+        highlights,
+      }),
+    [otherResumes, recordUri, listKey, refKey, highlights],
+  );
+
+  const setRefs = (next) => patchEntry(listKey, index, { highlightIds: next });
+
+  const toggleBullet = (baseId, on) => {
+    if (on) {
+      setRefs([...refs, baseId]);
+    } else {
+      const key = `${listKey}:${recordUri}:${baseId}`;
+      if (editingKey === key) setEditingKey(null);
+      setRefs(refs.filter((r) => parseHighlightRef(r).id !== baseId));
+    }
+  };
+
+  const moveBullet = (pos, dir) => setRefs(moveItem(refs, pos, pos + dir));
+
+  const setVariant = (baseId, variantId) =>
+    setRefs(refs.map((r) => (parseHighlightRef(r).id === baseId ? makeHighlightRef(baseId, variantId || null) : r)));
+
+  const setBulletText = (baseId, variantId, text) => {
+    const nextHighlights = highlights.map((h) => {
+      if (h.id !== baseId) return h;
+      if (variantId) {
+        return {
+          ...h,
+          variants: (h.variants || []).map((v) => (v.id === variantId ? { ...v, text } : v)),
+        };
+      }
+      return { ...h, text };
+    });
+    stageRecord(recordUri, { ...recordValue, highlights: nextHighlights });
+  };
+
+  // Fork the phrasing this version currently shows into a new variant on the
+  // canonical record, select it here, and open it for rewording.
+  const forkBullet = (baseId) => {
+    const h = highlights.find((x) => x.id === baseId);
+    if (!h) return;
+    const currentRef = refByBase.get(baseId) || baseId;
+    const currentText = resolveHighlightRef(recordValue, currentRef)?.text ?? h.text ?? '';
+    const vid = nextVariantId(h.variants);
+    const nextHighlights = highlights.map((x) =>
+      x.id === baseId
+        ? { ...x, variants: [...(x.variants || []), { id: vid, text: currentText, label: resumeSlug }] }
+        : x,
+    );
+    stageRecord(recordUri, { ...recordValue, highlights: nextHighlights });
+    setRefs(refs.map((r) => (parseHighlightRef(r).id === baseId ? makeHighlightRef(baseId, vid) : r)));
+    setEditingKey(`${listKey}:${recordUri}:${baseId}`);
+  };
+
+  const addBullet = () => {
+    const hid = nextHighlightId(highlights);
+    stageRecord(recordUri, {
+      ...recordValue,
+      highlights: [...highlights, { id: hid, text: '', visibility: 'public' }],
+    });
+    setRefs([...refs, hid]);
+    setEditingKey(`${listKey}:${recordUri}:${hid}`);
+  };
+
+  if (recordUri && !recordValue) {
+    return (
+      <div className="rw-entry rf-card">
+        <div className="rf-card-head">
+          <p className="admin-error-inline rw-entry-missing">
+            Referenced record not found: <code>{recordUri}</code>
+          </p>
+          <div className="rf-controls">
+            <button
+              type="button"
+              className="rf-icon-btn rf-icon-btn-danger"
+              onClick={() => removeEntry(listKey, index)}
+              aria-label="Remove entry"
+              title="Remove entry"
+            >
+              <X size={15} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const overrideOpen = Boolean(entry?.titleOverride || entry?.summaryOverride);
+
+  return (
+    <div className="rw-entry rf-card">
+      <div className="rw-entry-head">
+        <div className="rw-entry-title">
+          <strong>{recordLabel(kind, recordValue) || rkey}</strong>
+          <span className="rw-entry-dates">{formatDateRange(recordValue)}</span>
+          {recordDirty && (
+            <span className="rs-chip rs-chip-warn small-caps" title="This shared record has staged copy edits — Save writes them.">
+              edited
+            </span>
+          )}
+        </div>
+        <div className="rf-controls">
+          <Link
+            className="rf-icon-btn"
+            to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(rkey || '')}`}
+            aria-label="Open the full record"
+            title="Open the full record (facts, dates, all bullets)"
+          >
+            <PenLine size={15} aria-hidden="true" />
+          </Link>
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => moveEntry(listKey, index, index - 1)}
+            disabled={index === 0}
+            aria-label="Move up"
+            title="Move up"
+          >
+            <ChevronUp size={15} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => moveEntry(listKey, index, index + 1)}
+            disabled={index === count - 1}
+            aria-label="Move down"
+            title="Move down"
+          >
+            <ChevronDown size={15} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="rf-icon-btn rf-icon-btn-danger"
+            onClick={() => removeEntry(listKey, index)}
+            aria-label="Remove from this version"
+            title="Remove from this version (the record itself stays)"
+          >
+            <X size={15} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {overrides && (
+        <details className="rw-overrides" open={overrideOpen}>
+          <summary className="rf-inline-label">Title & summary for this version</summary>
+          <div className="rf-overrides">
+            <label className="rf-inline-field rf-inline-field-block">
+              <span className="rf-inline-label">Title override</span>
+              <input
+                className="admin-input"
+                type="text"
+                value={entry?.titleOverride ?? ''}
+                placeholder={recordValue?.title || 'Falls back to the job title'}
+                onChange={(e) => patchEntry(listKey, index, { titleOverride: e.target.value || undefined })}
+              />
+            </label>
+            <label className="rf-inline-field rf-inline-field-block">
+              <span className="rf-inline-label">Summary override</span>
+              <textarea
+                className="admin-input admin-textarea"
+                rows={2}
+                value={entry?.summaryOverride ?? ''}
+                placeholder={recordValue?.summary || 'Falls back to the job summary'}
+                onChange={(e) => patchEntry(listKey, index, { summaryOverride: e.target.value || undefined })}
+              />
+            </label>
+          </div>
+        </details>
+      )}
+
+      <div className="rw-bullets">
+        <div className="rw-bullets-head">
+          <span className="rf-inline-label">
+            {refs.length} of {highlights.length} bullet{highlights.length === 1 ? '' : 's'} shown
+            {!explicit && highlights.length > 0 && ' — default (all, job order)'}
+          </span>
+          {explicit && (
+            <button
+              type="button"
+              className="admin-link-subtle rw-reset"
+              onClick={() => {
+                setEditingKey(null);
+                patchEntry(listKey, index, { highlightIds: undefined });
+              }}
+              title="Back to the default: every non-private bullet, in the job's order, canonical phrasing"
+            >
+              <RotateCcw size={12} aria-hidden="true" /> reset to default
+            </button>
+          )}
+        </div>
+
+        {highlights.length === 0 && (
+          <p className="admin-field-hint">This record has no bullets yet.</p>
+        )}
+
+        <ul className="rw-bullet-list">
+          {refs.map((ref, pos) => {
+            const { id: baseId } = parseHighlightRef(ref);
+            const h = highlights.find((x) => x.id === baseId);
+            if (!h) {
+              return (
+                <li key={ref} className="rw-bullet is-missing">
+                  <span className="admin-error-inline">
+                    Unknown bullet <code>{ref}</code>
+                  </span>
+                  <button
+                    type="button"
+                    className="admin-link-subtle"
+                    onClick={() => setRefs(refs.filter((r) => r !== ref))}
+                  >
+                    remove
+                  </button>
+                </li>
+              );
+            }
+            return (
+              <BulletRow
+                key={ref}
+                included
+                refString={ref}
+                highlight={h}
+                recordValue={recordValue}
+                pos={pos}
+                lastPos={refs.length - 1}
+                editing={editingKey === `${listKey}:${recordUri}:${baseId}`}
+                usageRows={usage.get(baseId) || []}
+                onToggle={(on) => toggleBullet(baseId, on)}
+                onMove={(dir) => moveBullet(pos, dir)}
+                onSetVariant={(vid) => setVariant(baseId, vid)}
+                onFork={() => forkBullet(baseId)}
+                onStartEdit={() => setEditingKey(`${listKey}:${recordUri}:${baseId}`)}
+                onStopEdit={() => setEditingKey(null)}
+                onEditText={(text) => {
+                  const { variantId } = parseHighlightRef(refByBase.get(baseId) || baseId);
+                  setBulletText(baseId, variantId, text);
+                }}
+              />
+            );
+          })}
+        </ul>
+
+        {excluded.length > 0 && (
+          <>
+            <div className="rw-excluded-divider small-caps">not on this version</div>
+            <ul className="rw-bullet-list rw-bullet-list-excluded">
+              {excluded.map((h) => (
+                <BulletRow
+                  key={h.id}
+                  included={false}
+                  refString={h.id}
+                  highlight={h}
+                  recordValue={recordValue}
+                  usageRows={usage.get(h.id) || []}
+                  onToggle={(on) => toggleBullet(h.id, on)}
+                />
+              ))}
+            </ul>
+          </>
+        )}
+
+        <button type="button" className="rf-add rw-add-bullet" onClick={addBullet}>
+          <Plus size={15} aria-hidden="true" /> Add bullet
+          <span className="rw-add-bullet-note">(added to the shared {KINDS[kind].noun} record)</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* One bullet                                                           */
+/* ------------------------------------------------------------------ */
+
+function BulletRow({
+  included,
+  refString,
+  highlight: h,
+  recordValue,
+  pos = 0,
+  lastPos = 0,
+  editing = false,
+  usageRows,
+  onToggle,
+  onMove,
+  onSetVariant,
+  onFork,
+  onStartEdit,
+  onStopEdit,
+  onEditText,
+}) {
+  const { variantId } = parseHighlightRef(refString);
+  const variants = Array.isArray(h.variants) ? h.variants : [];
+  const resolved = resolveHighlightRef(recordValue, refString);
+  const shownText = resolved?.text ?? h.text ?? '';
+  const activeVariant = variantId ? variants.find((v) => v.id === variantId) : null;
+
+  // Other versions showing this bullet — and specifically its canonical text —
+  // to flag when a re-word would ripple beyond this version.
+  const othersOnBullet = [];
+  const seen = new Set();
+  for (const u of usageRows || []) {
+    if (seen.has(u.rkey)) continue;
+    seen.add(u.rkey);
+    othersOnBullet.push(u);
+  }
+  const othersOnCanonical = othersOnBullet.filter((u) =>
+    (usageRows || []).some((r) => r.rkey === u.rkey && !r.variantId),
+  );
+
+  return (
+    <li className={`rw-bullet${included ? '' : ' is-excluded'}${editing ? ' is-editing' : ''}`}>
+      <label className="admin-checkbox rw-bullet-check" title={included ? 'Shown on this version' : 'Include on this version'}>
+        <input type="checkbox" checked={included} onChange={(e) => onToggle(e.target.checked)} />
+      </label>
+
+      <div className="rw-bullet-body">
+        {editing ? (
+          <div className="rw-bullet-editor">
+            <textarea
+              className="admin-input admin-textarea"
+              rows={3}
+              autoFocus
+              value={shownText}
+              placeholder="Shipped X, driving Y% growth…"
+              onChange={(e) => onEditText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape' || (e.key === 'Enter' && (e.metaKey || e.ctrlKey))) {
+                  e.preventDefault();
+                  onStopEdit();
+                }
+              }}
+            />
+            <div className="rw-bullet-editor-foot">
+              {variantId ? (
+                <span className="admin-field-hint">
+                  Editing the <strong>{activeVariant?.label || variantId}</strong> phrasing — only
+                  versions that pick it change.
+                </span>
+              ) : othersOnCanonical.length > 0 ? (
+                <span className="admin-field-hint rw-shared-warning">
+                  Canonical text — also shown on{' '}
+                  {othersOnCanonical.map((u) => u.label).join(', ')}. Fork to re-word just this
+                  version.
+                </span>
+              ) : (
+                <span className="admin-field-hint">
+                  Canonical text — no other version shows it.
+                </span>
+              )}
+              <div className="rw-bullet-editor-actions">
+                {!variantId && (
+                  <button type="button" className="admin-link-subtle" onClick={onFork}>
+                    <GitBranch size={12} aria-hidden="true" /> fork instead
+                  </button>
+                )}
+                <button type="button" className="admin-gate-button admin-gate-button-tight" onClick={onStopEdit}>
+                  Done
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="rw-bullet-text"
+            onClick={() => (included && onStartEdit ? onStartEdit() : onToggle(true))}
+            title={included ? 'Click to edit this bullet’s copy' : 'Include on this version'}
+          >
+            {shownText || <em>(empty bullet)</em>}
+          </button>
+        )}
+
+        <div className="rw-bullet-meta">
+          <code className="rf-id">{refString}</code>
+          {h.featured && <span className="rf-badge rf-badge-accent">featured</span>}
+          {h.metric && <span className="rf-badge">metric</span>}
+          {(h.visibility || 'public') !== 'public' && <span className="rf-badge">{h.visibility}</span>}
+          {included && variants.length > 0 && (
+            <label className="rf-inline-field rw-phrasing">
+              <span className="rf-inline-label">phrasing</span>
+              <select
+                className="admin-input rf-select-sm"
+                value={variantId || ''}
+                onChange={(e) => onSetVariant(e.target.value || null)}
+              >
+                <option value="">canonical</option>
+                {variants.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.label || v.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {!included && variants.length > 0 && (
+            <span className="rf-badge">{variants.length} fork{variants.length === 1 ? '' : 's'}</span>
+          )}
+          {included && !editing && (
+            <>
+              <button type="button" className="admin-link-subtle rw-bullet-action" onClick={onStartEdit}>
+                <PenLine size={12} aria-hidden="true" /> reword
+              </button>
+              <button
+                type="button"
+                className="admin-link-subtle rw-bullet-action"
+                onClick={onFork}
+                title="Copy this phrasing into a new variant only this version uses"
+              >
+                <GitBranch size={12} aria-hidden="true" /> fork
+              </button>
+            </>
+          )}
+          {othersOnBullet.length > 0 && (
+            <span className="rf-usage" title={`Also shown on: ${othersOnBullet.map((u) => u.label).join(', ')}`}>
+              also on {othersOnBullet.map((u) => u.label).join(', ')}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {included && onMove && (
+        <div className="rf-controls rw-bullet-order">
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => onMove(-1)}
+            disabled={pos === 0}
+            aria-label="Move bullet up"
+            title="Move up"
+          >
+            <ChevronUp size={15} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => onMove(1)}
+            disabled={pos === lastPos}
+            aria-label="Move bullet down"
+            title="Move down"
+          >
+            <ChevronDown size={15} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/resume/resumeStudio.css
+++ b/src/components/resume/resumeStudio.css
@@ -1,0 +1,512 @@
+/* ------------------------------------------------------------------ */
+/* Resume studio (rs-) — the /admin?view=resume overview                */
+/* ------------------------------------------------------------------ */
+
+.rs-section {
+  margin-top: var(--space-7);
+}
+
+.rs-section:first-of-type {
+  margin-top: var(--space-5);
+}
+
+.rs-section > .admin-collection-group-heading {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.rs-section > .admin-collection-group-note {
+  margin-bottom: var(--space-4);
+}
+
+.rs-version-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.rs-version {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.rs-version:last-child {
+  border-bottom: none;
+}
+
+/* Featured / active picker: a quiet radio that fills when active. */
+.rs-active-radio {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  margin-top: 0.1rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.rs-radio-dot {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  border: 1px solid var(--rule);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.rs-active-radio:hover:not(:disabled) .rs-radio-dot {
+  border-color: var(--accent-soft);
+}
+
+.rs-version.is-active .rs-radio-dot {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 2px var(--page);
+}
+
+.rs-version-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.rs-version-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.rs-version-title {
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.rs-version-title:hover {
+  color: var(--accent);
+}
+
+.rs-version-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: var(--space-1);
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+  font-family: var(--sans);
+}
+
+.rs-dot {
+  color: var(--rule);
+}
+
+.rs-version-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.rs-version-actions .admin-gate-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.rs-version-raw {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  font-size: var(--text-xs);
+}
+
+.rs-chip {
+  font-family: var(--mono-ui);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  padding: 0.1em 0.45em;
+  border: 1px solid var(--rule-soft);
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.rs-chip-accent {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
+
+.rs-chip-warn {
+  color: var(--tan, #a88c5f);
+  border-color: currentColor;
+}
+
+.rs-record-counts {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+  font-family: var(--sans);
+}
+
+.rs-section-add {
+  margin-top: var(--space-3);
+  text-decoration: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tailoring workbench (rw-)                                            */
+/* ------------------------------------------------------------------ */
+
+.rw {
+  display: flex;
+  flex-direction: column;
+}
+
+.rw-section {
+  margin-top: var(--space-7);
+}
+
+.rw-section:first-of-type {
+  margin-top: var(--space-4);
+}
+
+.rw-section > .admin-collection-group-heading {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.rw-section > .admin-collection-group-note {
+  margin-bottom: var(--space-4);
+}
+
+.rw-toolbar-links {
+  margin-left: auto;
+  display: inline-flex;
+  gap: var(--space-3);
+}
+
+/* Framing grid: title/slug side by side, headline/summary full width. */
+.rw-framing {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3) var(--space-4);
+  align-items: end;
+}
+
+.rw-framing-wide {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 40rem) {
+  .rw-framing {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rw-entries {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.rw-entry {
+  gap: var(--space-3);
+}
+
+.rw-entry-head {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.rw-entry-title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  min-width: 0;
+  font-family: var(--serif);
+}
+
+.rw-entry-dates {
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+  font-family: var(--sans);
+  letter-spacing: 0.04em;
+}
+
+.rw-entry-head .rf-controls {
+  margin-left: auto;
+}
+
+.rw-entry-head a.rf-icon-btn {
+  text-decoration: none;
+}
+
+.rw-entry-missing {
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.rw-overrides > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.rw-overrides > summary::before {
+  content: '▸ ';
+}
+
+.rw-overrides[open] > summary::before {
+  content: '▾ ';
+}
+
+.rw-overrides[open] > .rf-overrides {
+  margin-top: var(--space-2);
+}
+
+/* --------------------------- bullet board -------------------------- */
+
+.rw-bullets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px dashed var(--rule-soft);
+}
+
+.rw-bullets-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.rw-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  font-size: var(--text-xs);
+}
+
+.rw-bullet-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rw-bullet {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--rule-soft) 55%, transparent);
+}
+
+.rw-bullet:last-child {
+  border-bottom: none;
+}
+
+.rw-bullet.is-editing {
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+}
+
+.rw-bullet-check {
+  padding-top: 0.15rem;
+  flex-shrink: 0;
+}
+
+.rw-bullet-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* The bullet copy itself reads as text but is a button → click to edit. */
+.rw-bullet-text {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: left;
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  color: var(--ink);
+  cursor: text;
+}
+
+.rw-bullet-text:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--accent-soft);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.rw-bullet-text em {
+  color: var(--ink-faint);
+}
+
+.rw-bullet-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: var(--text-xs);
+}
+
+.rw-bullet-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  font-size: var(--text-xs);
+}
+
+.rw-phrasing {
+  gap: var(--space-1);
+}
+
+.rw-bullet-order {
+  flex-shrink: 0;
+}
+
+.rw-bullet.is-excluded .rw-bullet-body {
+  opacity: 0.55;
+}
+
+.rw-bullet.is-excluded .rw-bullet-text {
+  cursor: pointer;
+}
+
+.rw-bullet.is-missing {
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.rw-excluded-divider {
+  margin-top: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+}
+
+.rw-excluded-divider::before,
+.rw-excluded-divider::after {
+  content: '';
+  height: 1px;
+  background: var(--rule-soft);
+  flex: 1;
+}
+
+.rw-bullet-list-excluded {
+  opacity: 0.9;
+}
+
+/* ----------------------------- editor ------------------------------ */
+
+.rw-bullet-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rw-bullet-editor-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.rw-bullet-editor-foot .admin-field-hint {
+  margin: 0;
+}
+
+.rw-shared-warning {
+  color: var(--tan, #a88c5f);
+}
+
+.rw-bullet-editor-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-left: auto;
+}
+
+.rw-bullet-editor-actions .admin-link-subtle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.rw-add-bullet {
+  margin-top: var(--space-1);
+}
+
+.rw-add-bullet-note {
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+}
+
+.rw-add-entry {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-4);
+}
+
+.rw-add-entry .rf-ref-select {
+  flex: 1;
+  min-width: 14rem;
+}
+
+.rw-add-entry .admin-gate-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.rw-add-entry-new {
+  font-size: var(--text-xs);
+}
+
+@media (max-width: 40rem) {
+  .rw-bullet {
+    flex-wrap: wrap;
+  }
+
+  .rw-bullet-order {
+    order: 3;
+    margin-left: auto;
+  }
+
+  .rs-version {
+    flex-wrap: wrap;
+  }
+
+  .rs-version-actions {
+    width: 100%;
+    justify-content: flex-start;
+    padding-left: calc(1.6rem + var(--space-3));
+  }
+}

--- a/src/components/resume/useResumeBundle.js
+++ b/src/components/resume/useResumeBundle.js
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { COLLECTIONS } from '../../config.js';
+
+/**
+ * Load the full resume working set — every resume version, job, and education
+ * record on the signed-in PDS — for the admin studio and tailoring workbench.
+ * Records come back as plain `{ uri, value }` objects (JSON round-tripped so
+ * drafts can be cloned/mutated safely). `reload()` refetches everything.
+ */
+export function useResumeBundle(agent, did) {
+  const [bundle, setBundle] = useState(null); // { resumes, jobs, education }
+  const [error, setError] = useState(null);
+  const [tick, setTick] = useState(0);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!agent || !did) return undefined;
+    setError(null);
+
+    async function listAll(collection) {
+      const all = [];
+      let cursor;
+      do {
+        const res = await agent.com.atproto.repo.listRecords({
+          repo: did,
+          collection,
+          limit: 100,
+          cursor,
+        });
+        const data = res?.data || res;
+        all.push(...(data?.records || []));
+        cursor = data?.cursor;
+      } while (cursor);
+      // Normalize to plain JSON so state updates can structurally clone freely.
+      return all.map((r) => ({ uri: r.uri, cid: r.cid, value: JSON.parse(JSON.stringify(r.value ?? {})) }));
+    }
+
+    (async () => {
+      try {
+        const [resumes, jobs, education] = await Promise.all([
+          listAll(COLLECTIONS.resume),
+          listAll(COLLECTIONS.resumeJob),
+          listAll(COLLECTIONS.resumeEducation),
+        ]);
+        if (!cancelled) setBundle({ resumes, jobs, education });
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || String(err));
+          setBundle({ resumes: [], jobs: [], education: [] });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did, tick]);
+
+  return {
+    resumes: bundle?.resumes || null,
+    jobs: bundle?.jobs || null,
+    education: bundle?.education || null,
+    loading: bundle === null,
+    error,
+    reload,
+  };
+}

--- a/src/components/resumeFields.jsx
+++ b/src/components/resumeFields.jsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ChevronUp, ChevronDown, Plus, X } from 'lucide-react';
+import { ChevronUp, ChevronDown, Copy, GitBranch, Plus, X } from 'lucide-react';
+import { COLLECTIONS } from '../config.js';
+import {
+  parseHighlightRef,
+  makeHighlightRef,
+  nextHighlightId,
+  nextVariantId,
+  resolveHighlightRef,
+  collectHighlightUsage,
+} from '../lib/resumeHelpers.js';
 
 /**
  * Structured form controls for the resume lexicons, replacing the raw-JSON
@@ -126,16 +135,61 @@ function useCollectionRecords(agent, did, collection) {
 /* Highlights (job / education achievement bullets)                     */
 /* ------------------------------------------------------------------ */
 
-/** Next unique `hN` id for a new highlight in this list. */
-function nextHighlightId(list) {
-  const used = new Set(list.map((h) => h?.id).filter(Boolean));
-  let n = list.length + 1;
-  while (used.has(`h${n}`)) n += 1;
-  return `h${n}`;
+/** Dedupe usage rows into short "which resumes" labels for a chip. */
+function usageSummary(rows) {
+  const labels = [];
+  const seen = new Set();
+  for (const u of rows || []) {
+    if (seen.has(u.rkey)) continue;
+    seen.add(u.rkey);
+    labels.push(u.label);
+  }
+  return labels;
 }
 
-export function HighlightsField({ value, onChange }) {
+/** "Used by primary, product-design" chip, or nothing when unused. */
+function UsageChip({ rows }) {
+  const labels = usageSummary(rows);
+  if (labels.length === 0) return null;
+  return (
+    <span
+      className="rf-usage"
+      title={`Selected by: ${labels.join(', ')}`}
+    >
+      used by {labels.join(', ')}
+    </span>
+  );
+}
+
+/**
+ * Bullet editor for a job/education record's `highlights`.
+ *
+ * Beyond text + flags, each bullet can be forked into **variants** — alternate
+ * phrasings of the same point that resumes pick individually (`h3#v2` refs).
+ * When `agent`/`did`/`recordUri` are provided, every resume is scanned so each
+ * bullet (and variant) shows which versions currently use it, and removals of
+ * in-use bullets ask first.
+ */
+export function HighlightsField({ value, onChange, agent, did, recordUri, usageKeys }) {
   const list = Array.isArray(value) ? value : [];
+
+  // Which resumes use these bullets. Only loaded when we know the record's
+  // own URI (i.e. editing an existing job/education record, not a new one).
+  const { records: resumes } = useCollectionRecords(
+    agent,
+    did,
+    recordUri ? COLLECTIONS.resume : null,
+  );
+  const usage = useMemo(() => {
+    if (!recordUri || !resumes) return new Map();
+    return collectHighlightUsage({
+      resumes,
+      recordUri,
+      listKey: usageKeys?.listKey || 'entries',
+      refKey: usageKeys?.refKey || 'job',
+      highlights: list,
+    });
+  }, [resumes, recordUri, usageKeys, list]);
 
   const update = (i, patch) => onChange(replaceAt(list, i, { ...list[i], ...patch }));
 
@@ -144,6 +198,59 @@ export function HighlightsField({ value, onChange }) {
       ...list,
       { id: nextHighlightId(list), text: '', visibility: 'public', featured: false, metric: false },
     ]);
+
+  const duplicate = (i) => {
+    const src = list[i];
+    const copy = JSON.parse(JSON.stringify(src));
+    copy.id = nextHighlightId(list);
+    delete copy.variants; // a duplicated bullet is a new point — forks stay with the original
+    const next = list.slice();
+    next.splice(i + 1, 0, copy);
+    onChange(next);
+  };
+
+  const remove = (i) => {
+    const h = list[i];
+    const used = usageSummary(usage.get(h?.id));
+    if (used.length > 0) {
+      const ok = window.confirm(
+        `“${truncateText(h?.text, 80)}” is selected by: ${used.join(', ')}.\n` +
+          'Removing it will drop the bullet from those resumes on your next save. Remove anyway?',
+      );
+      if (!ok) return;
+    }
+    onChange(removeAt(list, i));
+  };
+
+  const fork = (i) => {
+    const h = list[i];
+    const variants = Array.isArray(h.variants) ? h.variants : [];
+    const v = { id: nextVariantId(variants), text: h.text || '', label: '' };
+    update(i, { variants: [...variants, v] });
+  };
+
+  const updateVariant = (i, vi, patch) => {
+    const variants = (list[i].variants || []).slice();
+    variants[vi] = { ...variants[vi], ...patch };
+    update(i, { variants });
+  };
+
+  const removeVariant = (i, vi) => {
+    const h = list[i];
+    const v = (h.variants || [])[vi];
+    const rows = (usage.get(h?.id) || []).filter((u) => u.variantId === v?.id);
+    const used = usageSummary(rows);
+    if (used.length > 0) {
+      const ok = window.confirm(
+        `This phrasing is picked by: ${used.join(', ')}.\n` +
+          'Those resumes will fall back to the canonical text. Remove it anyway?',
+      );
+      if (!ok) return;
+    }
+    const variants = (h.variants || []).slice();
+    variants.splice(vi, 1);
+    update(i, { variants: variants.length ? variants : undefined });
+  };
 
   return (
     <div className="rf-list">
@@ -154,13 +261,56 @@ export function HighlightsField({ value, onChange }) {
         <div className="rf-card" key={h.id || i}>
           <div className="rf-card-head">
             <code className="rf-id">{h.id || '—'}</code>
-            <RowControls
-              index={i}
-              length={list.length}
-              onMove={(from, to) => onChange(move(list, from, to))}
-              onRemove={(idx) => onChange(removeAt(list, idx))}
-              removeLabel="Remove highlight"
-            />
+            <UsageChip rows={usage.get(h.id)} />
+            <div className="rf-controls">
+              <button
+                type="button"
+                className="rf-icon-btn"
+                onClick={() => fork(i)}
+                aria-label="Fork into a variant phrasing"
+                title="Fork — add an alternate phrasing resumes can pick"
+              >
+                <GitBranch size={15} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="rf-icon-btn"
+                onClick={() => duplicate(i)}
+                aria-label="Duplicate as a new bullet"
+                title="Duplicate as a new bullet"
+              >
+                <Copy size={15} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="rf-icon-btn"
+                onClick={() => onChange(move(list, i, i - 1))}
+                disabled={i === 0}
+                aria-label="Move up"
+                title="Move up"
+              >
+                <ChevronUp size={15} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="rf-icon-btn"
+                onClick={() => onChange(move(list, i, i + 1))}
+                disabled={i === list.length - 1}
+                aria-label="Move down"
+                title="Move down"
+              >
+                <ChevronDown size={15} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="rf-icon-btn rf-icon-btn-danger"
+                onClick={() => remove(i)}
+                aria-label="Remove highlight"
+                title="Remove highlight"
+              >
+                <X size={15} aria-hidden="true" />
+              </button>
+            </div>
           </div>
           <textarea
             className="admin-input admin-textarea"
@@ -169,6 +319,48 @@ export function HighlightsField({ value, onChange }) {
             placeholder="Shipped X, driving Y% growth…"
             onChange={(e) => update(i, { text: e.target.value })}
           />
+          {Array.isArray(h.variants) && h.variants.length > 0 && (
+            <div className="rf-variants">
+              <span className="rf-inline-label">
+                Variants — alternate phrasings of this same point
+              </span>
+              {h.variants.map((v, vi) => (
+                <div className="rf-variant" key={v.id || vi}>
+                  <div className="rf-card-head">
+                    <code className="rf-id">{makeHighlightRef(h.id, v.id)}</code>
+                    <input
+                      className="admin-input rf-variant-label"
+                      type="text"
+                      value={v.label ?? ''}
+                      placeholder="label, e.g. design-focused"
+                      onChange={(e) => updateVariant(i, vi, { label: e.target.value || undefined })}
+                    />
+                    <UsageChip
+                      rows={(usage.get(h.id) || []).filter((u) => u.variantId === v.id)}
+                    />
+                    <div className="rf-controls">
+                      <button
+                        type="button"
+                        className="rf-icon-btn rf-icon-btn-danger"
+                        onClick={() => removeVariant(i, vi)}
+                        aria-label="Remove variant"
+                        title="Remove variant"
+                      >
+                        <X size={15} aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+                  <textarea
+                    className="admin-input admin-textarea"
+                    rows={2}
+                    value={v.text ?? ''}
+                    placeholder="The same achievement, framed differently…"
+                    onChange={(e) => updateVariant(i, vi, { text: e.target.value })}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
           <div className="rf-inline">
             <label className="admin-checkbox rf-checkbox">
               <input
@@ -219,6 +411,11 @@ export function HighlightsField({ value, onChange }) {
       </button>
     </div>
   );
+}
+
+function truncateText(s, n) {
+  const str = String(s || '');
+  return str.length <= n ? str : `${str.slice(0, n - 1).trimEnd()}…`;
 }
 
 /* ------------------------------------------------------------------ */
@@ -275,7 +472,10 @@ export function RecordRefsField({ field, value, onChange, agent, did }) {
         const rec = byUri.get(uri);
         const highlights = Array.isArray(rec?.value?.highlights) ? rec.value.highlights : [];
         const explicit = Array.isArray(entry.highlightIds);
-        const includedSet = new Set(explicit ? entry.highlightIds : defaultHighlightIds(rec));
+        const refs = explicit ? entry.highlightIds : defaultHighlightIds(rec);
+        // Map of base highlight id → the full ref selecting it (bare or #variant).
+        const refByBase = new Map(refs.map((r) => [parseHighlightRef(r).id, r]));
+        const naturalIndex = new Map(highlights.map((h, idx) => [h.id, idx]));
 
         const setCustomize = (on) => {
           if (on) update(i, { highlightIds: defaultHighlightIds(rec) });
@@ -286,12 +486,36 @@ export function RecordRefsField({ field, value, onChange, agent, did }) {
           }
         };
 
+        // Toggle a bullet without disturbing the rest of the selection's
+        // order (a custom order set in the tailoring workbench survives).
+        // A newly checked bullet slots in at its natural position.
         const toggleHighlight = (id, on) => {
-          // Rebuild in the job's natural order so display order stays stable.
-          const ordered = highlights
-            .map((h) => h.id)
-            .filter((hid) => (hid === id ? on : includedSet.has(hid)));
-          update(i, { highlightIds: ordered });
+          const current = refs.slice();
+          if (!on) {
+            update(i, { highlightIds: current.filter((r) => parseHighlightRef(r).id !== id) });
+            return;
+          }
+          const idx = naturalIndex.get(id) ?? Infinity;
+          let insertAt = current.length;
+          for (let k = 0; k < current.length; k += 1) {
+            const other = naturalIndex.get(parseHighlightRef(current[k]).id) ?? Infinity;
+            if (other > idx) {
+              insertAt = k;
+              break;
+            }
+          }
+          current.splice(insertAt, 0, id);
+          update(i, { highlightIds: current });
+        };
+
+        // Swap which phrasing an included bullet uses (canonical or a variant),
+        // keeping its position in the selection.
+        const setVariant = (id, variantId) => {
+          update(i, {
+            highlightIds: refs.map((r) =>
+              parseHighlightRef(r).id === id ? makeHighlightRef(id, variantId || null) : r,
+            ),
+          });
         };
 
         return (
@@ -360,25 +584,51 @@ export function RecordRefsField({ field, value, onChange, agent, did }) {
                   <span>Choose which highlights show (default: all)</span>
                 </label>
                 <ul className="rf-highlight-list">
-                  {highlights.map((h) => (
-                    <li key={h.id} className="rf-highlight-row">
-                      <label className="admin-checkbox rf-checkbox">
-                        <input
-                          type="checkbox"
-                          disabled={!explicit}
-                          checked={includedSet.has(h.id)}
-                          onChange={(e) => toggleHighlight(h.id, e.target.checked)}
-                        />
-                        <span className="rf-highlight-text">
-                          {h.text || <em>(empty)</em>}
-                          {(h.visibility && h.visibility !== 'public') && (
-                            <span className="rf-badge">{h.visibility}</span>
-                          )}
-                          {h.featured && <span className="rf-badge rf-badge-accent">featured</span>}
-                        </span>
-                      </label>
-                    </li>
-                  ))}
+                  {highlights.map((h) => {
+                    const selectedRef = refByBase.get(h.id);
+                    const included = refByBase.has(h.id);
+                    const { variantId } = parseHighlightRef(selectedRef || h.id);
+                    const variants = Array.isArray(h.variants) ? h.variants : [];
+                    const shownText = included && selectedRef
+                      ? resolveHighlightRef(rec?.value, selectedRef)?.text ?? h.text
+                      : h.text;
+                    return (
+                      <li key={h.id} className="rf-highlight-row">
+                        <label className="admin-checkbox rf-checkbox">
+                          <input
+                            type="checkbox"
+                            disabled={!explicit}
+                            checked={included}
+                            onChange={(e) => toggleHighlight(h.id, e.target.checked)}
+                          />
+                          <span className="rf-highlight-text">
+                            {shownText || <em>(empty)</em>}
+                            {(h.visibility && h.visibility !== 'public') && (
+                              <span className="rf-badge">{h.visibility}</span>
+                            )}
+                            {h.featured && <span className="rf-badge rf-badge-accent">featured</span>}
+                          </span>
+                        </label>
+                        {explicit && included && variants.length > 0 && (
+                          <label className="rf-inline-field rf-variant-pick">
+                            <span className="rf-inline-label">Phrasing</span>
+                            <select
+                              className="admin-input rf-select-sm"
+                              value={variantId || ''}
+                              onChange={(e) => setVariant(h.id, e.target.value || null)}
+                            >
+                              <option value="">canonical</option>
+                              {variants.map((v) => (
+                                <option key={v.id} value={v.id}>
+                                  {v.label || v.id}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             )}

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -207,7 +207,7 @@ export const LEXICONS = {
       { key: 'summary', label: 'Summary', type: 'textarea' },
       {
         key: 'highlights', label: 'Highlights', type: 'highlights',
-        hint: 'Achievement bullets. Reorder with the arrows; each is referenced by resumes that tailor which bullets to show.',
+        hint: 'Achievement bullets. Reorder with the arrows; each is referenced by resumes that tailor which bullets to show. Fork a bullet to keep alternate phrasings of the same point that individual resume versions can pick.',
       },
       { key: 'skills', label: 'Skills', type: 'tags' },
       ...COMMON_TIMESTAMPS,
@@ -263,7 +263,7 @@ export const LEXICONS = {
       {
         key: 'entries', label: 'Experience (jobs)', type: 'recordRefs',
         refKey: 'job', refCollection: COLLECTIONS.resumeJob, overrides: true,
-        hint: 'Pick jobs and order them with the arrows. Per job, choose which highlights show.',
+        hint: 'Pick jobs and order them with the arrows. Per job, choose which highlights show and which phrasing each uses. The tailoring workbench (Resume studio → Tailor) is the richer editor for this.',
       },
       {
         key: 'education', label: 'Education', type: 'recordRefs',

--- a/src/lib/resumeHelpers.js
+++ b/src/lib/resumeHelpers.js
@@ -48,18 +48,150 @@ export function formatDateRange({ startDate, endDate, current } = {}) {
 
 const VISIBLE = (h) => (h?.visibility || 'public') !== 'private';
 
+/* ------------------------------------------------------------------ */
+/* Highlight refs & variants                                            */
+/* ------------------------------------------------------------------ */
+//
+// A resume's `highlightIds` entry is either a bare highlight id ("h3" → the
+// bullet's canonical text) or "<highlightId>#<variantId>" ("h3#v2" → that
+// forked phrasing from the highlight's `variants`). These helpers are the one
+// place that syntax is parsed/produced.
+
+/** Split a highlight ref into its base id and optional variant id. */
+export function parseHighlightRef(ref) {
+  const s = String(ref || '');
+  const i = s.indexOf('#');
+  if (i === -1) return { id: s, variantId: null };
+  return { id: s.slice(0, i), variantId: s.slice(i + 1) || null };
+}
+
+/** Build a highlight ref string from a base id and optional variant id. */
+export function makeHighlightRef(id, variantId) {
+  return variantId ? `${id}#${variantId}` : id;
+}
+
+/** Next unique `hN` id for a new highlight in this list. */
+export function nextHighlightId(list) {
+  const used = new Set((list || []).map((h) => h?.id).filter(Boolean));
+  let n = (list || []).length + 1;
+  while (used.has(`h${n}`)) n += 1;
+  return `h${n}`;
+}
+
+/** Next unique `vN` id for a new variant of one highlight. */
+export function nextVariantId(variants) {
+  const used = new Set((variants || []).map((v) => v?.id).filter(Boolean));
+  let n = (variants || []).length + 1;
+  while (used.has(`v${n}`)) n += 1;
+  return `v${n}`;
+}
+
+/**
+ * Resolve one highlight ref against a job/education record's highlights.
+ * Returns a render-ready bullet — the base highlight with `text` swapped for
+ * the variant's when the ref names one — or null when the base id is gone.
+ * A dangling variant id degrades to the canonical text rather than dropping
+ * the bullet. `refId` echoes the ref that actually resolved (so keys stay
+ * stable and editors can round-trip the selection).
+ */
+export function resolveHighlightRef(record, ref) {
+  const all = Array.isArray(record?.highlights) ? record.highlights : [];
+  const { id, variantId } = parseHighlightRef(ref);
+  const h = all.find((x) => x?.id === id);
+  if (!h) return null;
+  if (variantId) {
+    const v = (h.variants || []).find((x) => x?.id === variantId);
+    if (v) return { ...h, refId: makeHighlightRef(id, variantId), text: v.text, variantId };
+  }
+  return { ...h, refId: h.id, variantId: null };
+}
+
 /**
  * Resolve which highlights a resume entry shows for its job, honoring the
- * entry's explicit `highlightIds` ordering when present (otherwise every
- * highlight in natural order), then dropping any marked `private`.
+ * entry's explicit `highlightIds` ordering (and any `#variant` phrasing picks)
+ * when present — otherwise every highlight in natural order, canonical text —
+ * then dropping any marked `private`.
  */
 export function selectHighlights(job, entry) {
   const all = Array.isArray(job?.highlights) ? job.highlights : [];
-  if (entry?.highlightIds?.length) {
-    const byId = new Map(all.map((h) => [h.id, h]));
-    return entry.highlightIds.map((id) => byId.get(id)).filter(Boolean).filter(VISIBLE);
+  // An array — even an empty one — is an explicit selection ("show none" is a
+  // legitimate tailoring choice). Only a missing list means "all non-private".
+  if (Array.isArray(entry?.highlightIds)) {
+    return entry.highlightIds
+      .map((ref) => resolveHighlightRef(job, ref))
+      .filter(Boolean)
+      .filter(VISIBLE);
   }
-  return all.filter(VISIBLE);
+  return all.filter(VISIBLE).map((h) => ({ ...h, refId: h.id, variantId: null }));
+}
+
+/**
+ * Scan every resume for uses of one job/education record's bullets.
+ *
+ * Returns Map<baseHighlightId, Array<{ rkey, label, variantId, implicit }>> —
+ * one entry per (resume, selection). `implicit: true` marks resumes that show
+ * the bullet because they omit `highlightIds` (default = all non-private), so
+ * `highlights` must be passed to expand that default. Powers the "used by"
+ * chips and the are-you-sure guards in the admin editors.
+ */
+export function collectHighlightUsage({ resumes, recordUri, listKey, refKey, highlights }) {
+  const usage = new Map();
+  const push = (baseId, info) => {
+    if (!baseId) return;
+    if (!usage.has(baseId)) usage.set(baseId, []);
+    usage.get(baseId).push(info);
+  };
+  for (const rec of resumes || []) {
+    const v = rec?.value || {};
+    const rkey = rkeyFromAtUri(rec.uri);
+    const label = v.title || v.slug || rkey;
+    for (const entry of v[listKey] || []) {
+      if (entry?.[refKey] !== recordUri) continue;
+      if (Array.isArray(entry.highlightIds)) {
+        for (const ref of entry.highlightIds) {
+          const { id, variantId } = parseHighlightRef(ref);
+          push(id, { rkey, label, variantId, implicit: false });
+        }
+      } else {
+        for (const h of highlights || []) {
+          if (!VISIBLE(h)) continue;
+          push(h.id, { rkey, label, variantId: null, implicit: true });
+        }
+      }
+    }
+  }
+  return usage;
+}
+
+/** Kebab-case a title into a slug/rkey candidate. */
+export function slugifyResumeTitle(text) {
+  return String(text || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+/**
+ * Deep-copy a resume value as a new draft version: fresh title/slug, never
+ * featured, private until deliberately published, timestamps reset. The
+ * entries/education selections (including variant picks), skills, and contact
+ * all carry over — that's the point of forking a version.
+ */
+export function duplicateResumeValue(value, { title, slug } = {}) {
+  const src = JSON.parse(JSON.stringify(value || {}));
+  const now = new Date().toISOString();
+  return {
+    ...src,
+    title: title || `${src.title || 'Untitled resume'} (copy)`,
+    slug: slug || `${src.slug || 'resume'}-copy`,
+    featured: false,
+    visibility: 'private',
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 /** Index an array of `{ uri, value }` records by AT URI. */

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -1031,3 +1031,44 @@ select.admin-input {
   flex: 1;
   min-width: 8rem;
 }
+
+/* Bullet variants (forked phrasings) nested inside a highlight card. */
+.rf-variants {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-left: var(--space-3);
+  padding-left: var(--space-3);
+  border-left: 2px solid var(--rule-soft);
+}
+
+.rf-variant {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.rf-variant-label {
+  flex: 1;
+  min-width: 8rem;
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
+  font-size: var(--text-xs);
+}
+
+.rf-variant-pick {
+  margin-left: calc(1.1rem + var(--space-2));
+  gap: var(--space-2);
+}
+
+/* "used by primary, product-design" chip on bullets and variants. */
+.rf-usage {
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 16rem;
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -4,6 +4,8 @@ import PageShell from '../components/PageShell.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
 import PageContentPanel from '../components/PageContentPanel.jsx';
 import GuestbookModerationPanel from '../components/GuestbookModerationPanel.jsx';
+import ResumeStudio from '../components/resume/ResumeStudio.jsx';
+import ResumeWorkbench from '../components/resume/ResumeWorkbench.jsx';
 import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -72,6 +74,12 @@ export default function Admin() {
   }
   if (view === 'listening') {
     return <ListeningManager agent={agent} did={did} />;
+  }
+  if (view === 'resume') {
+    return <ResumeStudio agent={agent} did={did} />;
+  }
+  if (view === 'resume-tailor' && rkey) {
+    return <ResumeWorkbench agent={agent} did={did} rkey={rkey} />;
   }
   if (view === 'blogging') {
     return (
@@ -217,14 +225,10 @@ const PICKER_GROUPS = [
   {
     key: 'resume',
     heading: 'Resume',
-    note: 'Backlinked job, education, and resume records.',
+    note: 'Versions assembled from canonical job and education records.',
     items: [
-      { collection: COLLECTIONS.resume, label: 'Resume',
-        summary: 'Resume versions — each selects which jobs, education, and highlights to show.' },
-      { collection: COLLECTIONS.resumeJob, label: 'Jobs',
-        summary: 'Canonical positions and their achievement bullets (highlights).' },
-      { collection: COLLECTIONS.resumeEducation, label: 'Education',
-        summary: 'Canonical education entries.' },
+      { to: '/admin?view=resume', label: 'Resume studio', nsid: COLLECTIONS.resume,
+        summary: 'Every version, job, and education record in one place — duplicate a version, then tailor it: pick, reorder, re-word, and fork bullets per version.' },
     ],
   },
 ];

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -158,7 +158,7 @@ export default function Resume() {
                         <ul className="resume-highlights">
                           {role.highlights.map((h) => (
                             <li
-                              key={h.id}
+                              key={h.refId || h.id}
                               className={`resume-highlight ${h.featured ? 'is-featured' : ''} ${
                                 h.metric ? 'is-metric' : ''
                               }`}
@@ -202,7 +202,7 @@ export default function Resume() {
                   {e.highlights.length > 0 && (
                     <ul className="resume-highlights">
                       {e.highlights.map((h) => (
-                        <li key={h.id} className="resume-highlight">
+                        <li key={h.refId || h.id} className="resume-highlight">
                           {h.text}
                         </li>
                       ))}


### PR DESCRIPTION
Makes multiple resume versions — and multiple phrasings of one bullet — first-class in the admin panel.

## Schema (backwards compatible)

- `is.dame.resume.job#highlight` gains `variants[]` — forked phrasings of the same point, living on the canonical job so a fork is edited once and every version that picked it stays in sync.
- A resume's `highlightIds` entries may now be `"<highlightId>#<variantId>"` (`"h3#v2"`) to select a phrasing; bare ids keep meaning the canonical text, so existing records are untouched.
- An explicit empty `highlightIds` now means "show none" (only a missing list means default-all), and dangling variant refs degrade to the canonical text.

## Admin

- **Resume studio** (`/admin?view=resume`): every version, job, and education record in one place — set the active version, duplicate a version under a new slug (starts private/unfeatured, carries the whole selection), bullet/fork counts per job.
- **Tailoring workbench** (`/admin?view=resume-tailor&r=<rkey>`): resume-first editing of framing copy, job order/inclusion, and the bullet board — include/exclude, reorder, pick phrasings, fork the current phrasing for just this version, reword inline (with "also shown on …" warnings before touching shared canonical text), add bullets. Staged job edits save together with the resume through the bottom edit bar.
- Record editors upgraded: highlights get fork/duplicate controls plus "used by ⟨version⟩" chips and delete guards; the resume form's entries field is variant-aware and preserves custom bullet order when toggling.

## Verification

Mock-agent Playwright harness driving both views (fork → reword → reorder → materialize → duplicate → set-active → staged save; 45 checks, no JS errors) plus node checks over the selection helpers; vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro)_