### PR TITLE
Pace are.na mirror writes against the PDS rate-limit budget

### DIFF
--- a/arena-mirror/README.md
+++ b/arena-mirror/README.md
@@ -106,10 +106,43 @@ new settings instead of serving a mix.
   out, 429s honour `Retry-After`, transient errors retry with backoff. An
   [are.na personal access token](https://www.are.na/developers) raises the
   rate ceiling and lets the mirror see your private channels.
+- **Write-rate aware.** A PDS caps record writes per-account on a points budget
+  (the reference/Bluesky PDS: CREATE=3, UPDATE=2, DELETE=1 points; ~5,000/hour,
+  ~35,000/day — so ~1,666 new records/hour, ~11,666/day). The mirror reads the
+  PDS's own `ratelimit-*` headers and slows down as it nears the wall; for a
+  short wait it sleeps, for a sustained one it ends the run **partial** and
+  resumes next time. It adapts to whatever your PDS actually enforces rather
+  than assuming a number.
 
 Known staleness window: editing a block (say, its title) without touching any
 channel may not bump the containing channel's `updated_at`, so the edit rides
 along with the next change to any channel containing it — or a `--full` run.
+
+## Rate limits & the first backfill
+
+Mirroring a large account is a **multi-day** job — not because the mirror is
+slow, but because the PDS won't accept the writes faster. A 15k–20k-record
+account is 45k–60k write points, well past a single day's ~35k budget. This is
+expected and handled: every run does as much as the budget allows, then stops
+cleanly and the next run continues (the sync-state record tracks exactly where
+it left off; re-listed records upsert rather than duplicate).
+
+Two ways to run the backfill:
+
+- **Attended (`--drain`, recommended):** the CLI sleeps through the hourly
+  window and keeps grinding, so one invocation spends a full day's budget
+  (~11k records) before pausing on the daily cap. Rerun the next day until it
+  reports `Backfill complete`.
+- **Unattended (the cron):** each daily firing writes until the first sustained
+  limit (~an hour's worth) and stops. Correct, but converging a big first
+  backfill this way takes many days — prefer `--drain` for the initial load and
+  let the cron handle incremental upkeep afterward.
+
+Blobs are a separate axis: `--media blobs` also pushes the file bytes (which can
+be gigabytes) and consumes PDS **storage**, which many hosted/third-party PDSes
+quota per account. Size it first with `--dry-run --media blobs` (the report's
+`blobs.plannedBytes`), consider `--scope created` to store only your own
+uploads, and check your PDS's storage limit before committing.
 
 ## Usage
 
@@ -132,6 +165,7 @@ const report = await syncArenaMirror({
   // nsidBase: 'is.dame.arena.mirror',
   // channels: ['some-slug'],            // subset, for testing
   // timeBudgetMs: 50_000,
+  // writeMaxSleepMs: 65 * 60_000,       // sleep through rate-limit windows (attended backfill)
   // full: true,
   // dryRun: true,
   log: console.log,

--- a/arena-mirror/src/defaults.js
+++ b/arena-mirror/src/defaults.js
@@ -64,6 +64,12 @@ export function normalizeOptions(opts = {}) {
     full: Boolean(opts.full),
     dryRun: Boolean(opts.dryRun),
     timeBudgetMs: opts.timeBudgetMs ? Number(opts.timeBudgetMs) : null,
+    // How long the write pacer will sleep at a rate-limit wall before instead
+    // ending the run partial (to resume later). Small = "stop and resume"
+    // (cron); large = "sleep through the window and keep going" (attended
+    // backfill). Default splits the difference: ride out short waits, stop for
+    // hourly/daily walls.
+    writeMaxSleepMs: opts.writeMaxSleepMs != null ? Number(opts.writeMaxSleepMs) : 120_000,
   };
 }
 

--- a/arena-mirror/src/engine.js
+++ b/arena-mirror/src/engine.js
@@ -21,7 +21,7 @@
 import { ArenaClient } from './arena.js';
 import { collectionsFor, normalizeOptions, settingsSignature } from './defaults.js';
 import { channelValue, blockValue, connectionValue, valuesEqual } from './records.js';
-import { listCollection, getRecord, applyOps, uploadBlob } from './pds.js';
+import { listCollection, getRecord, applyOps, uploadBlob, WritePacer, WritePauseNeeded } from './pds.js';
 
 const asId = (v) => (v == null ? null : String(v));
 
@@ -52,6 +52,12 @@ export async function syncArenaMirror(options) {
 
   const client =
     arenaClient || new ArenaClient({ token, userAgent: 'arena-pds-mirror (+https://dame.is)', log });
+
+  // Paces PDS writes against the account's points budget. maxSleepMs is the
+  // stop-vs-wait ceiling: the cron keeps it small (stop cleanly, resume next
+  // firing); an attended `--drain` backfill raises it to sleep through the
+  // hourly window and keep going until the daily budget is spent.
+  const pacer = new WritePacer({ maxSleepMs: o.writeMaxSleepMs, log });
 
   // --- 1. are.na identity + channel enumeration -----------------------------
   const profile = await client.user(o.user);
@@ -194,12 +200,13 @@ export async function syncArenaMirror(options) {
     }
     try {
       const dl = await client.fetchBinary(media.url, { maxBytes: o.maxBlobBytes });
-      const ref = await uploadBlob(agent, dl.bytes, target.contentType || dl.contentType);
+      const ref = await uploadBlob(agent, dl.bytes, target.contentType || dl.contentType, { pacer });
       if (!ref) throw new Error('uploadBlob returned no ref');
       target.blob = ref;
       blobs.uploaded++;
       blobs.uploadedBytes += dl.bytes.byteLength;
     } catch (err) {
+      if (err instanceof WritePauseNeeded) throw err; // rate pause is not a per-blob failure
       keepPrior();
       blobs.fallback++;
       log(`  blob refresh skipped for ${media.url} (${err.message}) — ${prior?.blob ? 'kept previous blob' : 'reference only'}`);
@@ -228,8 +235,10 @@ export async function syncArenaMirror(options) {
 
   const overBudget = () => Boolean(o.timeBudgetMs && Date.now() - startedAt > o.timeBudgetMs);
   let suspectChannels = 0;
+  let rateLimited = false;
 
-  for (const ch of scoped) {
+  try {
+   for (const ch of scoped) {
     const chId = asId(ch.id);
     if (overBudget()) {
       partial = true;
@@ -315,7 +324,7 @@ export async function syncArenaMirror(options) {
 
     let chFailed = 0;
     if (!o.dryRun && ops.length) {
-      const res = await applyOps(agent, did, ops, { log });
+      const res = await applyOps(agent, did, ops, { log, pacer });
       chFailed = res.fail;
       writes.failed += res.fail;
     }
@@ -328,6 +337,17 @@ export async function syncArenaMirror(options) {
     log(`channel "${ch.title}" (${ch.slug}): ${ops.length} write(s)${chFailed ? `, ${chFailed} FAILED` : ''}.`);
     // After a mid-walk abort the loop keeps going only to tally the rest as
     // unvisited — the top-of-loop budget check short-circuits each of them.
+   }
+  } catch (err) {
+    if (!(err instanceof WritePauseNeeded)) throw err;
+    // Out of write budget for now: stop starting work, keep everything
+    // already written, and resume on the next run. The channel being written
+    // when this fired isn't marked fresh, so its remaining records are
+    // reconciled next time (idempotent — re-listed records upsert, not
+    // duplicate).
+    partial = true;
+    rateLimited = true;
+    log(err.message + ' — run is partial; rerun (or the next cron) resumes.');
   }
 
   // --- 5. deletion pass (complete runs only) ---------------------------------
@@ -369,9 +389,19 @@ export async function syncArenaMirror(options) {
       if (o.dryRun) {
         writes.deleted = stale.length;
       } else if (stale.length) {
-        const res = await applyOps(agent, did, stale, { log });
-        writes.deleted = res.ok;
-        writes.failed += res.fail;
+        try {
+          const res = await applyOps(agent, did, stale, { log, pacer });
+          writes.deleted = res.ok;
+          writes.failed += res.fail;
+        } catch (err) {
+          if (!(err instanceof WritePauseNeeded)) throw err;
+          // All record writes are done by now; deletions just didn't finish.
+          // Safe to resume next run — a complete run will re-detect the same
+          // stale records.
+          partial = true;
+          rateLimited = true;
+          log(err.message + ' — deletions deferred to the next run.');
+        }
       }
     }
   }
@@ -405,16 +435,19 @@ export async function syncArenaMirror(options) {
     channelsFresh,
     channelsUnvisited,
     suspectChannels: suspectChannels || undefined,
+    rateLimited: rateLimited || undefined,
+    pausedMs: pacer.paused || undefined,
     blocksExternal,
     writes,
     blobs,
     localOnly,
     arenaRequests: client.requestCount,
   };
+  const partialWhy = rateLimited ? 'write rate limit' : 'time budget';
   log(
     `${o.dryRun ? 'dry run — would write' : 'wrote'} ${writes.created} new / ${writes.updated} updated ` +
       `(${writes.unchanged} unchanged), ${o.dryRun ? 'would delete' : 'deleted'} ${writes.deleted}` +
-      `${writes.failed ? `, ${writes.failed} FAILED` : ''}${partial ? ' — PARTIAL (time budget hit, next run resumes)' : ''}.`,
+      `${writes.failed ? `, ${writes.failed} FAILED` : ''}${partial ? ` — PARTIAL (${partialWhy}; next run resumes)` : ''}.`,
   );
   return report;
 }

--- a/arena-mirror/src/pds.js
+++ b/arena-mirror/src/pds.js
@@ -1,8 +1,79 @@
 // PDS plumbing for the mirror: collection listing, batched writes, blob
-// upload. Takes any logged-in AtpAgent (or an unauthenticated one for
-// read-only dry runs — listRecords/getRecord are public XRPC).
+// upload, and write-rate pacing. Takes any logged-in AtpAgent (or an
+// unauthenticated one for read-only dry runs — listRecords/getRecord are
+// public XRPC).
+//
+// Why pacing lives here: a PDS rate-limits record writes per-DID on a points
+// budget (the reference/Bluesky PDS: CREATE=3, UPDATE=2, DELETE=1 points;
+// 5,000/hour and 35,000/day). A full backfill of a large are.na account is
+// tens of thousands of creates — well over a single day's budget — so the
+// mirror must (a) slow down as it approaches the limit and (b) stop cleanly
+// and resume later when the wait would be long, rather than error out. The
+// pacer reads the PDS's own `ratelimit-*` headers, so it adapts to whatever
+// limit the PDS actually enforces instead of hard-coding one.
 
 const rkeyFromUri = (uri) => String(uri || '').split('/').pop() || null;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Thrown when the write budget is exhausted and the reset is further off than
+ * the pacer is willing to sleep. The engine catches it, marks the run partial,
+ * persists progress, and resumes on the next invocation.
+ */
+export class WritePauseNeeded extends Error {
+  constructor(waitMs) {
+    super(`PDS write rate limit reached — ~${Math.round(waitMs / 1000)}s until reset, pausing run`);
+    this.name = 'WritePauseNeeded';
+    this.waitMs = waitMs;
+  }
+}
+
+/** ms until a rate-limit window resets, from response/error headers. */
+function resetWaitMs(headers) {
+  const h = headers || {};
+  const reset = Number(h['ratelimit-reset']); // unix seconds
+  if (Number.isFinite(reset) && reset > 1e9) return Math.max(0, reset * 1000 - Date.now());
+  const retryAfter = Number(h['retry-after']); // delta seconds
+  if (Number.isFinite(retryAfter) && retryAfter >= 0) return retryAfter * 1000;
+  return 0;
+}
+
+/**
+ * Adapts write throughput to the PDS's advertised budget. `observe` is called
+ * after every successful write with that response's headers; `backoff` is
+ * called on a 429. Both sleep for short waits and throw WritePauseNeeded when
+ * the wait exceeds `maxSleepMs` — that ceiling is the whole knob: small (the
+ * cron) means "stop and resume next run", large (an attended `--drain`
+ * backfill) means "sleep through the hourly window and keep grinding".
+ */
+export class WritePacer {
+  constructor({ minRemaining = 50, maxSleepMs = 120_000, log = () => {} } = {}) {
+    this.minRemaining = minRemaining;
+    this.maxSleepMs = maxSleepMs;
+    this.log = log;
+    this.paused = 0; // total ms spent sleeping on rate limits (for the report)
+  }
+
+  async _waitOrPause(waitMs, why) {
+    if (waitMs > this.maxSleepMs) throw new WritePauseNeeded(waitMs);
+    if (waitMs <= 0) return;
+    this.log(`${why} — waiting ${Math.round(waitMs / 1000)}s`);
+    this.paused += waitMs;
+    await sleep(waitMs);
+  }
+
+  async observe(headers) {
+    const remaining = Number(headers?.['ratelimit-remaining']);
+    if (!Number.isFinite(remaining) || remaining > this.minRemaining) return;
+    await this._waitOrPause(resetWaitMs(headers) || 1000, `approaching write limit (remaining ${remaining})`);
+  }
+
+  async backoff(headers) {
+    await this._waitOrPause(resetWaitMs(headers) || 15_000, 'write rate limited (429)');
+  }
+}
+
+const is429 = (err) => err?.status === 429 || /rate ?limit/i.test(err?.message || '');
 
 /** Every record in a collection as `{ rkey, value }`. */
 export async function listCollection(agent, did, collection) {
@@ -28,57 +99,93 @@ export async function getRecord(agent, did, collection, rkey) {
 }
 
 /**
- * Apply create/update/delete ops in applyWrites batches. On a failed batch,
- * falls back to per-op calls so one bad record can't sink its batchmates.
+ * Apply create/update/delete ops in applyWrites batches, paced by `pacer`.
+ * On a non-rate-limit batch failure, falls back to per-op calls so one bad
+ * record can't sink its batchmates. A 429 (batch or per-op) defers to the
+ * pacer, which may sleep or throw WritePauseNeeded to end the run. Records use
+ * side-loaded lexicons, so validation is off.
  * Ops: `{ type: 'create'|'update'|'delete', collection, rkey, value? }`.
- * Records use side-loaded lexicons, so validation is off.
  */
-export async function applyOps(agent, did, ops, { batchSize = 50, log = () => {} } = {}) {
+export async function applyOps(agent, did, ops, { batchSize = 50, log = () => {}, pacer } = {}) {
   let ok = 0;
   let fail = 0;
-  for (let i = 0; i < ops.length; i += batchSize) {
+  const toWrite = (op) =>
+    op.type === 'delete'
+      ? { $type: 'com.atproto.repo.applyWrites#delete', collection: op.collection, rkey: op.rkey }
+      : {
+          $type: `com.atproto.repo.applyWrites#${op.type}`,
+          collection: op.collection,
+          rkey: op.rkey,
+          value: op.value,
+        };
+
+  for (let i = 0; i < ops.length; ) {
     const batch = ops.slice(i, i + batchSize);
-    const writes = batch.map((op) =>
-      op.type === 'delete'
-        ? { $type: 'com.atproto.repo.applyWrites#delete', collection: op.collection, rkey: op.rkey }
-        : {
-            $type: `com.atproto.repo.applyWrites#${op.type}`,
-            collection: op.collection,
-            rkey: op.rkey,
-            value: op.value,
-          },
-    );
     try {
-      await agent.com.atproto.repo.applyWrites({ repo: did, writes, validate: false });
+      const res = await agent.com.atproto.repo.applyWrites({ repo: did, writes: batch.map(toWrite), validate: false });
       ok += batch.length;
+      i += batch.length;
+      if (pacer) await pacer.observe(res?.headers);
     } catch (err) {
+      if (is429(err)) {
+        // Not a bad batch — we're over budget. Wait (or pause the run) and
+        // retry the SAME batch; nothing was written.
+        if (pacer) await pacer.backoff(err.headers);
+        else throw err; // no pacer (shouldn't happen for writes) → surface it
+        continue;
+      }
       log(`applyWrites batch failed (${err.message}) — retrying ${batch.length} op(s) individually`);
       for (const op of batch) {
-        try {
-          if (op.type === 'delete') {
-            await agent.com.atproto.repo.deleteRecord({ repo: did, collection: op.collection, rkey: op.rkey });
-          } else {
-            await agent.com.atproto.repo.putRecord({
-              repo: did,
-              collection: op.collection,
-              rkey: op.rkey,
-              record: op.value,
-              validate: false,
-            });
+        for (;;) {
+          try {
+            if (op.type === 'delete') {
+              await agent.com.atproto.repo.deleteRecord({ repo: did, collection: op.collection, rkey: op.rkey });
+            } else {
+              const res = await agent.com.atproto.repo.putRecord({
+                repo: did,
+                collection: op.collection,
+                rkey: op.rkey,
+                record: op.value,
+                validate: false,
+              });
+              if (pacer) await pacer.observe(res?.headers);
+            }
+            ok++;
+            break;
+          } catch (opErr) {
+            if (is429(opErr) && pacer) {
+              await pacer.backoff(opErr.headers); // may throw WritePauseNeeded
+              continue; // retry this op
+            }
+            fail++;
+            log(`  ${op.type} ${op.collection}/${op.rkey} failed: ${opErr.message}`);
+            break;
           }
-          ok++;
-        } catch (opErr) {
-          fail++;
-          log(`  ${op.type} ${op.collection}/${op.rkey} failed: ${opErr.message}`);
         }
       }
+      i += batch.length;
     }
   }
   return { ok, fail };
 }
 
-/** Upload bytes as a blob; returns the blob ref to embed in a record. */
-export async function uploadBlob(agent, bytes, contentType) {
-  const res = await agent.uploadBlob(bytes, { encoding: contentType });
-  return res?.data?.blob || null;
+/**
+ * Upload bytes as a blob; returns the blob ref to embed in a record. A 429
+ * defers to the pacer (sleep or WritePauseNeeded). Other errors propagate to
+ * the caller, which decides whether to fall back to a reference.
+ */
+export async function uploadBlob(agent, bytes, contentType, { pacer } = {}) {
+  for (;;) {
+    try {
+      const res = await agent.uploadBlob(bytes, { encoding: contentType });
+      if (pacer) await pacer.observe(res?.headers);
+      return res?.data?.blob || null;
+    } catch (err) {
+      if (is429(err) && pacer) {
+        await pacer.backoff(err.headers); // may throw WritePauseNeeded
+        continue;
+      }
+      throw err;
+    }
+  }
 }

--- a/scripts/mirror-arena.mjs
+++ b/scripts/mirror-arena.mjs
@@ -24,12 +24,21 @@
 //                         leave this off unless you understand that.
 //   --channels a,b,c      Only sync these channel slugs/ids (testing; skips deletions).
 //   --budget-s N          Stop cleanly after ~N seconds; next run resumes.
+//   --drain               Attended backfill: sleep through PDS rate-limit windows
+//                         (up to ~65 min) and keep going, instead of stopping at
+//                         the first wall. One --drain run spends a full day's write
+//                         budget (~11k records) then pauses on the daily cap; rerun
+//                         the next day to continue. Without it, the run stops at the
+//                         first sustained limit and you rerun to resume.
 //   --user SLUG           are.na profile slug (default: ARENA_USER from src/config.js).
 //   --pds URL             Override the PDS endpoint (default: resolved from your DID).
 //
-// First backfill advice: run it from here (no time budget), with --media blobs
-// if you want the files themselves on your PDS. The daily cron then keeps it
-// fresh — keep its ARENA_MIRROR_* env vars matching the flags you use here.
+// First backfill advice: a PDS caps record writes (~5k points/hr, ~35k/day;
+// create=3pts), so a big account is a multi-day job. Run it from here with
+// --drain and let it grind; rerun daily until it reports no more work. Consider
+// --media references first (no blob bandwidth) and --scope created to shrink the
+// blob volume. The daily cron then keeps it fresh — keep its ARENA_MIRROR_* env
+// vars matching the flags you use here.
 
 import { AtpAgent } from '@atproto/api';
 
@@ -53,6 +62,7 @@ function parseArgs(argv) {
     maxBlobMb: null,
     channels: null,
     budgetS: null,
+    drain: false,
     user: null,
     pds: null,
   };
@@ -66,6 +76,7 @@ function parseArgs(argv) {
     else if (a === '--max-blob-mb') args.maxBlobMb = Number(argv[++i]);
     else if (a === '--channels') args.channels = String(argv[++i] || '').split(',');
     else if (a === '--budget-s') args.budgetS = Number(argv[++i]);
+    else if (a === '--drain') args.drain = true;
     else if (a === '--user') args.user = argv[++i];
     else if (a === '--pds') args.pds = argv[++i];
     else die(`unknown argument: ${a}`);
@@ -122,11 +133,23 @@ async function main() {
       maxBlobBytes: args.maxBlobMb ? Math.round(args.maxBlobMb * 1024 * 1024) : undefined,
       channels: args.channels,
       timeBudgetMs: args.budgetS ? args.budgetS * 1000 : null,
+      // --drain sleeps through the hourly window (~65 min) to keep going; the
+      // default rides out short waits but stops at a sustained wall to resume.
+      writeMaxSleepMs: args.drain ? 65 * 60 * 1000 : undefined,
       full: args.full,
       dryRun: args.dryRun,
       log,
     });
     log('report:', JSON.stringify(report, null, 2));
+    if (report.partial) {
+      log(
+        report.rateLimited
+          ? 'Stopped at the PDS write limit — rerun to continue (or --drain to sleep through the window).'
+          : 'Partial run — rerun to continue.',
+      );
+    } else if (!args.dryRun) {
+      log('Backfill complete — nothing left to sync.');
+    }
     if (report.writes?.failed) process.exitCode = 2;
   } catch (err) {
     die(err.stack || err.message);


### PR DESCRIPTION
Follow-up to #246. A dry run of a real backfill (~17.5k records, 4.5 GB of blobs) surfaced that the mirror had no PDS write pacing — it would trip 429s and, at the daily budget wall, fail rather than resume.

## The constraint

A PDS caps record writes per-account on a points budget (reference/Bluesky PDS: CREATE=3, UPDATE=2, DELETE=1; ~5,000/hour, ~35,000/day → ~1,666 new records/hour, ~11,666/day). A large first backfill is therefore inherently a multi-day job.

## The fix

- **`WritePacer`** (in `arena-mirror/src/pds.js`) reads the PDS's own `ratelimit-*` response headers and adapts to whatever the PDS actually enforces — it slows as remaining nears zero, sleeps through short waits, and throws `WritePauseNeeded` on a sustained wall.
- The engine catches that, marks the run **partial**, persists progress, and resumes next run (re-listed records upsert, never duplicate).
- Both record writes (`applyOps`, incl. the per-op fallback) and blob uploads route through the pacer; 429s retry the same batch instead of counting as failures.
- One knob (`writeMaxSleepMs`): the cron keeps it small (stop cleanly, resume next firing); the CLI's new **`--drain`** flag raises it so an attended backfill sleeps through the hourly window and spends a full day's budget before pausing on the daily cap.
- Report gains `rateLimited` / `pausedMs`; README documents the multi-day backfill and blob-storage sizing.

## Verification

Pacer behavior unit-tested against mock agents (sleep-on-low-remaining, pause-on-long-reset, retry-then-succeed, per-op fallback); dry run against the real account and a site build both pass. No changes to record shapes or the sync contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q)_