### PR TITLE
Resume studio: rename a record's key (slug)

### DIFF
--- a/src/components/resume/ResumeStudio.jsx
+++ b/src/components/resume/ResumeStudio.jsx
@@ -10,6 +10,7 @@ import {
   duplicateResumeValue,
   slugifyResumeTitle,
 } from '../../lib/resumeHelpers.js';
+import { renameRecordKey, backlinksFor, countBacklinks } from '../../lib/resumeAdmin.js';
 import { useResumeBundle } from './useResumeBundle.js';
 import './resumeStudio.css';
 
@@ -25,6 +26,67 @@ import './resumeStudio.css';
 export default function ResumeStudio({ agent, did }) {
   const { resumes, jobs, education, loading, error, reload } = useResumeBundle(agent, did);
   const [actionError, setActionError] = useState(null);
+  const [renamingUri, setRenamingUri] = useState(null);
+
+  const listFor = (collection) =>
+    collection === COLLECTIONS.resumeJob
+      ? jobs
+      : collection === COLLECTIONS.resumeEducation
+        ? education
+        : resumes;
+
+  // "Rename" a record's key. Because AT keys records immutably, this recreates
+  // the record under the new key, repoints resume backlinks, and deletes the
+  // old one (see renameRecordKey). Jobs/education warn with how many versions
+  // reference them; a version rename also syncs its slug + /for-hire URL.
+  async function renameRecord(collection, rec) {
+    if (renamingUri) return;
+    const fromRkey = rkeyFromUri(rec.uri);
+    const v = rec.value || {};
+    const siblings = listFor(collection) || [];
+    const taken = new Set(siblings.map((r) => rkeyFromUri(r.uri)));
+    const label =
+      [v.title || v.institution, v.organization || v.area].filter(Boolean).join(' · ') || fromRkey;
+
+    const input = window.prompt(
+      `New record key for “${label}”.\n` +
+        'Lowercase letters, numbers, and dashes — it drives the record\'s at:// URI' +
+        (collection === COLLECTIONS.resume ? ' and /for-hire/<slug>.' : '.'),
+      fromRkey,
+    );
+    if (input == null) return;
+    const toRkey = slugifyResumeTitle(input);
+    if (!toRkey) {
+      setActionError('That key is empty once cleaned up — use letters, numbers, and dashes.');
+      return;
+    }
+    if (toRkey === fromRkey) return;
+    if (taken.has(toRkey)) {
+      setActionError(`A record with the key “${toRkey}” already exists.`);
+      return;
+    }
+
+    const backlinks = backlinksFor(collection);
+    const refCount = backlinks.length ? countBacklinks(resumes, rec.uri, backlinks) : 0;
+    const detail = backlinks.length
+      ? `\n\nThis recreates it as “${toRkey}”, repoints ${refCount} resume version${
+          refCount === 1 ? '' : 's'
+        } that reference it, and deletes the old “${fromRkey}”.`
+      : `\n\nThis recreates it as “${toRkey}” (syncing its slug + /for-hire URL) and deletes the old one.`;
+    if (!window.confirm(`Rename ${fromRkey} → ${toRkey}?${detail}`)) return;
+
+    setRenamingUri(rec.uri);
+    setActionError(null);
+    try {
+      const value = collection === COLLECTIONS.resume ? { ...v, slug: toRkey } : v;
+      await renameRecordKey({ agent, did, collection, fromRkey, toRkey, value, resumes, backlinks });
+      reload();
+    } catch (err) {
+      setActionError(err?.message || String(err));
+    } finally {
+      setRenamingUri(null);
+    }
+  }
 
   const jobsByUri = useMemo(() => {
     const m = new Map();
@@ -71,6 +133,8 @@ export default function ResumeStudio({ agent, did }) {
             jobsByUri={jobsByUri}
             onChanged={reload}
             onError={setActionError}
+            onRename={(rec) => renameRecord(COLLECTIONS.resume, rec)}
+            renamingUri={renamingUri}
           />
           <RecordsSection
             heading="Jobs"
@@ -79,6 +143,8 @@ export default function ResumeStudio({ agent, did }) {
             records={sortedJobs}
             labelFor={(v) => [v.title, v.organization].filter(Boolean).join(' · ')}
             newLabel="New job"
+            onRename={(rec) => renameRecord(COLLECTIONS.resumeJob, rec)}
+            renamingUri={renamingUri}
           />
           <RecordsSection
             heading="Education"
@@ -87,6 +153,8 @@ export default function ResumeStudio({ agent, did }) {
             records={sortedEducation}
             labelFor={(v) => [v.institution, v.studyType || v.area].filter(Boolean).join(' · ')}
             newLabel="New education entry"
+            onRename={(rec) => renameRecord(COLLECTIONS.resumeEducation, rec)}
+            renamingUri={renamingUri}
           />
         </>
       )}
@@ -113,7 +181,7 @@ function versionCounts(value, jobsByUri) {
   return { jobs: entries.length, bullets };
 }
 
-function VersionsSection({ agent, did, resumes, jobsByUri, onChanged, onError }) {
+function VersionsSection({ agent, did, resumes, jobsByUri, onChanged, onError, onRename, renamingUri }) {
   const navigate = useNavigate();
   const [busy, setBusy] = useState(null); // rkey being written
 
@@ -264,6 +332,17 @@ function VersionsSection({ agent, did, resumes, jobsByUri, onChanged, onError })
                   >
                     record
                   </Link>
+                  {onRename && (
+                    <button
+                      type="button"
+                      className="admin-link-subtle rs-version-raw"
+                      onClick={() => onRename(rec)}
+                      disabled={!!busy || !!renamingUri}
+                      title="Change this version's key + slug (/for-hire URL)"
+                    >
+                      {renamingUri === rec.uri ? 'renaming…' : 'rename'}
+                    </button>
+                  )}
                   {vis !== 'private' && (
                     <Link
                       className="admin-link-subtle rs-version-raw"
@@ -287,7 +366,7 @@ function VersionsSection({ agent, did, resumes, jobsByUri, onChanged, onError })
 /* Canonical record lists (jobs / education)                            */
 /* ------------------------------------------------------------------ */
 
-function RecordsSection({ heading, note, collection, records, labelFor, newLabel }) {
+function RecordsSection({ heading, note, collection, records, labelFor, newLabel, onRename, renamingUri }) {
   return (
     <section className="admin-page-section rs-section">
       <h2 className="admin-collection-group-heading small-caps">{heading}</h2>
@@ -306,7 +385,7 @@ function RecordsSection({ heading, note, collection, records, labelFor, newLabel
             );
             const dates = formatDateRange(v);
             return (
-              <li key={rec.uri} className="admin-record-row">
+              <li key={rec.uri} className="admin-record-row rs-record-row">
                 <Link
                   to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(r)}`}
                   className="admin-record-link"
@@ -321,6 +400,17 @@ function RecordsSection({ heading, note, collection, records, labelFor, newLabel
                   </span>
                   {dates && <span className="admin-record-time small-caps">{dates}</span>}
                 </Link>
+                {onRename && (
+                  <button
+                    type="button"
+                    className="admin-link-subtle rs-rename"
+                    onClick={() => onRename(rec)}
+                    disabled={!!renamingUri}
+                    title="Change this record's key (slug), updating every version that references it"
+                  >
+                    {renamingUri === rec.uri ? 'renaming…' : 'rename key'}
+                  </button>
+                )}
               </li>
             );
           })}

--- a/src/components/resume/resumeStudio.css
+++ b/src/components/resume/resumeStudio.css
@@ -158,6 +158,24 @@
   font-family: var(--sans);
 }
 
+/* Record rows in the studio carry a "rename key" action beside the link. */
+.rs-record-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.rs-record-row .admin-record-link {
+  flex: 1;
+  min-width: 0;
+}
+
+.rs-rename {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .rs-section-add {
   margin-top: var(--space-3);
   text-decoration: none;

--- a/src/lib/resumeAdmin.js
+++ b/src/lib/resumeAdmin.js
@@ -1,0 +1,114 @@
+// Admin-side mutations for the resume graph that go beyond editing one record.
+//
+// AT Protocol keys a record immutably by its rkey, so "renaming" a job or
+// education slug is really a move: create the record under the new key, repoint
+// every resume backlink from the old at:// URI to the new one, then delete the
+// old record. Ordering (create → repoint → delete) guarantees no resume ever
+// references a key that doesn't exist mid-flight.
+
+import { rkeyFromAtUri } from './atproto.js';
+import { COLLECTIONS } from '../config.js';
+
+const RKEY_RE = /^[a-zA-Z0-9][a-zA-Z0-9._~:-]{0,511}$/;
+
+/** Whether a string is a syntactically valid AT record key. */
+export function isValidRkey(rkey) {
+  return typeof rkey === 'string' && rkey !== '.' && rkey !== '..' && RKEY_RE.test(rkey);
+}
+
+/**
+ * Count the resume versions that backlink to a record URI through the given
+ * lists (e.g. jobs via `entries[].job`). Used to warn before a rename.
+ */
+export function countBacklinks(resumes, recordUri, backlinks) {
+  const rkeys = new Set();
+  for (const rec of resumes || []) {
+    for (const { listKey, refKey } of backlinks || []) {
+      const list = rec?.value?.[listKey];
+      if (Array.isArray(list) && list.some((e) => e?.[refKey] === recordUri)) {
+        rkeys.add(rkeyFromAtUri(rec.uri));
+      }
+    }
+  }
+  return rkeys.size;
+}
+
+/**
+ * Move a record to a new rkey, repointing resume backlinks.
+ *
+ *   agent, did      — the signed-in PDS agent + repo DID
+ *   collection      — the record's NSID (job / education / resume)
+ *   fromRkey/toRkey — old and new keys (caller validates + checks availability)
+ *   value           — the record's current value (moved verbatim, updatedAt bumped)
+ *   resumes         — the loaded resume bundle, scanned for backlinks
+ *   backlinks       — [{ listKey, refKey }] pairs to rewrite (empty for resumes)
+ *
+ * Returns `{ newUri, updatedResumes }` — the rkeys of the resumes rewritten.
+ */
+export async function renameRecordKey({
+  agent,
+  did,
+  collection,
+  fromRkey,
+  toRkey,
+  value,
+  resumes,
+  backlinks = [],
+}) {
+  const oldUri = `at://${did}/${collection}/${fromRkey}`;
+  const newUri = `at://${did}/${collection}/${toRkey}`;
+  const now = new Date().toISOString();
+
+  // 1. Create the record under the new key (same facts, bumped updatedAt).
+  const record = { ...(value || {}), $type: value?.$type || collection, updatedAt: now };
+  if (!record.createdAt) record.createdAt = now;
+  await agent.com.atproto.repo.putRecord({ repo: did, collection, rkey: toRkey, record });
+
+  // 2. Repoint every resume backlink from the old URI to the new one.
+  const updatedResumes = [];
+  for (const rec of resumes || []) {
+    const v = rec?.value;
+    if (!v) continue;
+    let changed = false;
+    const nextValue = { ...v };
+    for (const { listKey, refKey } of backlinks) {
+      const list = v[listKey];
+      if (!Array.isArray(list)) continue;
+      let listChanged = false;
+      const nextList = list.map((entry) => {
+        if (entry?.[refKey] === oldUri) {
+          listChanged = true;
+          return { ...entry, [refKey]: newUri };
+        }
+        return entry;
+      });
+      if (listChanged) {
+        nextValue[listKey] = nextList;
+        changed = true;
+      }
+    }
+    if (changed) {
+      const rkey = rkeyFromAtUri(rec.uri);
+      // eslint-disable-next-line no-await-in-loop
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: COLLECTIONS.resume,
+        rkey,
+        record: { ...nextValue, updatedAt: now },
+      });
+      updatedResumes.push(rkey);
+    }
+  }
+
+  // 3. Delete the old record last — nothing points at it anymore.
+  await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey: fromRkey });
+
+  return { newUri, updatedResumes };
+}
+
+/** The backlink lists that reference each canonical collection from a resume. */
+export function backlinksFor(collection) {
+  if (collection === COLLECTIONS.resumeJob) return [{ listKey: 'entries', refKey: 'job' }];
+  if (collection === COLLECTIONS.resumeEducation) return [{ listKey: 'education', refKey: 'education' }];
+  return [];
+}


### PR DESCRIPTION
Adds the ability to change a record's rkey — e.g. renaming a job's slug — from the resume studio.

## Why it's not a simple edit

AT Protocol keys a record immutably by its rkey, and jobs/education are referenced by resumes via their `at://…/rkey` URI. So a rename is really a move: `renameRecordKey()` recreates the record under the new key, repoints every resume backlink from the old URI to the new one, then deletes the old record — ordered **create → repoint → delete** so no version ever references a key that doesn't exist mid-flight.

## UI

- **Jobs** and **education** rows get a **"rename key"** action; **versions** get **"rename"**.
- Jobs/education warn with how many versions reference them before proceeding ("repoints N resume versions…").
- A version rename also syncs its `slug` and `/for-hire/<slug>` URL.
- Input is slugified and rejected if empty, unchanged, or colliding with an existing key.

## Verification

- **Node unit test**: repointing preserves per-entry variant selections (`h1#v1`) and untouched entries, `createdAt` survives, only referencing resumes are rewritten, and the ordering (new put before old delete, delete last) holds.
- **Playwright**: drives the studio's prompt → confirm flow end-to-end — the referenced versions repoint, the old key disappears, and a colliding rename is rejected with an error.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro)_