### PR TITLE
Fix debug panel error: home route claimed a nonexistent is.dame.page/home record

### DIFF
--- a/src/hooks/useAtUri.js
+++ b/src/hooks/useAtUri.js
@@ -197,7 +197,13 @@ function deriveFromRoute(pathname, override) {
 }
 
 function pageRkeyForPath(pathname) {
-  if (pathname === '/' || pathname === '/index') return 'home';
+  // The home route ('/' + its '/index' alias) is intentionally omitted: the
+  // feed aggregates many records rather than being backed by a single
+  // is.dame.page/home record. No such record exists, `home` isn't in
+  // PAGE_REGISTRY, and nothing renders it — so claiming it only made the debug
+  // pane's "Edit record" fetch a missing record and surface the raw PDS
+  // "Could not locate record" error. Mirrors middleware.js's
+  // TOP_LEVEL_PAGE_RKEY, which also excludes home.
   if (pathname === '/posting') return 'posting';
   if (pathname === '/logging') return 'logging';
   if (pathname === '/blogging') return 'blogging';

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -540,10 +540,15 @@ export default function Home() {
     return map;
   }, [groups, newUris]);
 
+  // The home feed aggregates many records; it has no single is.dame.page/home
+  // backing record (none exists, and it isn't in PAGE_REGISTRY), so PageShell
+  // gets no `atUri`. Advertising that phantom record made the debug pane's
+  // "Edit record" surface a raw PDS "Could not locate record" error and emitted
+  // a dead <link rel="alternate"> hint. See pageRkeyForPath in
+  // src/hooks/useAtUri.js.
   return (
     <PageShell
       title={<HeroSentence shuffleRef={shuffleRef} />}
-      atUri={`at://${ME_DID}/is.dame.page/home`}
       headTitle="dame.is"
     >
       <nav className="home-hero-cta" aria-label="Primary destinations">


### PR DESCRIPTION
## Problem

Opening the atmosphere debug panel on the home page surfaced a raw PDS error:

> Could not locate record: at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/is.dame.page/home

That string is the verbatim `RecordNotFound` message the PDS returns — confirmed against the live PDS, where `is.dame.page/home` genuinely does not exist (the real page records are `sharing, resume, posting, mothing, logging, listening, guestbook, curating, creating, blogging, about`).

## Root cause

The home route advertised a backing page record it never had. Every other layer already treats home as recordless:

- `home` isn't in `PAGE_REGISTRY`, so the admin "Site pages" panel offers no way to create/edit it
- nothing calls `usePageContent('home')` — the home title is the rotating `HeroSentence`, not a page record
- `middleware.js`'s `TOP_LEVEL_PAGE_RKEY` deliberately omits `/` so the feed route stays static
- `Home.jsx` itself notes "the feed has no single backing record"

Only two client spots claimed the phantom record: `pageRkeyForPath('/')` → `'home'` and the hardcoded `atUri` on Home's `PageShell`. Together they made the debug pane offer the signed-in owner an "Edit record" button that mounted `RecordEditor` → `getRecord({collection: is.dame.page, rkey: home})` → echoed the PDS's `RecordNotFound` message. It also emitted a dead `<link rel="alternate" type="application/at-record+json">` discovery hint for crawlers.

## Fix

Drop both references so the home route correctly reports no single backing record:

- `src/hooks/useAtUri.js` — remove the `/` → `home` mapping in `pageRkeyForPath`
- `src/pages/Home.jsx` — remove the `atUri={…/is.dame.page/home}` prop

The debug pane on `/` now shows "No backing record for this route yet." with no failed fetch and no misleading edit affordance — matching the other recordless routes (`/guestbook`, `/mothing`, `/curating`) and aligning the client with the middleware, registry, prefetch, and PDS.

## Verification

Built the app and drove the debug pane in a real browser (Chromium/Playwright), before and after:

| | Before | After |
|---|---|---|
| `at uri` row | `at://…/is.dame.page/home` | `—` |
| `lexicon` | `is.dame.page` | `—` |
| edit affordance | "Sign in to edit" → "Edit record" (→ the error) | none |
| empty state | tries to resolve the phantom | "No backing record for this route yet." |
| `getRecord` for `rkey=home` | fired | not fired |

`npm run build:offline` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShEL6NpDeVaTHS6cZb24zX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShEL6NpDeVaTHS6cZb24zX)_