### PR TITLE
Resume: tie portfolio/creating posts and links under a job

### DIFF
--- a/lexicons/RESUME.md
+++ b/lexicons/RESUME.md
@@ -8,9 +8,10 @@ them on the site at all.
 
 ```
 is.dame.resume            (a resume version — "primary", "product-design", …)
- ├─ entries[]   ──at://──▶ is.dame.resume.job        (canonical job; owns the bullets)
- │   └─ highlightIds[]      ─▶ picks job.highlights[].id — or "h3#v2" to pick a
- │                             forked phrasing from that highlight's variants[]
+ ├─ entries[]   ──at://──▶ is.dame.resume.job        (canonical job; owns the bullets + links)
+ │   ├─ highlightIds[]      ─▶ picks job.highlights[].id — or "h3#v2" to pick a
+ │   │                         forked phrasing from that highlight's variants[]
+ │   └─ linkIds[]           ─▶ picks job.links[].id — portfolio pieces shown under the role
  ├─ education[] ──at://──▶ is.dame.resume.education   (canonical degree/program)
  ├─ skills[]                  (inline skill groups — the audience-specific part)
  └─ contact                   (inline, or fall back to the site profile)
@@ -34,6 +35,14 @@ sync; the `label` ("design-focused", "one-pager") is admin-only naming.
 Variants share the parent bullet's flags (visibility, featured, metric, tags) —
 they are the *same point*, differently worded. If two phrasings diverge into
 genuinely different claims, make a second highlight instead.
+
+A job can also carry **links** — portfolio pieces tied to the role
+(`links: [{ id, work?, url?, label?, description? }]`), rendered as a "Selected
+work" row under the job. A link points either at a first-party `/creating`
+post via `work` (a `site.standard.document` AT URI, resolved live to that
+post's title + cover so it renders as an **embed**) or at any external page via
+`url`. Like highlights, links live on the canonical job and each resume selects
+which to show with `linkIds` (omit for all non-private, in natural order).
 
 ### `is.dame.resume.education` — the canonical education entry
 Same idea for schooling. Reuses the job's `#highlight` shape for honors /

--- a/lexicons/is.dame.resume.job.json
+++ b/lexicons/is.dame.resume.job.json
@@ -33,6 +33,12 @@
             "items": { "type": "string", "maxLength": 64 },
             "description": "Skills exercised in this role. Aggregated across selected jobs to build a resume's skill list."
           },
+          "links":           {
+            "type": "array",
+            "maxLength": 30,
+            "description": "Portfolio pieces and external links tied to this role — the work you did here. Each carries a stable id so a resume can select, reorder, and reuse a subset per version (mirrors highlights). Rendered under the role.",
+            "items": { "type": "ref", "ref": "#link" }
+          },
           "createdAt":       { "type": "string", "format": "datetime" },
           "updatedAt":       { "type": "string", "format": "datetime" }
         }
@@ -70,6 +76,19 @@
         "id":    { "type": "string", "maxLength": 64, "description": "Stable id, unique within the parent highlight (e.g. \"v1\"). Addressed from resumes as \"<highlightId>#<id>\"." },
         "text":  { "type": "string", "maxLength": 2000 },
         "label": { "type": "string", "maxLength": 80, "description": "What this phrasing is for, e.g. \"design-focused\" or \"one-pager\" — shown in the admin variant picker, never rendered on the site." }
+      }
+    },
+    "link": {
+      "type": "object",
+      "description": "A portfolio piece or external link tied to a job — a sample of the work done in that role, rendered under it. Point it at a first-party /creating post with `work` (resolved to that post's title, URL, and cover as an embed) or at any external page with `url`.",
+      "required": ["id"],
+      "properties": {
+        "id":          { "type": "string", "maxLength": 64, "description": "Stable id, unique within this job. Referenced from is.dame.resume entries[].linkIds." },
+        "work":        { "type": "string", "format": "at-uri", "description": "Backlink to a first-party portfolio post (a site.standard.document homed in the portfolio publication, shown at /creating/<slug>). Resolved live, so the embed tracks the post's current title and cover. Takes precedence over `url`." },
+        "url":         { "type": "string", "format": "uri", "description": "External URL for a piece that isn't a /creating post. Used only when `work` is absent." },
+        "label":       { "type": "string", "maxLength": 200, "description": "Display label. For a `work` link it overrides the resolved post title; for a `url` link it is the link text." },
+        "description": { "type": "string", "maxLength": 500, "description": "Optional one-line note shown beneath the link." },
+        "visibility":  { "type": "string", "enum": ["public", "unlisted", "private"], "default": "public", "description": "Site display intent (NOT privacy). \"private\" links never render; \"unlisted\" render only when a resume explicitly selects them." }
       }
     }
   }

--- a/lexicons/is.dame.resume.json
+++ b/lexicons/is.dame.resume.json
@@ -54,6 +54,12 @@
           "items": { "type": "string", "maxLength": 130 },
           "description": "Which of the job's highlight ids to include, in this order. Each item is either a bare highlight id (\"h3\" — shows the canonical text) or \"<highlightId>#<variantId>\" (\"h3#v2\" — shows that forked phrasing from the highlight's variants). Omit to include every non-private highlight in its natural order."
         },
+        "linkIds": {
+          "type": "array",
+          "maxLength": 30,
+          "items": { "type": "string", "maxLength": 64 },
+          "description": "Which of the job's links[] (portfolio pieces / external links) to show under this role, in this order. Omit to include every non-private link in its natural order."
+        },
         "titleOverride":   { "type": "string", "maxLength": 200, "description": "Optional per-resume retitling of the role (e.g. condensing for a one-pager). Falls back to the job's title." },
         "summaryOverride": { "type": "string", "maxLength": 2000, "description": "Optional per-resume role summary. Falls back to the job's summary." }
       }

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -14,6 +14,7 @@ import {
   RecordRefsField,
   SkillGroupsField,
   ContactField,
+  LinksField,
   TagsInput,
 } from './resumeFields.jsx';
 import '../pages/Admin.css';
@@ -649,6 +650,9 @@ function Field({ field, value, record, onChange, agent, did, collection, rkey, o
       break;
     case 'skillGroups':
       control = <SkillGroupsField value={value} onChange={onChange} />;
+      break;
+    case 'links':
+      control = <LinksField value={value} onChange={onChange} agent={agent} did={did} />;
       break;
     case 'contact':
       control = <ContactField value={value} onChange={onChange} />;

--- a/src/components/resume/ResumeStudio.jsx
+++ b/src/components/resume/ResumeStudio.jsx
@@ -383,6 +383,7 @@ function RecordsSection({ heading, note, collection, records, labelFor, newLabel
               (n, h) => n + (Array.isArray(h.variants) ? h.variants.length : 0),
               0,
             );
+            const linkCount = Array.isArray(v.links) ? v.links.length : 0;
             const dates = formatDateRange(v);
             return (
               <li key={rec.uri} className="admin-record-row rs-record-row">
@@ -396,6 +397,7 @@ function RecordsSection({ heading, note, collection, records, labelFor, newLabel
                     <span className="rs-record-counts">
                       {highlights.length} bullet{highlights.length === 1 ? '' : 's'}
                       {forks > 0 && ` · ${forks} fork${forks === 1 ? '' : 's'}`}
+                      {linkCount > 0 && ` · ${linkCount} link${linkCount === 1 ? '' : 's'}`}
                     </span>
                   </span>
                   {dates && <span className="admin-record-time small-caps">{dates}</span>}

--- a/src/components/resume/ResumeWorkbench.jsx
+++ b/src/components/resume/ResumeWorkbench.jsx
@@ -16,8 +16,25 @@ import {
   resolveHighlightRef,
   collectHighlightUsage,
 } from '../../lib/resumeHelpers.js';
+import { workSlug } from '../../lib/publications.js';
 import { useResumeBundle } from './useResumeBundle.js';
 import './resumeStudio.css';
+
+/** The default set of link ids for an entry: every non-private link, in order. */
+function defaultLinkIds(job) {
+  const links = Array.isArray(job?.links) ? job.links : [];
+  return links.filter((l) => (l.visibility || 'public') !== 'private').map((l) => l.id);
+}
+
+/** Human label for a link — the resolved post title, its label, or its URL. */
+function linkLabel(link, docByUri) {
+  if (!link) return '';
+  if (link.work) {
+    const doc = docByUri?.get(link.work);
+    return link.label || doc?.value?.title || workSlug(doc?.value) || link.work;
+  }
+  return link.label || link.url || '(untitled link)';
+}
 
 /**
  * The tailoring workbench — a resume-centric editor for one version.
@@ -89,7 +106,16 @@ function applyPatch(obj, patch) {
 export default function ResumeWorkbench({ agent, did, rkey }) {
   const navigate = useNavigate();
   const { setPageEditor } = useEditMode();
-  const { resumes, jobs, education, loading: bundleLoading, error: loadError } = useResumeBundle(agent, did);
+  const { resumes, jobs, education, documents, loading: bundleLoading, error: loadError } =
+    useResumeBundle(agent, did);
+
+  // Portfolio posts by URI, so a job's `work` links can be labeled with the
+  // post's live title in the selection UI.
+  const docByUri = useMemo(() => {
+    const m = new Map();
+    for (const r of documents || []) m.set(r.uri, r);
+    return m;
+  }, [documents]);
 
   // The resume value being tailored, plus staged drafts of every canonical
   // job/education record (bullet copy edits and forks land on those).
@@ -368,6 +394,7 @@ export default function ResumeWorkbench({ agent, did, rkey }) {
               removeEntry={removeEntry}
               addEntry={addEntry}
               stageRecord={stageRecord}
+              docByUri={docByUri}
             />
           ))}
 
@@ -492,6 +519,7 @@ function EntriesSection({
   removeEntry,
   addEntry,
   stageRecord,
+  docByUri,
 }) {
   const { listKey, refKey, collection, heading, noun } = KINDS[kind];
   const entries = Array.isArray(draft?.[listKey]) ? draft[listKey] : [];
@@ -531,6 +559,7 @@ function EntriesSection({
             moveEntry={moveEntry}
             removeEntry={removeEntry}
             stageRecord={stageRecord}
+            docByUri={docByUri}
           />
         ))}
       </div>
@@ -611,6 +640,7 @@ function EntryCard({
   moveEntry,
   removeEntry,
   stageRecord,
+  docByUri,
 }) {
   const { listKey, refKey, collection, overrides } = KINDS[kind];
   const highlights = Array.isArray(recordValue?.highlights) ? recordValue.highlights : [];
@@ -902,7 +932,184 @@ function EntryCard({
           <span className="rw-add-bullet-note">(added to the shared {KINDS[kind].noun} record)</span>
         </button>
       </div>
+
+      {kind === 'job' && (
+        <LinkBoard
+          links={Array.isArray(recordValue?.links) ? recordValue.links : []}
+          entry={entry}
+          docByUri={docByUri}
+          collection={collection}
+          rkey={rkey}
+          onChange={(linkIds) => patchEntry(listKey, index, { linkIds })}
+        />
+      )}
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Work samples (per-version link selection)                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Choose which of a job's `links` (portfolio pieces / URLs) show under it on
+ * this version, and in what order. Same include/exclude/reorder model as the
+ * bullet board; the link pool itself is edited on the job record. Selection is
+ * stored on the resume entry as `linkIds` (omit = all non-private).
+ */
+function LinkBoard({ links, entry, docByUri, collection, rkey, onChange }) {
+  const explicit = Array.isArray(entry?.linkIds);
+  const refs = explicit ? entry.linkIds : defaultLinkIds({ links });
+  const included = new Set(refs);
+  const byId = new Map(links.map((l) => [l.id, l]));
+  const excluded = links.filter((l) => !included.has(l.id));
+  const naturalIndex = new Map(links.map((l, i) => [l.id, i]));
+
+  const toggle = (id, on) => {
+    if (!on) {
+      onChange(refs.filter((r) => r !== id));
+      return;
+    }
+    const idx = naturalIndex.get(id) ?? Infinity;
+    const next = refs.slice();
+    let at = next.length;
+    for (let k = 0; k < next.length; k += 1) {
+      if ((naturalIndex.get(next[k]) ?? Infinity) > idx) {
+        at = k;
+        break;
+      }
+    }
+    next.splice(at, 0, id);
+    onChange(next);
+  };
+  const moveLink = (pos, dir) => onChange(moveItem(refs, pos, pos + dir));
+
+  return (
+    <div className="rw-bullets rw-links">
+      <div className="rw-bullets-head">
+        <span className="rf-inline-label">
+          Work samples — {refs.length} of {links.length} shown
+          {!explicit && links.length > 0 && ' — default (all)'}
+        </span>
+        {explicit && (
+          <button
+            type="button"
+            className="admin-link-subtle rw-reset"
+            onClick={() => onChange(undefined)}
+            title="Back to the default: every non-private link, in the job's order"
+          >
+            <RotateCcw size={12} aria-hidden="true" /> reset to default
+          </button>
+        )}
+      </div>
+
+      {links.length === 0 ? (
+        <p className="admin-field-hint">
+          No work samples on this job yet.{' '}
+          <Link to={`/admin?c=${encodeURIComponent(collection)}&r=${encodeURIComponent(rkey || '')}`}>
+            Add portfolio links on the job record →
+          </Link>
+        </p>
+      ) : (
+        <>
+          <ul className="rw-bullet-list">
+            {refs.map((id, pos) => {
+              const link = byId.get(id);
+              if (!link) {
+                return (
+                  <li key={id} className="rw-bullet is-missing">
+                    <span className="admin-error-inline">
+                      Unknown link <code>{id}</code>
+                    </span>
+                    <button
+                      type="button"
+                      className="admin-link-subtle"
+                      onClick={() => onChange(refs.filter((r) => r !== id))}
+                    >
+                      remove
+                    </button>
+                  </li>
+                );
+              }
+              return (
+                <LinkRow
+                  key={id}
+                  included
+                  link={link}
+                  docByUri={docByUri}
+                  pos={pos}
+                  lastPos={refs.length - 1}
+                  onToggle={(on) => toggle(id, on)}
+                  onMove={(dir) => moveLink(pos, dir)}
+                />
+              );
+            })}
+          </ul>
+          {excluded.length > 0 && (
+            <>
+              <div className="rw-excluded-divider small-caps">not on this version</div>
+              <ul className="rw-bullet-list rw-bullet-list-excluded">
+                {excluded.map((link) => (
+                  <LinkRow
+                    key={link.id}
+                    included={false}
+                    link={link}
+                    docByUri={docByUri}
+                    onToggle={(on) => toggle(link.id, on)}
+                  />
+                ))}
+              </ul>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function LinkRow({ included, link, docByUri, pos = 0, lastPos = 0, onToggle, onMove }) {
+  const label = linkLabel(link, docByUri);
+  const kind = link.work ? 'post' : 'link';
+  return (
+    <li className={`rw-bullet${included ? '' : ' is-excluded'}`}>
+      <label className="admin-checkbox rw-bullet-check">
+        <input type="checkbox" checked={included} onChange={(e) => onToggle(e.target.checked)} />
+      </label>
+      <div className="rw-bullet-body">
+        <span className="rw-link-title">{label}</span>
+        <div className="rw-bullet-meta">
+          <span className="rf-badge">{kind}</span>
+          {(link.visibility || 'public') !== 'public' && (
+            <span className="rf-badge">{link.visibility}</span>
+          )}
+          {link.description && <span className="rw-link-desc">{link.description}</span>}
+        </div>
+      </div>
+      {included && onMove && (
+        <div className="rf-controls rw-bullet-order">
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => onMove(-1)}
+            disabled={pos === 0}
+            aria-label="Move up"
+            title="Move up"
+          >
+            <ChevronUp size={15} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="rf-icon-btn"
+            onClick={() => onMove(1)}
+            disabled={pos === lastPos}
+            aria-label="Move down"
+            title="Move down"
+          >
+            <ChevronDown size={15} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </li>
   );
 }
 

--- a/src/components/resume/resumeStudio.css
+++ b/src/components/resume/resumeStudio.css
@@ -507,6 +507,22 @@
   margin-top: var(--space-1);
 }
 
+/* Work-samples board reuses the bullet-board layout. */
+.rw-links {
+  margin-top: var(--space-3);
+}
+
+.rw-link-title {
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  color: var(--ink);
+}
+
+.rw-link-desc {
+  color: var(--ink-muted);
+  font-size: var(--text-xs);
+}
+
 .rw-add-bullet-note {
   color: var(--ink-faint);
   font-size: var(--text-xs);

--- a/src/components/resume/useResumeBundle.js
+++ b/src/components/resume/useResumeBundle.js
@@ -1,14 +1,18 @@
 import { useCallback, useEffect, useState } from 'react';
 import { COLLECTIONS } from '../../config.js';
+import { showOnCreating } from '../../lib/publications.js';
+
+const STANDARD_DOC = 'site.standard.document';
 
 /**
  * Load the full resume working set — every resume version, job, and education
- * record on the signed-in PDS — for the admin studio and tailoring workbench.
- * Records come back as plain `{ uri, value }` objects (JSON round-tripped so
- * drafts can be cloned/mutated safely). `reload()` refetches everything.
+ * record on the signed-in PDS, plus the portfolio posts a job's `work` links
+ * can point at — for the admin studio and tailoring workbench. Records come
+ * back as plain `{ uri, value }` objects (JSON round-tripped so drafts can be
+ * cloned/mutated safely). `reload()` refetches everything.
  */
 export function useResumeBundle(agent, did) {
-  const [bundle, setBundle] = useState(null); // { resumes, jobs, education }
+  const [bundle, setBundle] = useState(null); // { resumes, jobs, education, documents }
   const [error, setError] = useState(null);
   const [tick, setTick] = useState(0);
 
@@ -39,16 +43,18 @@ export function useResumeBundle(agent, did) {
 
     (async () => {
       try {
-        const [resumes, jobs, education] = await Promise.all([
+        const [resumes, jobs, education, docs] = await Promise.all([
           listAll(COLLECTIONS.resume),
           listAll(COLLECTIONS.resumeJob),
           listAll(COLLECTIONS.resumeEducation),
+          listAll(STANDARD_DOC).catch(() => []),
         ]);
-        if (!cancelled) setBundle({ resumes, jobs, education });
+        const documents = docs.filter((r) => showOnCreating(r?.value));
+        if (!cancelled) setBundle({ resumes, jobs, education, documents });
       } catch (err) {
         if (!cancelled) {
           setError(err?.message || String(err));
-          setBundle({ resumes: [], jobs: [], education: [] });
+          setBundle({ resumes: [], jobs: [], education: [], documents: [] });
         }
       }
     })();
@@ -62,6 +68,7 @@ export function useResumeBundle(agent, did) {
     resumes: bundle?.resumes || null,
     jobs: bundle?.jobs || null,
     education: bundle?.education || null,
+    documents: bundle?.documents || null,
     loading: bundle === null,
     error,
     reload,

--- a/src/components/resumeFields.jsx
+++ b/src/components/resumeFields.jsx
@@ -9,6 +9,9 @@ import {
   resolveHighlightRef,
   collectHighlightUsage,
 } from '../lib/resumeHelpers.js';
+import { showOnCreating, workSlug } from '../lib/publications.js';
+
+const STANDARD_DOC = 'site.standard.document';
 
 /**
  * Structured form controls for the resume lexicons, replacing the raw-JSON
@@ -454,6 +457,168 @@ export function HighlightsField({ value, onChange, agent, did, recordUri, usageK
 function truncateText(s, n) {
   const str = String(s || '');
   return str.length <= n ? str : `${str.slice(0, n - 1).trimEnd()}…`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Links (portfolio pieces / external URLs tied to a job)               */
+/* ------------------------------------------------------------------ */
+
+/** Next unique `lN` id for a new link in this list. */
+function nextLinkId(list) {
+  const used = new Set((list || []).map((l) => l?.id).filter(Boolean));
+  let n = (list || []).length + 1;
+  while (used.has(`l${n}`)) n += 1;
+  return `l${n}`;
+}
+
+/**
+ * Editor for a job's `links` — portfolio pieces / external links tied to the
+ * role. Each link is either a first-party `/creating` post (picked from the
+ * portfolio, stored as a `work` AT URI and rendered live as an embed) or an
+ * external `url`. Loads the portfolio documents for the picker.
+ */
+export function LinksField({ value, onChange, agent, did }) {
+  const list = Array.isArray(value) ? value : [];
+  const { records, error } = useCollectionRecords(agent, did, STANDARD_DOC);
+  const portfolioDocs = useMemo(
+    () => (records || []).filter((r) => showOnCreating(r.value)),
+    [records],
+  );
+  const docByUri = useMemo(() => {
+    const m = new Map();
+    for (const r of portfolioDocs) m.set(r.uri, r);
+    return m;
+  }, [portfolioDocs]);
+
+  const update = (i, patch) => onChange(replaceAt(list, i, { ...list[i], ...patch }));
+  const add = () =>
+    onChange([
+      ...list,
+      { id: nextLinkId(list), work: portfolioDocs[0]?.uri || undefined, visibility: 'public' },
+    ]);
+
+  return (
+    <div className="rf-list">
+      {list.length === 0 && (
+        <p className="admin-field-hint">
+          No work samples yet. Attach a <code>/creating</code> post or an external link below.
+        </p>
+      )}
+      {list.map((link, i) => {
+        // `work` is the discriminator: present (even as an empty, not-yet-picked
+        // string) means portfolio-post mode; absent means external-URL mode.
+        const mode = link.work != null ? 'work' : 'url';
+        const doc = link.work ? docByUri.get(link.work) : null;
+        return (
+          <div className="rf-card" key={link.id || i}>
+            <div className="rf-card-head">
+              <code className="rf-id">{link.id || '—'}</code>
+              <select
+                className="admin-input rf-select-sm"
+                value={mode}
+                onChange={(e) => {
+                  if (e.target.value === 'work') update(i, { work: portfolioDocs[0]?.uri, url: undefined });
+                  else update(i, { url: link.url || '', work: undefined });
+                }}
+              >
+                <option value="work">/creating post</option>
+                <option value="url">external link</option>
+              </select>
+              <RowControls
+                index={i}
+                length={list.length}
+                onMove={(from, to) => onChange(move(list, from, to))}
+                onRemove={(idx) => onChange(removeAt(list, idx))}
+                removeLabel="Remove link"
+              />
+            </div>
+
+            {mode === 'work' ? (
+              records == null ? (
+                <p className="admin-field-hint">Loading posts…</p>
+              ) : portfolioDocs.length === 0 ? (
+                <p className="admin-field-hint">
+                  No <code>/creating</code> posts found — publish one, or use an external link.
+                </p>
+              ) : (
+                <select
+                  className="admin-input"
+                  value={link.work || ''}
+                  onChange={(e) => update(i, { work: e.target.value })}
+                >
+                  <option value="">— pick a post —</option>
+                  {portfolioDocs.map((r) => (
+                    <option key={r.uri} value={r.uri}>
+                      {r.value?.title || workSlug(r.value) || r.uri}
+                    </option>
+                  ))}
+                </select>
+              )
+            ) : (
+              <input
+                className="admin-input"
+                type="url"
+                value={link.url || ''}
+                placeholder="https://…"
+                onChange={(e) => update(i, { url: e.target.value })}
+              />
+            )}
+
+            {link.work && !doc && (
+              <p className="admin-field-hint admin-error-inline">
+                Referenced post not found: <code>{link.work}</code>
+              </p>
+            )}
+
+            <label className="rf-inline-field rf-inline-field-block">
+              <span className="rf-inline-label">Label</span>
+              <input
+                className="admin-input"
+                type="text"
+                value={link.label ?? ''}
+                placeholder={
+                  mode === 'work'
+                    ? doc?.value?.title || 'Falls back to the post title'
+                    : 'Link text'
+                }
+                onChange={(e) => update(i, { label: e.target.value || undefined })}
+              />
+            </label>
+            <label className="rf-inline-field rf-inline-field-block">
+              <span className="rf-inline-label">Description</span>
+              <input
+                className="admin-input"
+                type="text"
+                value={link.description ?? ''}
+                placeholder="Optional one-line note"
+                onChange={(e) => update(i, { description: e.target.value || undefined })}
+              />
+            </label>
+            <div className="rf-inline">
+              <label className="rf-inline-field">
+                <span className="rf-inline-label">Visibility</span>
+                <select
+                  className="admin-input rf-select-sm"
+                  value={link.visibility || 'public'}
+                  onChange={(e) => update(i, { visibility: e.target.value })}
+                >
+                  <option value="public">public</option>
+                  <option value="unlisted">unlisted</option>
+                  <option value="private">private</option>
+                </select>
+              </label>
+            </div>
+          </div>
+        );
+      })}
+      <button type="button" className="rf-add" onClick={add}>
+        <Plus size={15} aria-hidden="true" /> Add work sample
+      </button>
+      {error && (
+        <p className="admin-field-hint admin-error-inline">Couldn’t load posts: {error}</p>
+      )}
+    </div>
+  );
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -210,6 +210,10 @@ export const LEXICONS = {
         hint: 'Achievement bullets. Reorder with the arrows; each is referenced by resumes that tailor which bullets to show. Fork a bullet to keep alternate phrasings of the same point that individual resume versions can pick.',
       },
       { key: 'skills', label: 'Skills', type: 'tags' },
+      {
+        key: 'links', label: 'Work samples', type: 'links',
+        hint: 'Portfolio pieces / links tied to this role — a /creating post (embedded with its cover) or any external URL. Resumes pick which to show under the job.',
+      },
       ...COMMON_TIMESTAMPS,
     ],
   },

--- a/src/lib/resumeHelpers.js
+++ b/src/lib/resumeHelpers.js
@@ -126,6 +126,42 @@ export function selectHighlights(job, entry) {
 }
 
 /**
+ * Resolve which links (portfolio pieces / external URLs) a resume entry shows
+ * for its job. Same selection semantics as highlights: an explicit `linkIds`
+ * array (even empty) wins, otherwise every non-private link in natural order.
+ */
+export function selectLinks(job, entry) {
+  const all = Array.isArray(job?.links) ? job.links : [];
+  if (Array.isArray(entry?.linkIds)) {
+    const byId = new Map(all.map((l) => [l.id, l]));
+    return entry.linkIds.map((id) => byId.get(id)).filter(Boolean).filter(VISIBLE);
+  }
+  return all.filter(VISIBLE);
+}
+
+/**
+ * Resolve an entry's selected links into a render-ready shape. A `work` link is
+ * matched against the fetched portfolio documents (a Map<uri, {value}>) so it
+ * can render as an embed of the live post; an unresolved or external link keeps
+ * its stored `url`. Returns `{ id, label, description, href, doc, isWork }`.
+ */
+export function resolveLinks(job, entry, docMap) {
+  return selectLinks(job, entry).map((link) => {
+    const doc = link.work ? docMap.get(link.work)?.value || null : null;
+    return {
+      id: link.id,
+      label: link.label || '',
+      description: link.description || '',
+      href: link.work || link.url || '',
+      url: link.url || '',
+      work: link.work || '',
+      doc,
+      isWork: Boolean(link.work),
+    };
+  });
+}
+
+/**
  * Scan every resume for uses of one job/education record's bullets.
  *
  * Returns Map<baseHighlightId, Array<{ rkey, label, variantId, implicit }>> —
@@ -222,10 +258,11 @@ function indexByUri(records) {
  * `unresolved` collects entry URIs whose job/education record wasn't found
  * (e.g. a stale snapshot) so the caller can decide whether to wait for live.
  */
-export function resolveResume(resumeRecord, jobs, education) {
+export function resolveResume(resumeRecord, jobs, education, documents) {
   const value = resumeRecord?.value || {};
   const jobMap = indexByUri(jobs);
   const eduMap = indexByUri(education);
+  const docMap = indexByUri(documents);
   const unresolved = [];
 
   const roles = [];
@@ -246,6 +283,7 @@ export function resolveResume(resumeRecord, jobs, education) {
       locationType: job.locationType,
       dateRange: formatDateRange(job),
       highlights: selectHighlights(job, entry),
+      links: resolveLinks(job, entry, docMap),
     });
   }
 

--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -205,6 +205,93 @@
   color: var(--accent);
 }
 
+/* --- Selected work (portfolio embeds under a role) ------------------ */
+.resume-work {
+  margin-top: var(--space-3);
+}
+
+.resume-work-label {
+  display: block;
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+  margin-bottom: var(--space-2);
+}
+
+.resume-work-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.resume-work-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  text-decoration: none;
+  color: var(--ink);
+  padding: var(--space-2);
+  border: 1px solid var(--rule-soft);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+a.resume-work-link:hover {
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+}
+
+.resume-work-link.is-static {
+  cursor: default;
+}
+
+.resume-work-thumb {
+  flex-shrink: 0;
+  width: 3.25rem;
+  height: 3.25rem;
+  overflow: hidden;
+  border: 1px solid var(--rule-soft);
+  background: color-mix(in srgb, var(--ink) 4%, var(--page));
+}
+
+.resume-work-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.resume-work-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.resume-work-title {
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  color: var(--ink);
+}
+
+a.resume-work-link:hover .resume-work-title {
+  color: var(--accent);
+}
+
+.resume-work-desc {
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+}
+
+.resume-work-ext {
+  margin-left: auto;
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+}
+
 /* --- Skills --------------------------------------------------------- */
 .resume-skills {
   display: flex;

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -5,6 +5,9 @@ import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, explorerPathFromAtUri } from '../lib/atproto.js';
 import { renderMarkdown } from '../lib/markdown.js';
+import { transformRecords } from '../lib/feedBuilder.js';
+import { showOnCreating, workSlug } from '../lib/publications.js';
+import { coverThumb } from '../lib/creatingHelpers.js';
 import {
   resolveResume,
   pickDefaultResume,
@@ -13,14 +16,95 @@ import {
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Resume.css';
 
+const STANDARD_DOC = 'site.standard.document';
+
 async function fetchResumeBundle() {
   const pds = await resolvePds(ME_DID);
-  const [resumes, jobs, education] = await Promise.all([
+  const [resumes, jobs, education, docs] = await Promise.all([
     listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.resume, max: 50 }).catch(() => []),
     listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.resumeJob, max: 200 }).catch(() => []),
     listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.resumeEducation, max: 100 }).catch(() => []),
+    // Portfolio posts, so a job's `work` links can render as live embeds
+    // (cover + title). Blob URLs are annotated for the covers.
+    listRecords(pds, { repo: ME_DID, collection: STANDARD_DOC, max: 200 }).catch(() => []),
   ]);
-  return { resumes, jobs, education };
+  transformRecords(docs, STANDARD_DOC, pds, ME_DID);
+  const documents = docs.filter((r) => showOnCreating(r?.value));
+  return { resumes, jobs, education, documents };
+}
+
+/** Shape one resolved link for rendering: title, href, thumbnail, external? */
+function displayLink(link) {
+  if (link.isWork && link.doc) {
+    const slug = workSlug(link.doc);
+    return {
+      id: link.id,
+      title: link.label || link.doc.title || slug,
+      description: link.description,
+      href: slug ? `/creating/${slug}` : null,
+      thumb: coverThumb(link.doc),
+      external: false,
+    };
+  }
+  // External link, or a `work` ref whose post wasn't found (fall back to any url).
+  const href = link.url || null;
+  if (!href && !link.label) return null;
+  return {
+    id: link.id,
+    title: link.label || href,
+    description: link.description,
+    href,
+    thumb: null,
+    external: true,
+  };
+}
+
+/** "Selected work" row under a role: portfolio embeds + external links. */
+function RoleWork({ links }) {
+  const items = (links || []).map(displayLink).filter(Boolean);
+  if (items.length === 0) return null;
+  return (
+    <div className="resume-work">
+      <span className="resume-work-label small-caps">Selected work</span>
+      <ul className="resume-work-list">
+        {items.map((it) => (
+          <li key={it.id} className={`resume-work-item${it.thumb ? ' has-thumb' : ''}`}>
+            <ResumeWorkLink item={it} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ResumeWorkLink({ item }) {
+  const inner = (
+    <>
+      {item.thumb && (
+        <span className="resume-work-thumb">
+          <img src={item.thumb.url} alt={item.thumb.alt || ''} loading="lazy" />
+        </span>
+      )}
+      <span className="resume-work-body">
+        <span className="resume-work-title">{item.title}</span>
+        {item.description && <span className="resume-work-desc">{item.description}</span>}
+      </span>
+      {item.external && item.href && <span className="resume-work-ext" aria-hidden="true">↗</span>}
+    </>
+  );
+  if (!item.href) return <span className="resume-work-link is-static">{inner}</span>;
+  if (item.external) {
+    return (
+      <a className="resume-work-link" href={item.href} target="_blank" rel="noreferrer noopener">
+        {inner}
+      </a>
+    );
+  }
+  return (
+    <Link className="resume-work-link" to={item.href}>
+      {inner}
+    </Link>
+  );
 }
 
 export default function Resume() {
@@ -38,7 +122,9 @@ export default function Resume() {
   const resumes = items?.resumes || [];
   const resolved = useMemo(() => {
     const chosen = slug ? findResumeBySlug(resumes, slug) : pickDefaultResume(resumes);
-    return chosen ? resolveResume(chosen, items?.jobs, items?.education) : null;
+    return chosen
+      ? resolveResume(chosen, items?.jobs, items?.education, items?.documents)
+      : null;
   }, [resumes, items, slug]);
 
   const summaryHtml = useMemo(() => {
@@ -168,6 +254,7 @@ export default function Resume() {
                           ))}
                         </ul>
                       )}
+                      <RoleWork links={role.links} />
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
Adds a "work samples" layer to the resume, parallel to highlights: attach portfolio pieces / links to a job and choose which appear under it per resume version.

## Model

A canonical `links[]` pool on `is.dame.resume.job`, with per-version selection via `entries[].linkIds` — exactly mirroring how highlights work. Each link points either at:
- a first-party **/creating post** (`site.standard.document`) via `work` — resolved live to its title + cover and rendered as an **embed**, so the resume tracks the post as it changes; or
- any **external page** via `url`.

Like highlights, links live on the job and each resume picks which to show (`linkIds`; omit = all non-private, in order), so different versions can surface different work under the same job.

## What's included

- **Schema**: `#link` def + `links[]` on the job, `linkIds[]` on the resume entry; `lexicons.js` `links` field; `RESUME.md`.
- **Helpers**: `selectLinks()` (parallel to `selectHighlights`); `resolveResume()` takes the portfolio documents and resolves each role's links to a render-ready shape (graceful when a post is missing).
- **Resume render**: a "Selected work" row under each role — embed cards (cover + title → `/creating/<slug>`) and external links.
- **Job editor**: `LinksField` — per link, pick a `/creating` post or type a URL, with label, description, and visibility.
- **Workbench**: a per-version "Work samples" board (include / exclude / reorder, labeled with the live post title); studio job rows show link counts.

## Verification

- **Node unit tests**: `selectLinks` selection + visibility semantics; `resolveResume` work-vs-url resolution, per-version subsetting, and graceful degrade when a post isn't found.
- **Playwright**: the job `LinksField` (mode toggle, portfolio picker excludes non-portfolio docs, add) and the workbench board (default-all, uncheck → materialize, reset), plus a render screenshot of the embeds.

Build clean; rebased onto latest `main` (no conflict with the #234 typography fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro)_