### PR TITLE
Resume workbench: per-bullet options editing + tag-input caret fix

### DIFF
--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -14,6 +14,7 @@ import {
   RecordRefsField,
   SkillGroupsField,
   ContactField,
+  TagsInput,
 } from './resumeFields.jsx';
 import '../pages/Admin.css';
 
@@ -573,20 +574,7 @@ function Field({ field, value, record, onChange, agent, did, collection, rkey, o
       break;
     case 'tags':
       control = (
-        <input
-          id={id}
-          className="admin-input"
-          type="text"
-          value={Array.isArray(value) ? value.join(', ') : ''}
-          onChange={(e) => {
-            const parts = e.target.value
-              .split(',')
-              .map((s) => s.trim())
-              .filter(Boolean);
-            onChange(parts);
-          }}
-          placeholder="comma, separated"
-        />
+        <TagsInput id={id} value={value} onChange={onChange} placeholder="comma, separated" />
       );
       break;
     case 'number':

--- a/src/components/resume/ResumeWorkbench.jsx
+++ b/src/components/resume/ResumeWorkbench.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { ChevronUp, ChevronDown, GitBranch, PenLine, Plus, RotateCcw, X } from 'lucide-react';
 import PageShell from '../PageShell.jsx';
 import { AdminEditorSkeleton } from '../Skeleton.jsx';
-import { SkillGroupsField, ContactField } from '../resumeFields.jsx';
+import { SkillGroupsField, ContactField, TagsInput } from '../resumeFields.jsx';
 import { useEditMode } from '../../hooks/useEditMode.jsx';
 import { COLLECTIONS } from '../../config.js';
 import { rkeyFromAtUri } from '../../lib/atproto.js';
@@ -75,14 +75,6 @@ function moveItem(arr, from, to) {
   const [item] = next.splice(from, 1);
   next.splice(to, 0, item);
   return next;
-}
-
-/** Comma-separated text → trimmed, de-blanked tag list. */
-function parseTagsInput(text) {
-  return String(text || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
 }
 
 /** Merge a patch, dropping any key set to `undefined` so records stay clean. */
@@ -1115,15 +1107,10 @@ function BulletRow({
             </div>
             <label className="rf-inline-field rf-inline-field-block">
               <span className="rf-inline-label">Tags</span>
-              <input
-                className="admin-input"
-                type="text"
-                value={Array.isArray(h.tags) ? h.tags.join(', ') : ''}
+              <TagsInput
+                value={h.tags}
                 placeholder="growth, leadership"
-                onChange={(e) => {
-                  const tags = parseTagsInput(e.target.value);
-                  onPatchHighlight({ tags: tags.length ? tags : undefined });
-                }}
+                onChange={(tags) => onPatchHighlight({ tags: tags.length ? tags : undefined })}
               />
             </label>
             {variantId && onPatchVariant && (

--- a/src/components/resume/ResumeWorkbench.jsx
+++ b/src/components/resume/ResumeWorkbench.jsx
@@ -77,6 +77,23 @@ function moveItem(arr, from, to) {
   return next;
 }
 
+/** Comma-separated text → trimmed, de-blanked tag list. */
+function parseTagsInput(text) {
+  return String(text || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Merge a patch, dropping any key set to `undefined` so records stay clean. */
+function applyPatch(obj, patch) {
+  const next = { ...obj, ...patch };
+  for (const k of Object.keys(patch)) {
+    if (next[k] === undefined) delete next[k];
+  }
+  return next;
+}
+
 export default function ResumeWorkbench({ agent, did, rkey }) {
   const navigate = useNavigate();
   const { setPageEditor } = useEditMode();
@@ -642,19 +659,23 @@ function EntryCard({
   const setVariant = (baseId, variantId) =>
     setRefs(refs.map((r) => (parseHighlightRef(r).id === baseId ? makeHighlightRef(baseId, variantId || null) : r)));
 
-  const setBulletText = (baseId, variantId, text) => {
-    const nextHighlights = highlights.map((h) => {
-      if (h.id !== baseId) return h;
-      if (variantId) {
-        return {
-          ...h,
-          variants: (h.variants || []).map((v) => (v.id === variantId ? { ...v, text } : v)),
-        };
-      }
-      return { ...h, text };
-    });
-    stageRecord(recordUri, { ...recordValue, highlights: nextHighlights });
-  };
+  // All bullet-property edits are canonical: they mutate the highlight (or one
+  // of its variants) on the shared job/education record and stage that record.
+  const updateHighlights = (mapFn) =>
+    stageRecord(recordUri, { ...recordValue, highlights: highlights.map(mapFn) });
+
+  const patchHighlight = (baseId, patch) =>
+    updateHighlights((h) => (h.id === baseId ? applyPatch(h, patch) : h));
+
+  const patchVariant = (baseId, variantId, patch) =>
+    updateHighlights((h) =>
+      h.id === baseId
+        ? { ...h, variants: (h.variants || []).map((v) => (v.id === variantId ? applyPatch(v, patch) : v)) }
+        : h,
+    );
+
+  const setBulletText = (baseId, variantId, text) =>
+    variantId ? patchVariant(baseId, variantId, { text }) : patchHighlight(baseId, { text });
 
   // Fork the phrasing this version currently shows into a new variant on the
   // canonical record, select it here, and open it for rewording.
@@ -856,6 +877,8 @@ function EntryCard({
                   const { variantId } = parseHighlightRef(refByBase.get(baseId) || baseId);
                   setBulletText(baseId, variantId, text);
                 }}
+                onPatchHighlight={(patch) => patchHighlight(baseId, patch)}
+                onPatchVariant={(vid, patch) => patchVariant(baseId, vid, patch)}
               />
             );
           })}
@@ -874,6 +897,8 @@ function EntryCard({
                   recordValue={recordValue}
                   usageRows={usage.get(h.id) || []}
                   onToggle={(on) => toggleBullet(h.id, on)}
+                  onPatchHighlight={(patch) => patchHighlight(h.id, patch)}
+                  onPatchVariant={(vid, patch) => patchVariant(h.id, vid, patch)}
                 />
               ))}
             </ul>
@@ -909,7 +934,10 @@ function BulletRow({
   onStartEdit,
   onStopEdit,
   onEditText,
+  onPatchHighlight,
+  onPatchVariant,
 }) {
+  const [showOptions, setShowOptions] = useState(false);
   const { variantId } = parseHighlightRef(refString);
   const variants = Array.isArray(h.variants) ? h.variants : [];
   const resolved = resolveHighlightRef(recordValue, refString);
@@ -1032,12 +1060,90 @@ function BulletRow({
               </button>
             </>
           )}
+          {!editing && onPatchHighlight && (
+            <button
+              type="button"
+              className={`admin-link-subtle rw-bullet-action${showOptions ? ' is-open' : ''}`}
+              onClick={() => setShowOptions((v) => !v)}
+              aria-expanded={showOptions}
+              title="Featured, metric, visibility, and tags for this bullet"
+            >
+              {showOptions ? <ChevronUp size={12} aria-hidden="true" /> : <ChevronDown size={12} aria-hidden="true" />}{' '}
+              options
+            </button>
+          )}
           {othersOnBullet.length > 0 && (
             <span className="rf-usage" title={`Also shown on: ${othersOnBullet.map((u) => u.label).join(', ')}`}>
               also on {othersOnBullet.map((u) => u.label).join(', ')}
             </span>
           )}
         </div>
+
+        {showOptions && onPatchHighlight && (
+          <div className="rw-bullet-options">
+            <div className="rw-bullet-options-row">
+              <label className="admin-checkbox rf-checkbox">
+                <input
+                  type="checkbox"
+                  checked={Boolean(h.featured)}
+                  onChange={(e) => onPatchHighlight({ featured: e.target.checked || undefined })}
+                />
+                <span>Featured</span>
+              </label>
+              <label className="admin-checkbox rf-checkbox">
+                <input
+                  type="checkbox"
+                  checked={Boolean(h.metric)}
+                  onChange={(e) => onPatchHighlight({ metric: e.target.checked || undefined })}
+                />
+                <span>Metric</span>
+              </label>
+              <label className="rf-inline-field">
+                <span className="rf-inline-label">Visibility</span>
+                <select
+                  className="admin-input rf-select-sm"
+                  value={h.visibility || 'public'}
+                  onChange={(e) =>
+                    onPatchHighlight({ visibility: e.target.value === 'public' ? undefined : e.target.value })
+                  }
+                >
+                  <option value="public">public</option>
+                  <option value="unlisted">unlisted</option>
+                  <option value="private">private</option>
+                </select>
+              </label>
+            </div>
+            <label className="rf-inline-field rf-inline-field-block">
+              <span className="rf-inline-label">Tags</span>
+              <input
+                className="admin-input"
+                type="text"
+                value={Array.isArray(h.tags) ? h.tags.join(', ') : ''}
+                placeholder="growth, leadership"
+                onChange={(e) => {
+                  const tags = parseTagsInput(e.target.value);
+                  onPatchHighlight({ tags: tags.length ? tags : undefined });
+                }}
+              />
+            </label>
+            {variantId && onPatchVariant && (
+              <label className="rf-inline-field rf-inline-field-block">
+                <span className="rf-inline-label">Phrasing label ({variantId})</span>
+                <input
+                  className="admin-input"
+                  type="text"
+                  value={activeVariant?.label ?? ''}
+                  placeholder="e.g. design-focused"
+                  onChange={(e) => onPatchVariant(variantId, { label: e.target.value || undefined })}
+                />
+              </label>
+            )}
+            <p className="admin-field-hint">
+              Featured, metric, visibility, and tags live on the shared bullet — changing them affects
+              every version that uses it.
+            </p>
+          </div>
+        )}
       </div>
 
       {included && onMove && (

--- a/src/components/resume/resumeStudio.css
+++ b/src/components/resume/resumeStudio.css
@@ -377,8 +377,35 @@
   font-size: var(--text-xs);
 }
 
+.rw-bullet-action.is-open {
+  color: var(--accent);
+}
+
 .rw-phrasing {
   gap: var(--space-1);
+}
+
+/* Canonical bullet properties (featured / metric / visibility / tags),
+   revealed under a bullet by the "options" toggle. */
+.rw-bullet-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--rule-soft);
+  background: color-mix(in srgb, var(--ink) 2%, var(--page));
+}
+
+.rw-bullet-options-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-4);
+}
+
+.rw-bullet-options .admin-field-hint {
+  margin: 0;
 }
 
 .rw-bullet-order {

--- a/src/components/resumeFields.jsx
+++ b/src/components/resumeFields.jsx
@@ -90,6 +90,49 @@ function parseTags(text) {
     .filter(Boolean);
 }
 
+/**
+ * Comma-separated tags input that keeps the caret where the user put it.
+ *
+ * Binding an <input> straight to `array.join(', ')` and re-parsing on every
+ * keystroke makes React overwrite the field with a normalized string, which
+ * yanks the caret to the end whenever you edit mid-string. Instead we hold the
+ * raw text locally and only re-sync from props when the incoming value differs
+ * from what the current text already parses to — i.e. on an external change (a
+ * record loaded, a reset), never as an echo of the user's own typing.
+ *
+ * `onChange` receives the parsed array; callers decide whether an empty array
+ * should be stored as `[]` or dropped.
+ */
+export function TagsInput({ id, value, onChange, placeholder, className = 'admin-input' }) {
+  const [text, setText] = useState(() => (Array.isArray(value) ? value.join(', ') : ''));
+
+  useEffect(() => {
+    const fromProps = Array.isArray(value) ? value : [];
+    // Compare with a sentinel that can't survive trimming into a tag, so
+    // the check is exact and never collapses "a b" vs ["a", "b"].
+    if (fromProps.join('\u0000') !== parseTags(text).join('\u0000')) {
+      setText(fromProps.join(', '));
+    }
+    // Keyed on `value` only: re-sync on external changes, not on the local
+    // edits that produced this `value` in the first place.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  return (
+    <input
+      id={id}
+      className={className}
+      type="text"
+      value={text}
+      placeholder={placeholder}
+      onChange={(e) => {
+        setText(e.target.value);
+        onChange(parseTags(e.target.value));
+      }}
+    />
+  );
+}
+
 /** Load every record of a collection once, for the ref pickers. */
 function useCollectionRecords(agent, did, collection) {
   const [records, setRecords] = useState(null);
@@ -393,15 +436,10 @@ export function HighlightsField({ value, onChange, agent, did, recordUri, usageK
           </div>
           <label className="rf-inline-field rf-inline-field-block">
             <span className="rf-inline-label">Tags</span>
-            <input
-              className="admin-input"
-              type="text"
-              value={Array.isArray(h.tags) ? h.tags.join(', ') : ''}
+            <TagsInput
+              value={h.tags}
               placeholder="growth, leadership"
-              onChange={(e) => {
-                const tags = parseTags(e.target.value);
-                update(i, { tags: tags.length ? tags : undefined });
-              }}
+              onChange={(tags) => update(i, { tags: tags.length ? tags : undefined })}
             />
           </label>
         </div>
@@ -684,12 +722,10 @@ export function SkillGroupsField({ value, onChange }) {
           </div>
           <label className="rf-inline-field rf-inline-field-block">
             <span className="rf-inline-label">Skills (comma separated)</span>
-            <input
-              className="admin-input"
-              type="text"
-              value={Array.isArray(group.items) ? group.items.join(', ') : ''}
+            <TagsInput
+              value={group.items}
               placeholder="React, TypeScript, Figma"
-              onChange={(e) => update(i, { items: parseTags(e.target.value) })}
+              onChange={(items) => update(i, { items })}
             />
           </label>
         </div>


### PR DESCRIPTION
Two follow-ups to the resume studio / tailoring workbench (#228).

## Per-bullet options in the workbench

`featured`, `metric`, and `visibility` were read-only badges and `tags` wasn't shown at all — the only way to change them was the raw job editor. Every bullet (included and excluded) now has an **options** toggle revealing inline controls for all four, plus the selected variant's phrasing label.

These are canonical highlight properties, so edits stage onto the shared job/education record (like rewording canonical text already does) and save together with the resume; the panel says as much and the "unsaved · N shared records" chip counts them. Unchecking a flag / clearing tags / setting visibility back to public drops the key so records stay clean.

## Caret fix for comma-separated inputs

Typing partway through a skills or tags field snapped the caret to the end. Those inputs bound their value to `array.join(', ')` and re-parsed on every keystroke, so React kept rewriting the field with a normalized string and the browser reset the caret.

Replaced them with a shared caret-preserving `TagsInput` that holds the raw text locally and only re-syncs from props on genuine external changes (record load, reset) — never as an echo of the user's own typing. Used for the resume skill groups, highlight tags, per-bullet tags, and the generic tags field (post langs, job skills). `onChange` still emits the parsed array, so the data model and save paths are unchanged.

## Verification

Mock-agent Playwright harnesses for both: editing each bullet property persists to the canonical record (and empties drop their keys; variant label persists without touching canonical text; excluded bullets editable too), and mid-string insert/backspace in the tag inputs keeps the caret in place with trailing comma-space preserved while typing. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro)_