### PR TITLE
Cap the document page at the reading measure, not the title's own ch

### DIFF
--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -104,23 +104,25 @@
   margin: 0 auto;
 }
 
-/* Cap the document title at the SAME visual column as the article body.
+/* Cap the whole document page — the title AND the article together — at the
+   reading measure, resolved ONCE against the page's own body font (1rem,
+   weight 400, --serif). This is what makes the title line up with the article
+   edge-for-edge.
 
-   --measure is `65ch`, and `ch` resolves against each element's own font-size.
-   The article inherits the body size (~1rem), so its `65ch` is the true reading
-   column. The title is --text-4xl (3rem = 3× the base), so a bare
-   `max-width: var(--measure)` resolves to 65ch at 3× scale — three times too
-   wide, which is why the title ran the full page width. Divide by the title's
-   font-size ratio (--text-4xl ÷ --text-base = 3) so the cap lands at 65ch *at
-   the body size* and the title lines up with the article edge-for-edge. The
-   ratio cancels the font metrics, so this holds for any --serif. The mobile
-   override re-derives the divisor for the smaller --text-3xl title. */
-.page:has(> .blog-article) > .page-title,
-.page:has(> .creating-work-page) > .page-title {
-  max-width: calc(var(--measure) / 3);
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
+   `--measure` is `65ch`, and `ch` resolves against each element's OWN font. An
+   earlier fix capped the title directly with `calc(--measure / 3)` to cancel
+   the title's 3× font-size — algebraically exact, but only while the title and
+   article share glyph metrics. They don't reliably: the title is --text-4xl at
+   weight 600, so whenever that heavy weight renders a wider digit advance than
+   the body-weight article — a synthesised bold, or a fallback serif in the
+   moment before Crimson Pro loads — its `65ch/3` measured a wider column and
+   the title spilled past the article on both sides. Capping the shared parent
+   never touches the title's font at all: `.page` is body-size/weight, so its
+   `65ch` is the true reading column, and both children simply stretch to it. */
+.page:has(> .blog-article),
+.page:has(> .creating-work-page) {
+  max-width: var(--measure);
+  margin-inline: auto;
 }
 
 .blog-article-meta {
@@ -209,12 +211,6 @@
    typography.css (shared with the resume summary and about page). */
 
 @media (max-width: 700px) {
-  /* The title shrinks to --text-3xl (2.25rem) here, so re-derive the divisor
-     (--text-3xl ÷ --text-base = 2.25) to keep the cap at 65ch @ the body size. */
-  .page:has(> .blog-article) > .page-title,
-  .page:has(> .creating-work-page) > .page-title {
-    max-width: calc(var(--measure) / 2.25);
-  }
   .blogging-toc-link {
     grid-template-columns: 1fr;
     gap: var(--space-2);


### PR DESCRIPTION
## What

Blog-post and portfolio-work titles could render **wider** than the article column beneath them.

The title was capped with `calc(var(--measure) / 3)` — dividing the `65ch` measure by the title's 3× font-size to land it on the article's column. That's algebraically exact, but only while the title and article share glyph metrics. The catch: `ch` resolves against *each element's own font*, and the title is `--text-4xl` at **weight 600** while the article is weight 400. Whenever that heavy weight rendered a wider digit advance than the body text — a synthesized bold, or a fallback serif in the moment before Crimson Pro loads — the title's `65ch/3` measured a wider column and spilled past the article on both sides.

## Fix

Cap the shared `.page` **once**, at `var(--measure)` resolved against the page's own 1rem / weight-400 body font — the true reading column. The title and article then simply stretch to that one width, so the cap never touches the title's font and they line up edge-for-edge regardless of how the heavy title weight renders. Drops the now-unneeded per-title desktop (`/3`) and mobile (`/2.25`) overrides.

## Verification

- Title and article widths are identical (0px delta) at 1440 / 900 / 600 / 390px.
- **Robustness:** even when the title's font is forced to a much wider face (monospace, weight 900) to simulate the synthetic-bold / fallback case, the title stays pinned to the content column — the old code widened here.
- Visual: the title's left edge lands exactly on the content column's edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r)_