### PR TITLE
Home hero CTAs: Resume, Projects, Blog

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -547,14 +547,14 @@ export default function Home() {
       headTitle="dame.is"
     >
       <nav className="home-hero-cta" aria-label="Primary destinations">
-        <Link className="home-hero-cta-btn home-hero-cta-primary" to="/creating">
+        <Link className="home-hero-cta-btn home-hero-cta-primary" to="/for-hire">
+          Resume
+        </Link>
+        <Link className="home-hero-cta-btn" to="/creating">
           Projects
         </Link>
         <Link className="home-hero-cta-btn" to="/blogging">
           Blog
-        </Link>
-        <Link className="home-hero-cta-btn" to="/guestbook">
-          Guestbook
         </Link>
         <button
           type="button"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -198,8 +198,8 @@
 }
 
 /* Home hero CTAs: destinations underneath the animated sentence.
-   The primary (Projects) is filled in the accent color to match the
-   compass button's visual weight; the secondaries (Blog, Guestbook)
+   The primary (Resume) is filled in the accent color to match the
+   compass button's visual weight; the secondaries (Projects, Blog)
    read as outlines, with the shuffle utility riding at the end. */
 .home-hero-cta {
   display: flex;


### PR DESCRIPTION
Updates the primary-destination CTA row next to the hero shuffle button on the home page.

## Changes
- **Resume** → `/for-hire` (canonical route; `/resume` permanently redirects there). Now the filled accent "primary" button, keeping the existing "lead button is filled" pattern.
- **Projects** → `/creating` — outline button.
- **Blog** → `/blogging` — outline button.
- Removed the **Guestbook** link from this row (still reachable via its own route and the main nav).
- Updated the CTA CSS comment to reflect the new set.

## Verification
- Offline Vite build passes (`vite build`). The chunk-size warning is pre-existing and unrelated.
- No tests or other components reference the home hero CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xT96YqCw45jR6Yenv4AVD

---
_Generated by [Claude Code](https://claude.ai/code/session_013xT96YqCw45jR6Yenv4AVD)_