### PR TITLE
Add Standard Site link tags + verification for Bluesky embeds

### DIFF
--- a/api/well-known.js
+++ b/api/well-known.js
@@ -1,0 +1,35 @@
+// Standard Site publication-verification endpoint.
+//
+// Bluesky (and other AT clients) verify a site.standard.publication by fetching
+// `{publication.url}/.well-known/site.standard.publication[/path]` and confirming
+// it returns that publication's bare AT-URI — see
+// https://standard.site/docs/verification. Without this, the enhanced "Standard
+// Site" link embed never renders for dame.is links.
+//
+// dame.is hosts two non-root publications, so each answers at its own path:
+//   /.well-known/site.standard.publication/blogging  → the blog publication
+//   /.well-known/site.standard.publication/creating  → the portfolio publication
+// (The bare /.well-known/site.standard.publication has no root publication.)
+//
+// Wired up in vercel.json, which rewrites the .well-known paths here.
+
+import { BLOG_PUBLICATION, PORTFOLIO_PUBLICATION } from '../src/config.js';
+
+// publication path (matches each record's `url` path) → publication AT-URI.
+const PUBLICATIONS = {
+  blogging: BLOG_PUBLICATION,
+  creating: PORTFOLIO_PUBLICATION,
+};
+
+export default function handler(req, res) {
+  const raw = req.query?.pub;
+  const key = String(Array.isArray(raw) ? raw.join('/') : raw || '')
+    .replace(/^\/+|\/+$/g, '')
+    .toLowerCase();
+  const uri = PUBLICATIONS[key] || null;
+
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=86400');
+  if (!uri) return res.status(404).end('');
+  return res.status(200).end(uri);
+}

--- a/middleware.js
+++ b/middleware.js
@@ -14,9 +14,17 @@
 
 import { pageMeta, SITE, cleanPath, segsFor } from './og/pages.js';
 import { recordMeta } from './og/records.js';
-import { ME_DID, COLLECTIONS } from './src/config.js';
+import { ME_DID, COLLECTIONS, BLOG_PUBLICATION, PORTFOLIO_PUBLICATION } from './src/config.js';
 
 const ORIGIN = 'https://dame.is';
+
+// site.standard.document is the lexicon Bluesky renders as a Standard Site
+// embed. Its section homes map to the publication the docs belong to.
+const STANDARD_DOC_NSID = 'site.standard.document';
+const SECTION_PUBLICATION = {
+  '/blogging': BLOG_PUBLICATION,
+  '/creating': PORTFOLIO_PUBLICATION,
+};
 
 // Top-level surfaces backed by an is.dame.page record (keyed by rkey), mirroring
 // the client's src/hooks/useAtUri.js `pageRkeyForPath`. Used to give crawlers
@@ -89,6 +97,20 @@ function injectAtprotoHead(html, atUri, cid) {
   return html.replace(/<\/head>/i, `${tags}  </head>`);
 }
 
+// Standard Site link tags: what Bluesky (and other AT clients) read to render a
+// site.standard.document as a rich "Standard Site" embed instead of a plain OG
+// card. Their crawler runs no JS, so these must be server-side. `document` goes
+// on an article page, `publication` on both articles and the publication home.
+// Verification is against the publication's own domain (its record `url` +
+// /.well-known/site.standard.publication), so a re-render like dame.is only
+// needs to declare the refs here. See https://standard.site/docs/verification/.
+function injectStandardSiteHead(html, { document: documentUri, publication: publicationUri }) {
+  let tags = '';
+  if (documentUri) tags += `    <link rel="site.standard.document" href="${escapeAttr(documentUri)}" />\n`;
+  if (publicationUri) tags += `    <link rel="site.standard.publication" href="${escapeAttr(publicationUri)}" />\n`;
+  return tags ? html.replace(/<\/head>/i, `${tags}  </head>`) : html;
+}
+
 export default async function middleware(request) {
   try {
     const url = new URL(request.url);
@@ -107,6 +129,11 @@ export default async function middleware(request) {
     let ogImage;
     let atUri = null;
     let cid = null;
+    // Standard Site refs: the site.standard.document + its publication, for the
+    // Bluesky rich embed. `stdDoc` only on article pages; `stdPub` on articles
+    // and the publication home pages (/blogging, /creating).
+    let stdDoc = null;
+    let stdPub = null;
     if (segs.length === 2) {
       const sectionSeg = segs[0];
       const sectionPath = `/${sectionSeg}`;
@@ -127,6 +154,12 @@ export default async function middleware(request) {
         ogImage = `${ORIGIN}/api/og?${params.toString()}`;
         atUri = rec.atUri;
         cid = rec.cid;
+        // Only site.standard.document records get the Standard Site embed; a
+        // leaflet or arena record on these routes is skipped.
+        if (rec.nsid === STANDARD_DOC_NSID) {
+          stdDoc = rec.atUri;
+          stdPub = rec.publication;
+        }
       } else {
         // A record route whose record can't be fetched degrades to the
         // section's own card + title, so crawlers never see the generic home
@@ -141,6 +174,8 @@ export default async function middleware(request) {
       desc = meta.desc;
       ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(path)}`;
       atUri = topLevelAtUri(path);
+      // Publication home pages advertise their publication for the embed.
+      stdPub = SECTION_PUBLICATION[path] || null;
     }
 
     // Pull the built SPA shell. The matcher never matches /index.html, so this
@@ -167,6 +202,9 @@ export default async function middleware(request) {
     // Record/leaf pages (and the top-level surfaces) advertise their canonical
     // at:// URI so AT-aware crawlers can find the backing record.
     if (atUri) html = injectAtprotoHead(html, atUri, cid);
+
+    // Standard Site link tags → Bluesky renders the rich publication embed.
+    if (stdDoc || stdPub) html = injectStandardSiteHead(html, { document: stdDoc, publication: stdPub });
 
     return new Response(html, {
       status: 200,

--- a/og/records.js
+++ b/og/records.js
@@ -149,15 +149,19 @@ function shapeMeta(record, section) {
   const description = String(v.description || v.summary || v.subtitle || '').trim();
   const atUri = record.uri || null;
   const cid = record.cid || null;
-  return { title, description, section, atUri, cid, nsid: collectionFromUri(atUri) };
+  // `site` is the site.standard.document → site.standard.publication link
+  // (an at:// URI). Bluesky needs it to render the Standard Site embed.
+  const publication = typeof v.site === 'string' ? v.site : null;
+  return { title, description, section, atUri, cid, nsid: collectionFromUri(atUri), publication };
 }
 
 /**
  * Resolve a record route to
- * `{ title, description, section, atUri, cid, nsid }`, or null if it's not a
- * record route or the record can't be resolved. `title` is the record's own
- * title; `description` is its summary/subtitle when present; `atUri`/`cid`
- * point at the canonical record; `nsid` is its collection.
+ * `{ title, description, section, atUri, cid, nsid, publication }`, or null if
+ * it's not a record route or the record can't be resolved. `title` is the
+ * record's own title; `description` is its summary/subtitle when present;
+ * `atUri`/`cid` point at the canonical record; `nsid` is its collection;
+ * `publication` is the parent site.standard.publication at:// URI (or null).
  */
 export async function recordMeta(pathname, origin) {
   const segs = (pathname || '').split('/').filter(Boolean);

--- a/scripts/set-publication-urls.mjs
+++ b/scripts/set-publication-urls.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// One-off migration: point dame's site.standard.publication records at dame.is
+// so Bluesky (and other AT clients) verify the Standard Site link embed against
+// dame.is instead of dame.leaflet.pub / dame.work (dead).
+//
+// Only each publication's `url` changes. The documents' `site` + `path` are left
+// alone — a doc's canonical URL is `publication.url + document.path`, and the
+// existing paths (e.g. /3m36ccn5kis2x, /red-blue-yellow) already resolve to
+// https://dame.is/blogging/… and https://dame.is/creating/…, which is exactly how
+// dame.is routes them. Pair this with the /.well-known/site.standard.publication
+// endpoints (api/well-known.js) and the <link> tags (middleware.js).
+//
+// Usage:
+//   node scripts/set-publication-urls.mjs --dry-run          # preview (no auth needed)
+//   DAME_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+//     node scripts/set-publication-urls.mjs                  # apply
+//
+// Get an app password at https://bsky.app/settings/app-passwords.
+
+import { AtpAgent } from '@atproto/api';
+import { ME_HANDLE, BLOG_PUBLICATION, PORTFOLIO_PUBLICATION } from '../src/config.js';
+
+const DRY_RUN = process.argv.includes('--dry-run') || process.argv.includes('-n');
+const HANDLE = process.env.DAME_HANDLE || process.env.BSKY_IDENTIFIER || ME_HANDLE;
+const PDS_OVERRIDE = process.env.DAME_PDS_SERVICE || null;
+const APP_PASSWORD =
+  process.env.DAME_APP_PASSWORD || process.env.BSKY_APP_PASSWORD || process.env.APP_PASSWORD || null;
+
+const COLLECTION = 'site.standard.publication';
+
+// publication AT-URI → the dame.is base url it should advertise.
+const TARGETS = [
+  { uri: BLOG_PUBLICATION, url: 'https://dame.is/blogging' },
+  { uri: PORTFOLIO_PUBLICATION, url: 'https://dame.is/creating' },
+];
+
+const log = (...a) => console.log('[pub-urls]', ...a);
+const rkeyOf = (uri) => String(uri).split('/').pop();
+
+async function resolveIdentity() {
+  const r = await fetch(
+    `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(HANDLE)}`,
+  );
+  if (!r.ok) throw new Error(`resolveHandle(${HANDLE}) → HTTP ${r.status}`);
+  const { did } = await r.json();
+  if (PDS_OVERRIDE) return { did, pds: PDS_OVERRIDE };
+  const docUrl = did.startsWith('did:web:')
+    ? `https://${did.slice('did:web:'.length)}/.well-known/did.json`
+    : `https://plc.directory/${did}`;
+  const doc = await (await fetch(docUrl)).json();
+  const svc = (doc.service || []).find(
+    (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer',
+  );
+  if (!svc) throw new Error(`No PDS endpoint in DID doc for ${did}`);
+  return { did, pds: svc.serviceEndpoint };
+}
+
+// getRecord is public (no auth), so --dry-run can preview the real change.
+async function fetchValue(pds, did, rkey) {
+  const params = new URLSearchParams({ repo: did, collection: COLLECTION, rkey });
+  const r = await fetch(`${pds}/xrpc/com.atproto.repo.getRecord?${params}`);
+  if (!r.ok) throw new Error(`getRecord(${rkey}) → HTTP ${r.status}`);
+  return r.json(); // { uri, cid, value }
+}
+
+async function main() {
+  const { did, pds } = await resolveIdentity();
+  log(`${HANDLE} → ${did}`);
+  log(`PDS: ${pds}`);
+
+  const plan = [];
+  for (const target of TARGETS) {
+    const rkey = rkeyOf(target.uri);
+    const { value } = await fetchValue(pds, did, rkey);
+    const from = value?.url || '(none)';
+    if (from === target.url) {
+      log(`✓ ${rkey} already ${target.url} — skipping`);
+      continue;
+    }
+    log(`• ${rkey}: url ${from}  →  ${target.url}`);
+    plan.push({ rkey, value: { ...value, url: target.url } });
+  }
+
+  if (!plan.length) {
+    log('nothing to change.');
+    return;
+  }
+  if (DRY_RUN) {
+    log(`\ndry-run — ${plan.length} record(s) would be updated. Re-run without --dry-run to apply.`);
+    return;
+  }
+  if (!APP_PASSWORD) {
+    throw new Error('Set DAME_APP_PASSWORD (an app password) to apply. Use --dry-run to preview.');
+  }
+
+  const agent = new AtpAgent({ service: pds });
+  await agent.login({ identifier: HANDLE, password: APP_PASSWORD });
+  for (const { rkey, value } of plan) {
+    await agent.com.atproto.repo.putRecord({
+      repo: did,
+      collection: COLLECTION,
+      rkey,
+      record: value,
+    });
+    log(`✓ updated ${rkey} → ${value.url}`);
+  }
+  log('done.');
+}
+
+main().catch((err) => {
+  console.error('[pub-urls] fatal:', err?.message || err);
+  process.exitCode = 1;
+});

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,8 @@
     { "path": "/api/mirror-mothing", "schedule": "50 5,11,17,23 * * *" }
   ],
   "rewrites": [
+    { "source": "/.well-known/site.standard.publication", "destination": "/api/well-known" },
+    { "source": "/.well-known/site.standard.publication/:pub*", "destination": "/api/well-known?pub=:pub*" },
     { "source": "/oauth-client-metadata.json", "destination": "/api/client-metadata" },
     { "source": "/app.bsky.feed.post/:rkey", "destination": "/index.html" },
     { "source": "/fm.teal.alpha.feed.play/:rkey", "destination": "/index.html" },


### PR DESCRIPTION
Make dame.is a first-class Standard Site so Bluesky renders its blog posts and creative works as rich **Standard Site** link embeds (not plain OG cards) when shared.

## Why
Bluesky's criteria ([integration doc](https://github.com/bluesky-social/atproto/discussions/4978), [verification spec](https://standard.site/docs/verification)): each article page must serve, server-side, a `<link rel="site.standard.document">` + `<link rel="site.standard.publication">` pointing at the backing `at://` records, and the publication must be verifiable at `{publication.url}/.well-known/site.standard.publication`. dame.is previously emitted neither, and its publications point at `dame.leaflet.pub` / `dame.work` (dead) rather than dame.is.

## Changes
- **`middleware.js`** — inject the two `<link>` tags on record pages (from the resolved record's own `uri` + `site`) and the publication tag on the `/blogging` + `/creating` publication homes. Gated to `site.standard.document` records (leaflet/arena routes skipped).
- **`og/records.js`** — return the record's `site` (parent publication `at://` URI).
- **`api/well-known.js` + `vercel.json`** — serve `/.well-known/site.standard.publication/{blogging,creating}` returning each publication's AT-URI, so the publications verify against dame.is.
- **`scripts/set-publication-urls.mjs`** — one-off migration to repoint the two publication records' `url` at `https://dame.is/{blogging,creating}`. A doc's canonical URL is `publication.url + document.path`, and the existing paths already map onto dame.is routes, so **no document records change**.

## Follow-up (not in this PR)
After deploy, repoint the two publications' `url` to dame.is (run `scripts/set-publication-urls.mjs` with an app password, or edit the records in-app). Deploy first, migrate second — no downtime. Note: the blog publication is the Leaflet one, so publishing via Leaflet afterward may reset its `url`.

## Verification
- Middleware emits both tags on article pages, publication tag on section homes, nothing on unrelated routes (tested with mocked snapshots).
- `api/well-known.js` returns the correct AT-URIs for `blogging`/`creating`, 404 for root/unknown.
- Migration dry-run confirms exactly two `url` changes and touches no documents.
- `npm run build` passes; all server modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb)_