### PR TITLE
Only auto-open the "Open in…" picker for bsky.app links

### DIFF
--- a/src/hooks/useWaypointsModal.jsx
+++ b/src/hooks/useWaypointsModal.jsx
@@ -1,18 +1,20 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import WaypointsSheet from '../components/WaypointsSheet.jsx';
-import { isWaypointHref } from '../lib/waypoints.js';
+import { isAutoWaypointHref } from '../lib/waypoints.js';
 
 const WaypointsModalContext = createContext(null);
 
 /**
- * Global "Open in…" picker for outbound Atmosphere links.
+ * Global "Open in…" picker for outbound Bluesky links.
  *
- * Rather than wrap every one of the dozens of `bsky.app` / `at://` links
- * scattered across the site, the provider installs a single capture-phase
- * click listener on the document. When a plain left-click lands on an anchor
- * pointing at a record on a supported Atmosphere host, it cancels the
- * navigation and opens a modal where the visitor can choose which client to
- * open it in (Bluesky, Anisota, Grain, Leaflet, a dev tool, …).
+ * Rather than wrap every one of the dozens of `bsky.app` links scattered across
+ * the site, the provider installs a single capture-phase click listener on the
+ * document. When a plain left-click lands on an anchor pointing at a record on
+ * Bluesky's web client (bsky.app), it cancels the navigation and opens a modal
+ * where the visitor can choose which client to open it in (Bluesky, Anisota,
+ * Grain, Leaflet, a dev tool, …). Links to other hosts — anisota.net,
+ * leaflet.pub, the Bluesky forks, … — navigate natively; the picker is still
+ * reachable for those records via the explicit "Open in…" affordance.
  *
  * Escape hatches:
  *   - Modified clicks (⌘/Ctrl/Shift/Alt, middle-click) are left alone so
@@ -47,9 +49,10 @@ export function WaypointsModalProvider({ children }) {
       // native navigation).
       if (anchor.closest('[data-no-waypoints]')) return;
 
-      // Use the resolved absolute href from the DOM; unknown schemes like
-      // `at://` are preserved verbatim by the browser.
-      if (!isWaypointHref(anchor.href)) return;
+      // Only Bluesky (bsky.app) record/profile links auto-open the picker;
+      // every other host (anisota.net, leaflet.pub, the forks, …) navigates
+      // natively. Uses the resolved absolute href from the DOM.
+      if (!isAutoWaypointHref(anchor.href)) return;
 
       e.preventDefault();
       setHref(anchor.href);

--- a/src/lib/waypoints.js
+++ b/src/lib/waypoints.js
@@ -12,14 +12,11 @@ import {
   matchSupportedUrl,
   resolveAtUri,
   resolveUrl,
-  SUPPORTED_HOSTS,
   WAYPOINT_CATEGORIES_DATA,
   WAYPOINT_DESTINATIONS_DATA,
   CATEGORY_ORDER,
 } from '@aturi.to/waypoints';
 import { resolveHandle } from './atproto.js';
-
-const SUPPORTED_HOST_SET = new Set(SUPPORTED_HOSTS);
 
 // --- Waypoint policy -------------------------------------------------------
 // The upstream catalog returns a URL for nearly every client on every record
@@ -96,25 +93,35 @@ function applyWaypointPolicy(result) {
   };
 }
 
+// Hosts whose links should *automatically* open the "Open in…" picker on a
+// plain left-click. We deliberately scope this to Bluesky's own web client
+// (bsky.app) only. A bsky.app link is the case where a visitor is most likely
+// to prefer opening the record in a *different* client, so it's worth
+// interposing the picker. Every other host the catalog can resolve — including
+// anisota.net, the other Bluesky forks (deer.social, reddwarf.app, …), and the
+// publication readers (leaflet.pub, grain.social, …) — is left to navigate
+// natively, since a visitor clicking one of those clearly meant to go there.
+// The picker stays reachable for any record via the explicit "Open in…"
+// affordance (<AturiActions>), which opens it imperatively regardless of host.
+const AUTO_INTERCEPT_HOSTS = new Set(['bsky.app']);
+
 /**
- * Cheap, synchronous test for "is this a link the waypoints modal should
- * intercept?" — a bare `at://` URI, or a URL on one of the Atmosphere hosts
- * the catalog knows how to reverse-parse into a record. Everything else
- * (internal SPA links, unrelated external links) returns false so the click
- * falls through to the browser untouched.
+ * Cheap, synchronous test for "should a plain left-click on this link auto-open
+ * the waypoints picker?" — true only for a Bluesky (bsky.app) URL the catalog
+ * can reverse-parse into a record. Everything else (internal SPA links, other
+ * Atmosphere hosts, unrelated external links) returns false so the click falls
+ * through to the browser untouched.
  */
-export function isWaypointHref(href) {
+export function isAutoWaypointHref(href) {
   if (!href) return false;
-  const s = String(href);
-  if (s.startsWith('at://')) return true;
   let url;
   try {
-    url = new URL(s);
+    url = new URL(String(href));
   } catch {
     return false;
   }
   // Fast host gate before the (slightly heavier) pattern match.
-  if (!SUPPORTED_HOST_SET.has(url.hostname)) return false;
+  if (!AUTO_INTERCEPT_HOSTS.has(url.hostname)) return false;
   try {
     return matchSupportedUrl(url) != null;
   } catch {


### PR DESCRIPTION
## Summary

The global "Open in…" click interceptor previously fired for **every host** the waypoints catalog can resolve (~20 hosts — `anisota.net`, `leaflet.pub`, `deer.social`, `reddwarf.app`, `grain.social`, …). So clicking an `anisota.net` document link (e.g. `https://anisota.net/profile/dame.is/document/3m36ccn5kis2x`) popped the picker instead of just opening the record in Anisota.

This scopes the **automatic** interception to Bluesky's own web client (`bsky.app`) only. Links to every other host now navigate natively.

## Changes

- **`src/lib/waypoints.js`** — added `AUTO_INTERCEPT_HOSTS = new Set(['bsky.app'])`; renamed `isWaypointHref` → `isAutoWaypointHref` and narrowed it to gate on `bsky.app`; dropped the now-unused `SUPPORTED_HOSTS` / `at://` interception handling.
- **`src/hooks/useWaypointsModal.jsx`** — updated the import, call site, and docstrings to reflect Bluesky-only interception.

## Unaffected

The explicit "Open in…" affordance under records (`AturiActions`) uses the imperative `openWaypoints()` → `resolveWaypoints()` path, so the picker stays fully reachable for **any** record — including anisota/leaflet ones. Only the automatic pop-on-click behavior changed.

## Verification

Ran `isAutoWaypointHref` against the real `@aturi.to/waypoints` resolver with 16 URL cases — all pass:

- `anisota.net/.../document/...` (the reported example) → navigates natively, no sheet
- `bsky.app` profiles / posts / lists → sheet opens
- `leaflet.pub`, `deer.social`, `reddwarf.app`, `grain.social` → navigate natively
- `bsky.app/` root, `/settings`, internal SPA links, `at://` URIs → not intercepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013M8dYo6tPzh5RjTX3VsaAg)_