### PR TITLE
Fix Firefox drop-cap alignment on resume/blog/about

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -135,19 +135,38 @@ blockquote {
 }
 
 /* Firefox has no `initial-letter` support yet — approximate with the classic
-   float. Sized in `em` so it still scales with the paragraph text at every
-   breakpoint (just without the exact-line-count guarantee above). */
+   float. Everything is in `em` so it scales with the paragraph text at every
+   breakpoint, matching the three-line drop the `initial-letter: 3` path gives
+   the other engines.
+
+   The two magic numbers are derived, not eyeballed — a float can't sink itself
+   the way `initial-letter` does, so we size and lead it by hand:
+
+   • font-size 5.85em — the cap must reach from the first line's cap-height down
+     to the third line's baseline, a visual span of `cap-height + 2 line-heights`.
+     For Crimson Pro (cap-height ≈ 0.655em) at our 1.6 line-height that's
+     0.655 + 2·1.6 ≈ 3.855em of cap, and 3.855 / 0.655 ≈ 5.85em of font-size.
+   • line-height 0.81 — a floated glyph is vertically centred in its own line
+     box, so this (< 1) is what drops the baseline onto the third line's baseline
+     and pulls the cap-top up flush with the first line's caps. It also sets the
+     float's height to ≈ 2.96 lines, so exactly three lines wrap and the fourth
+     clears.
+
+   Measured against the `initial-letter` rendering this lands both the cap-top
+   and the baseline within ~0.1px, versus the old 3.3em/0.82 float that only
+   spanned two lines and poked above the first line in Firefox. */
 @supports not ((initial-letter: 3) or (-webkit-initial-letter: 3)) {
   .dropcap::first-letter,
   .blog-prose > p:first-of-type::first-letter,
   .blog-prose .first-paragraph::first-letter,
   .about-longform > p:first-of-type::first-letter {
     float: left;
-    font-size: 3.3em;
-    line-height: 0.82;
-    padding-top: 0.02em;
-    padding-right: 0.12em;
+    font-size: 5.85em;
+    line-height: 0.81;
+    /* Cancel the base rule's 0.18em gap (huge at this font-size) and set the
+       gap to the wrapping text in the float's own em instead. */
     margin-right: 0;
+    padding-right: 0.04em;
   }
 }
 


### PR DESCRIPTION
## Problem

On desktop Firefox, the first-paragraph drop caps (resume summary, blog posts, About page) sat too high — poking above the first line with the baseline aligning to nothing — while Safari/Chrome looked correct.

**Root cause:** The shared drop-cap rule in `src/styles/typography.css` uses `initial-letter: 3` for a metric-correct three-line drop. Firefox is the one major engine that still doesn't support `initial-letter`, so it falls through to the `@supports not (…)` float fallback. That fallback (`font-size: 3.3em; line-height: 0.82`) was eyeballed — it only spanned **two** lines and its negative leading pushed the cap glyph *above* the first line's caps. Safari/Chrome never hit that path, which is why the bug was Firefox-only.

## Fix

Re-derived the float's size and leading from Crimson Pro's actual metrics so the fallback matches the `initial-letter: 3` rendering:

- **`font-size: 5.85em`** — makes the cap span from the first line's cap-height down to the third line's baseline (`cap-height + 2·line-height`, ÷ the cap-height ratio).
- **`line-height: 0.81`** — a floated glyph centers in its own line box, so `<1` drops the baseline onto line 3 and pulls the cap-top flush with line 1, while sizing the float to wrap exactly three lines (the fourth clears).
- Dropped the now-unneeded `padding-top` and tuned the gap to the wrapping text.

This one change fixes all three surfaces at once, since they share the rule.

## Verification

Because this is font-metric-dependent, it was verified in **actual Firefox** against the metric-correct `initial-letter` reference, using a self-hosted copy of the same Crimson Pro variable font, the real `1.6` line-height, and a baseline grid overlay:

- Confirmed Firefox reports `initial-letter` unsupported → the float path is genuinely active.
- **Before:** cap poked above line 1, spanned 2 lines.
- **After:** cap-top flush with line 1, baseline resting on line 3, spanning 3 clean lines — landing within ~0.1px of the `initial-letter` reference.
- Checked at both the resume (1rem) and blog (1.05rem) sizes, and with both a round (`C`) and a flat-top (`T`) initial letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExZAW1ryVPqX8fjzKCvT5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExZAW1ryVPqX8fjzKCvT5a)_