### PR TITLE
Block editor: insert a block between blocks, not just at the bottom

### DIFF
--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -27,6 +27,9 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
   const blocks = content.pages[0].blocks;
 
   const [activeIndex, setActiveIndex] = useState(null);
+  // Which gap's "insert here" palette is open (an index into blocks, meaning
+  // "insert before block N"), or null. Only one open at a time.
+  const [openInsertSlot, setOpenInsertSlot] = useState(null);
   const [dragIndex, setDragIndex] = useState(null);
   const [dropIndex, setDropIndex] = useState(null); // insertion slot (0..length)
   const [canUndo, setCanUndo] = useState(false);
@@ -107,8 +110,11 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
   );
 
   const insertMany = useCallback(
-    (newBlocks) => {
-      const next = blocks.concat(newBlocks.map((b) => ({ $type: WRAPPER_TYPE, block: b })));
+    (newBlocks, atIndex = null) => {
+      const wrapped = newBlocks.map((b) => ({ $type: WRAPPER_TYPE, block: b }));
+      const next = blocks.slice();
+      const index = atIndex == null ? next.length : atIndex;
+      next.splice(index, 0, ...wrapped);
       commit(next, { kind: 'structural' });
     },
     [blocks, commit],
@@ -207,15 +213,29 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
     [dragIndex, moveTo],
   );
 
-  // Collapse the active editor when the user clicks outside the editor.
+  // Collapse the active editor / insert palette when the user clicks outside.
   useEffect(() => {
-    if (activeIndex == null) return undefined;
+    if (activeIndex == null && openInsertSlot == null) return undefined;
     function onDown(e) {
-      if (rootRef.current && !rootRef.current.contains(e.target)) setActiveIndex(null);
+      if (rootRef.current && !rootRef.current.contains(e.target)) {
+        setActiveIndex(null);
+        setOpenInsertSlot(null);
+      }
     }
     document.addEventListener('mousedown', onDown);
     return () => document.removeEventListener('mousedown', onDown);
+  }, [activeIndex, openInsertSlot]);
+
+  // Editing a block and an open insert palette are mutually exclusive focuses:
+  // opening one closes the other.
+  useEffect(() => {
+    if (activeIndex != null) setOpenInsertSlot(null);
   }, [activeIndex]);
+
+  const openInsert = useCallback((index) => {
+    setActiveIndex(null);
+    setOpenInsertSlot(index);
+  }, []);
 
   // Drop focus into the block that just became active — and again if its type
   // changes underfoot (e.g. converting text → heading swaps the editor).
@@ -227,6 +247,11 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
 
   const handleRootKeyDown = useCallback(
     (e) => {
+      if (e.key === 'Escape' && openInsertSlot != null) {
+        e.preventDefault();
+        setOpenInsertSlot(null);
+        return;
+      }
       if (!(e.metaKey || e.ctrlKey)) return;
       const isZ = e.key === 'z' || e.key === 'Z';
       const isY = e.key === 'y' || e.key === 'Y';
@@ -238,7 +263,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
         redo();
       }
     },
-    [undo, redo],
+    [undo, redo, openInsertSlot],
   );
 
   return (
@@ -282,6 +307,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
             'blocks-editor-item',
             isActive ? 'is-active' : 'is-preview',
             dragIndex === i ? 'is-dragging' : '',
+            openInsertSlot === i ? 'has-insert-open' : '',
             showBefore ? 'drop-before' : '',
             showAfter ? 'drop-after' : '',
           ]
@@ -296,6 +322,24 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
               onDragOver={(e) => handleDragOver(e, i)}
               onDrop={(e) => handleDrop(e, i)}
             >
+              {dragIndex == null && (
+                <InsertSlot
+                  index={i}
+                  open={openInsertSlot === i}
+                  onOpen={openInsert}
+                  onClose={() => setOpenInsertSlot(null)}
+                  agent={agent}
+                  did={did}
+                  onInsert={(block) => {
+                    insertBlock(block, i);
+                    setOpenInsertSlot(null);
+                  }}
+                  onInsertMany={(bs) => {
+                    insertMany(bs, i);
+                    setOpenInsertSlot(null);
+                  }}
+                />
+              )}
               <div
                 className="blocks-editor-handle"
                 draggable
@@ -389,7 +433,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
           );
         })}
       </ol>
-      <BlockAdder agent={agent} did={did} onInsert={insertBlock} onInsertMany={insertMany} />
+      <BlockAdder agent={agent} onInsert={insertBlock} onInsertMany={insertMany} />
     </div>
   );
 }
@@ -498,7 +542,13 @@ function focusFirstField(container) {
   }
 }
 
-function BlockAdder({ agent, did, onInsert, onInsertMany }) {
+/**
+ * The shared block-type palette: one button per block kind, plus a multi-image
+ * "Gallery…" upload. `onInsert(block)` / `onInsertMany(blocks)` decide where the
+ * new block(s) land — the bottom adder appends; an insert slot drops them at a
+ * specific gap.
+ */
+function BlockPalette({ agent, onInsert, onInsertMany }) {
   const galleryInputRef = useRef(null);
   const [uploadStatus, setUploadStatus] = useState(null);
 
@@ -528,8 +578,7 @@ function BlockAdder({ agent, did, onInsert, onInsertMany }) {
   }
 
   return (
-    <div className="blocks-editor-add">
-      <div className="blocks-editor-add-label small-caps gutter">Add block</div>
+    <>
       <div className="blocks-editor-add-buttons">
         <AddButton onClick={() => onInsert({ $type: 'pub.leaflet.blocks.text', plaintext: '', facets: [] })}>
           Text
@@ -574,6 +623,52 @@ function BlockAdder({ agent, did, onInsert, onInsertMany }) {
         onChange={handleGallery}
       />
       {uploadStatus && <p className="admin-field-hint">{uploadStatus}</p>}
+    </>
+  );
+}
+
+/** Bottom-of-editor adder — appends a new block. */
+function BlockAdder({ agent, onInsert, onInsertMany }) {
+  return (
+    <div className="blocks-editor-add">
+      <div className="blocks-editor-add-label small-caps gutter">Add block</div>
+      <BlockPalette agent={agent} onInsert={onInsert} onInsertMany={onInsertMany} />
+    </div>
+  );
+}
+
+/**
+ * Between-blocks inserter: a "+" that appears in the gap at the top of a block
+ * (revealed on hover) and, when clicked, drops the block-type palette right
+ * there so a new block lands at that slot instead of at the bottom.
+ */
+function InsertSlot({ index, open, onOpen, onClose, agent, onInsert, onInsertMany }) {
+  return (
+    <div className={`blocks-editor-insert${open ? ' is-open' : ''}`}>
+      <button
+        type="button"
+        className="blocks-editor-insert-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          if (open) onClose();
+          else onOpen(index);
+        }}
+        onMouseDown={(e) => e.stopPropagation()}
+        aria-label="Insert a block here"
+        aria-expanded={open}
+        title="Insert a block here"
+      >
+        <span aria-hidden="true">+</span>
+      </button>
+      {open && (
+        <div
+          className="blocks-editor-insert-menu"
+          role="menu"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <BlockPalette agent={agent} onInsert={onInsert} onInsertMany={onInsertMany} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -49,6 +49,7 @@
 }
 
 .blocks-editor-item {
+  position: relative;
   display: flex;
   align-items: stretch;
   gap: 0.25rem;
@@ -56,6 +57,77 @@
   border-radius: 0;
   background: transparent;
   padding: 0.1rem 0.4rem 0.1rem 0.1rem;
+}
+
+/* Raise the block whose insert palette is open so the popover isn't covered
+   by the block below it. */
+.blocks-editor-item.has-insert-open {
+  z-index: 20;
+}
+
+/* ---- Between-blocks inserter ("+" in the gap at a block's top edge) ---- */
+.blocks-editor-insert {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Straddle the gap above the block; the container itself is click-through so
+     only the "+" (and the open menu) capture pointer events. */
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.blocks-editor-insert-btn {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  padding: 0;
+  border: 1px solid var(--rule, rgba(0, 0, 0, 0.2));
+  background: var(--page, #fff);
+  color: var(--ink-soft, rgba(0, 0, 0, 0.55));
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 100ms ease, color 100ms ease, border-color 100ms ease;
+}
+
+/* Reveal the "+" when hovering the block, or when its menu is open. */
+.blocks-editor-item:hover > .blocks-editor-insert > .blocks-editor-insert-btn,
+.blocks-editor-insert.is-open .blocks-editor-insert-btn,
+.blocks-editor-insert-btn:focus-visible {
+  opacity: 1;
+}
+
+.blocks-editor-insert-btn:hover,
+.blocks-editor-insert.is-open .blocks-editor-insert-btn {
+  color: var(--accent, #5e7a47);
+  border-color: var(--accent-soft, #8a9f6e);
+}
+
+/* The palette popover, dropped just below the "+". */
+.blocks-editor-insert-menu {
+  pointer-events: auto;
+  position: absolute;
+  top: calc(50% + 0.9rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  max-width: min(28rem, 90vw);
+  padding: 0.5rem;
+  border: 1px solid var(--rule, rgba(0, 0, 0, 0.2));
+  background: var(--page, #fff);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+}
+
+.blocks-editor-insert-menu .blocks-editor-add-buttons {
+  justify-content: center;
 }
 
 .blocks-editor-main {


### PR DESCRIPTION
Adds a way to insert a block mid-document in the blog/creating block editor, instead of scrolling to the bottom "Add block" panel every time.

## What it does

A hover-revealed **"+"** sits in the gap at the top of each block. Clicking it drops the block-type palette right there and inserts the chosen block at that slot — then opens it for editing. To insert between blocks A and B, hover B and click its "+"; the first block's "+" prepends at the top.

The capability was already latent: `insertBlock(block, atIndex)` accepted an index; the UI just never passed one.

## Details

- The palette (every block type + multi-image **Gallery** upload) is refactored into a shared `BlockPalette` used by both the bottom adder and the new insert slots, so they never drift apart.
- `insertMany()` now takes an optional index, so a gallery can drop mid-document too.
- One slot's palette is open at a time; it closes on insert, on **Escape**, on an outside click, or when a block is opened for editing. Insert slots hide while dragging so they don't clash with the drag drop-indicator.
- The bottom "Add block" panel stays for appending; nothing about existing flows changes.

## Verification

Playwright run against the editor: open a slot → insert a heading between two blocks (lands at the right index and becomes the active/editing block), prepend at index 0, Escape-to-cancel (no block added), and the bottom adder still appends. Build clean; rebased onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoEdEhw8wi6hRyKQX5haro)_