### PR TITLE
Document meta: unify blog & creating date stamp, drop meta margins

### DIFF
--- a/src/components/DocumentMeta.jsx
+++ b/src/components/DocumentMeta.jsx
@@ -1,0 +1,30 @@
+import { relativeDay, formatDateFull } from '../lib/time.js';
+import { dayOfLife } from '../lib/dayOfLife.js';
+
+/**
+ * The one-line publication stamp shared by the blog-post and creating-work
+ * document pages:
+ *
+ *   Published 7 months ago on April 7, 2026 (Day 12,221)
+ *
+ * Rendered as a single flowing phrase — not the bullet-separated atoms the
+ * `.blog-article-meta` container uses elsewhere — so the whole thing reads as
+ * one sentence. Both pages render it identically, so it lives here to keep
+ * them in sync rather than being duplicated per page.
+ *
+ * `date` is the document's publish date (a blog post's `publishedAt`, a work's
+ * `createdAt`); the day number is that date's position in dame's day-of-life
+ * count.
+ */
+export default function DocumentMeta({ date }) {
+  if (!date) return null;
+  const day = dayOfLife(date);
+  return (
+    <div className="blog-article-meta">
+      <span>
+        Published {relativeDay(date)} on {formatDateFull(date)}
+        {day ? ` (Day ${day.toLocaleString()})` : ''}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -3,11 +3,10 @@ import { Link, useParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import LeafletDocument from '../components/LeafletDocument.jsx';
 import Comments from '../components/Comments.jsx';
+import DocumentMeta from '../components/DocumentMeta.jsx';
 import { BlogPostSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
-import { formatDateFull, relativeDay } from '../lib/time.js';
-import { dayOfLife } from '../lib/dayOfLife.js';
 import { getPostThread } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { showOnBlog, isDraft } from '../lib/publications.js';
@@ -144,7 +143,6 @@ function resolveById(data, id) {
 function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
   const value = record?.value || {};
   const created = value.publishedAt || value.createdAt;
-  const dayNum = created ? dayOfLife(created) : null;
   const title = value.title || id;
 
   return (
@@ -155,11 +153,7 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
       headTitle={`${title} — dame.is`}
     >
       <article className="blog-article reveal">
-        <div className="blog-article-meta">
-          {created && <span>{relativeDay(created)}</span>}
-          {created && <span>{formatDateFull(created)}</span>}
-          {dayNum && <span>Day {dayNum.toLocaleString()}</span>}
-        </div>
+        <DocumentMeta date={created} />
         {/* The `description` field is intentionally not rendered here — it's the
             open-graph / feed-summary blurb, and on the post itself it just
             duplicated the opening lines of the body. */}

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -146,17 +146,6 @@
   color: var(--ink-faint);
 }
 
-.blog-article-tags {
-  display: inline-flex;
-  gap: var(--space-2);
-}
-
-.blog-article-tag {
-  font-variant: all-small-caps;
-  letter-spacing: 0.12em;
-  color: var(--accent);
-}
-
 .blog-prose {
   font-family: var(--serif);
   font-size: 1.05rem;

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -134,7 +134,6 @@
   font-size: var(--text-xs);
   color: var(--ink-muted);
   letter-spacing: 0.04em;
-  margin: var(--space-2) 0 var(--space-6);
 }
 
 /* Bullet separators between the meta atoms — relative time • date • day —

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -3,13 +3,13 @@ import { Link, useParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import { CreatingWorkSkeleton } from '../components/Skeleton.jsx';
 import LeafletDocument from '../components/LeafletDocument.jsx';
+import DocumentMeta from '../components/DocumentMeta.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { renderMarkdown } from '../lib/markdown.js';
-import { formatDateLong } from '../lib/time.js';
-import { showOnCreating, isDraft, workSlug, workCategory } from '../lib/publications.js';
+import { showOnCreating, isDraft, workSlug } from '../lib/publications.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Creating.css';
 import './Blogging.css';
@@ -94,12 +94,7 @@ export default function CreatingWork() {
       headTitle={v?.title ? `${v.title} — dame.is` : `${slug} — dame.is`}
     >
       <article className="creating-work-page reveal">
-        <div className="blog-article-meta">
-          {workCategory(v) && (
-            <span className="blog-article-tag">{workCategory(v)}</span>
-          )}
-          {v?.createdAt && <span>· {formatDateLong(v.createdAt)}</span>}
-        </div>
+        <DocumentMeta date={v?.createdAt} />
         {/* The summary is metadata — the feed-card / open-graph blurb, not page
             copy. For standard/leaflet docs it's auto-derived from the body's
             opening (feedBuilder's leafletSynopsis) when the record has no


### PR DESCRIPTION
Unifies the metadata line on the blog-post and creating-work document pages and tightens its spacing.

## Date stamp
Both pages now render one flowing line via a shared `DocumentMeta` component:

> Published 3 months ago on April 7, 2026 (Day 12,024)

Previously they diverged:
- **Blog post:** `7 months ago • April 7, 2026 • Day 12,221` — bullet-separated atoms
- **Creating work:** `PRESENTATION • · 7 April 2026` — category tag, a stray leading `· `, day-month-year order, no day number

The creating page drops its category tag in favor of the unified stamp. The shared component reuses the existing `relativeDay` / `formatDateFull` / `dayOfLife` helpers so the two pages can't drift.

## Spacing
Removes the `var(--space-2) 0 var(--space-6)` margins on `.blog-article-meta` — they added too much vertical space around the line.

## Cleanup
- Removed now-unused imports from both pages (`formatDateLong`, `workCategory`, `relativeDay`/`formatDateFull`/`dayOfLife` where they moved into the component).
- Removed the orphaned `.blog-article-tag(s)` CSS (no remaining users anywhere in the repo).
- Kept the `.blog-article-meta` bullet-separator rule — `Record.jsx` still relies on it.

Verified with an offline `vite build` (passes; only pre-existing chunk-size warnings) and a runtime check of the exact rendered string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6vZhbdYn4EVbD6K4iM7XY

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6vZhbdYn4EVbD6K4iM7XY)_