### PR TITLE
Don't render the metadata summary on standard-doc work pages

### DIFF
--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -100,10 +100,15 @@ export default function CreatingWork() {
           )}
           {v?.createdAt && <span>· {formatDateLong(v.createdAt)}</span>}
         </div>
-        {/* Only the legacy `summary` shows as an on-page intro. The standard.site
-            `description` is the open-graph / feed-summary blurb and isn't
-            rendered on the work itself. */}
-        {v?.summary && (
+        {/* The summary is metadata — the feed-card / open-graph blurb, not page
+            copy. For standard/leaflet docs it's auto-derived from the body's
+            opening (feedBuilder's leafletSynopsis) when the record has no
+            `description`, so rendering it here just duplicates the first lines of
+            the body. Show it only for LEGACY works (no `content.pages`), whose
+            `summary` is a hand-written intro distinct from the body; standard
+            docs keep it as metadata only, exactly as the blog post page omits
+            its `description`. */}
+        {v?.summary && !v?.content?.pages && (
           <p className="page-intro">{v.summary}</p>
         )}
         {v?.content?.pages ? (


### PR DESCRIPTION
## What

Creating/portfolio work pages showed a `.page-intro` blurb above the body that duplicated its opening lines.

That blurb is `v.summary`, which for standard/leaflet docs `feedBuilder` **auto-derives** from the first ~280 chars of the body (`leafletSynopsis`) for feed cards and open-graph — it's metadata, not page copy. The guard `{v?.summary && …}` predates that derivation; it was written when only legacy works carried a hand-written `summary` worth showing as an intro.

## Fix

Gate the intro on `!v?.content?.pages`, so it renders **only for legacy works** (whose `summary` is a genuine hand-written intro distinct from the body). Standard docs now keep the summary as metadata only — exactly as the blog-post page already omits its `description`.

## Verification

Rendered the real component against both record shapes via a local snapshot fixture:

- **Standard doc** → the metadata synopsis is hidden, the body still renders.
- **Legacy work** → the hand-written intro still shows.

The blog-post page (`BlogPost`) was already correct — it never rendered the summary/description — so this was a creating-page-only bug; both are now consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv4Gp1ZmipKqDpZsCovE7r)_