### PR TITLE
Theme the input placeholders so they keep contrast through the sky hours

### DIFF
--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -48,6 +48,18 @@ input, button, textarea, select {
   color: inherit;
 }
 
+/* Placeholders otherwise render in the UA's fixed gray, which ignores the
+   theme entirely and washes out against several hours of the sky theme's
+   pages. Ride the theme's ink ramp instead — --ink-soft is the strongest
+   secondary step, re-derived every sky hour, so the hint text keeps its
+   contrast at dawn and dusk while staying quieter than the typed text's
+   full --ink. The opacity resets Firefox's extra placeholder dimming. */
+input::placeholder,
+textarea::placeholder {
+  color: var(--ink-soft);
+  opacity: 1;
+}
+
 button {
   background: none;
   border: 0;


### PR DESCRIPTION
Placeholders had no CSS rule anywhere, so they rendered in the UA's fixed default gray — which ignores the dynamic sky theme and washes out against several hours' pages (mid-day cyans, the dawn/dusk shoulders).

One global rule in `reset.css`: `input::placeholder, textarea::placeholder { color: var(--ink-soft); opacity: 1; }`. That token is re-derived every sky hour and flips with the day/night ink, so hint text stays readable at all stages while remaining a step quieter than typed text. Applies site-wide (guestbook form, admin gate, dock sign-in field). `opacity: 1` resets Firefox's extra placeholder dimming.

Verified visually in the built site by injecting hour palettes: 3pm cyan, the 7am/6pm flip hours (mathematically the worst per a WCAG contrast sweep of all 24 palettes), and 10pm night where the placeholder correctly flips to light ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjEPXVScRgyGGgPAu2KSqL)_