### PR TITLE
Custom OG cards for all record routes; drop mothing time-span

### DIFF
--- a/api/og.js
+++ b/api/og.js
@@ -70,6 +70,7 @@ export default async function handler(req, res) {
     let subtitle = '';
     let nsid = DEFAULT.nsid;
     let record = false;
+    let body = false;
     if (q.page) {
       pathname = cleanPath(String(q.page));
       const meta = pageMeta(pathname);
@@ -84,6 +85,9 @@ export default async function handler(req, res) {
       subtitle = String(q.subtitle || '');
       nsid = String(q.nsid || DEFAULT.nsid);
       record = true;
+      // `body=1` renders the label as wrapped body copy (a post/status quote)
+      // instead of a big headline.
+      body = q.body === '1' || q.body === 'true';
     } else if (q.title || q.subtitle) {
       label = String(q.title || '');
       subtitle = String(q.subtitle || '');
@@ -99,6 +103,7 @@ export default async function handler(req, res) {
       subtitle,
       nsid,
       record,
+      body,
       segs: segsFor(pathname),
       avatarUri,
       folio: folio(folioAt),

--- a/middleware.js
+++ b/middleware.js
@@ -57,9 +57,13 @@ export const config = {
     '/curating',
     '/curating/:slug',
     '/listening',
+    '/listening/:rkey',
     '/posting',
+    '/posting/:rkey',
     '/logging',
+    '/logging/:rkey',
     '/mothing',
+    '/mothing/:rkey',
     '/sharing',
   ],
 };
@@ -140,19 +144,30 @@ export default async function middleware(request) {
       const section = pageMeta(sectionPath);
       const rec = await recordMeta(path, url.origin);
       if (rec) {
-        // The record resolved: its own title/description, its own OG card
-        // (breadcrumb = section, headline = the record title), and its at://
-        // URI for the head. Falls back below only when it can't be resolved.
-        title = `${rec.title} — ${SITE.domain}`;
-        desc = rec.description || section.desc;
+        // The record resolved: its own OG card + at:// URI for the head. Falls
+        // back below only when it can't be resolved.
+        //   • titled records (blog/work/channel/track/moth) → "{title} — dame.is"
+        //     with the title as the card headline and its description beneath.
+        //   • textOnly records (posts, statuses) have no title of their own, so
+        //     the section names the page, the text becomes the description, and
+        //     the card renders the text as body copy.
+        const cardSubtitle = rec.textOnly ? '' : rec.description;
+        if (rec.textOnly) {
+          title = section.title;
+          desc = rec.title;
+        } else {
+          title = `${rec.title} — ${SITE.domain}`;
+          desc = rec.description || section.desc;
+        }
         const params = new URLSearchParams({
           section: sectionSeg,
           label: rec.title,
-          subtitle: desc,
+          subtitle: cardSubtitle,
           nsid: rec.nsid || section.nsid,
         });
         // Stamp the card's day-of-life folio with the record's own date.
         if (rec.date) params.set('date', rec.date);
+        if (rec.textOnly) params.set('body', '1');
         ogImage = `${ORIGIN}/api/og?${params.toString()}`;
         atUri = rec.atUri;
         cid = rec.cid;

--- a/og/design.js
+++ b/og/design.js
@@ -216,21 +216,9 @@ function subCardS4(t, { segs, label, subtitle, nsid, avatarUri, folio }) {
 // .page-title: serif 600, roman ink, with only the section term accent-italic
 // in the breadcrumb — the .gerund treatment). The description sits below on the
 // half-pitch rules, exactly like a section card.
-function recordCard(t, { segs, title, subtitle, nsid, avatarUri, folio }) {
+function recordCard(t, { segs, title, subtitle, nsid, avatarUri, folio, body }) {
   const DIV = 320, CX = DIV, bcBy = P - LE;
-  const colW = W - PAD - CX; // headline / description column width
-  const { size, lines } = fitHeadline(title || '', colW, 3);
-  const descAll = wrapText(subtitle || '', 24, colW);
-  const descLines = descAll.slice(0, 3);
-  if (descAll.length > descLines.length && descLines.length) {
-    const last = descLines[descLines.length - 1].replace(/\s+\S*$/, '');
-    descLines[descLines.length - 1] = `${last}…`;
-  }
-  // Headline lines land on coarse rules from row 3 down; the description
-  // follows a coarse row below the last headline line, on half-pitch rules.
-  const headBase = 3 * P - 8;
-  const descBase = (3 + lines.length) * P - 8;
-  const bandTo = descBase + descLines.length * HP;
+  const colW = W - PAD - CX; // content column width
   // Breadcrumb "dame.is / {section}" with the section term echoing .gerund.
   const section = segs[segs.length - 1] || '';
   const crumb = [
@@ -238,17 +226,48 @@ function recordCard(t, { segs, title, subtitle, nsid, avatarUri, folio }) {
     h('div', { style: { color: t.inkFaint } }, '/'),
     h('div', { style: { color: t.accent, fontStyle: 'italic', fontWeight: 600 } }, section),
   ];
+
+  let content;
+  let bandTo;
+  if (body) {
+    // A post / status: no title of its own, so `title` IS the text. Render it
+    // as wrapped body copy — more lines, smaller, all on the fine rules, like
+    // writing on ruled paper — rather than a giant headline.
+    const size = 30;
+    const all = wrapText(title || '', size, colW);
+    const lines = all.slice(0, 7);
+    if (all.length > lines.length && lines.length) {
+      const last = lines[lines.length - 1].replace(/\s+\S*$/, '');
+      lines[lines.length - 1] = `${last}…`;
+    }
+    const top = 3 * P - 8;
+    bandTo = top + lines.length * HP;
+    content = lines.map((l, i) => at(l, { size, by: top + i * HP, left: CX, weight: 400, color: t.ink }));
+  } else {
+    // A titled record: big serif headline (rows 3+, coarse pitch), then a short
+    // description a coarse row below, on the half-pitch rules.
+    const { size, lines } = fitHeadline(title || '', colW, 3);
+    const descAll = wrapText(subtitle || '', 24, colW);
+    const descLines = descAll.slice(0, 3);
+    if (descAll.length > descLines.length && descLines.length) {
+      const last = descLines[descLines.length - 1].replace(/\s+\S*$/, '');
+      descLines[descLines.length - 1] = `${last}…`;
+    }
+    const headBase = 3 * P - 8;
+    const descBase = (3 + lines.length) * P - 8;
+    bandTo = descBase + descLines.length * HP;
+    content = [
+      ...lines.map((l, i) => at(l, { size, by: headBase + i * P, left: CX, weight: 600, color: t.ink, ls: '-0.01em' })),
+      ...descLines.map((l, i) => at(l, { size: 24, by: descBase + i * HP, left: CX, color: t.inkSoft, weight: 400 })),
+    ];
+  }
+
   return shell(t, [
     at('day', { size: 23, by: 3 * P - LE, left: PAD, color: t.inkFaint, ls: '0.12em' }),
     at(folio, { size: 44, by: 4 * P - 10, left: PAD, color: t.inkSoft }),
     avatarMark(t, avatarUri, { textBaseline: bcBy, left: CX }),
     rowAt(crumb, { size: 28, by: bcBy, left: avatarUri ? CX + 46 + 18 : CX }),
-    ...lines.map((l, i) =>
-      at(l, { size, by: headBase + i * P, left: CX, weight: 600, color: t.ink, ls: '-0.01em' }),
-    ),
-    ...descLines.map((l, i) =>
-      at(l, { size: 24, by: descBase + i * HP, left: CX, color: t.inkSoft, weight: 400 }),
-    ),
+    ...content,
     at(nsid, { size: 22, by: 8 * P - LE, left: CX, color: t.inkMuted }),
   ], { verticals: [PAD, { x: DIV, strong: true }, W - PAD], halfBands: [{ from: 3 * P + HP, to: bandTo }] });
 }
@@ -321,7 +340,7 @@ export function ogElement(o = {}) {
     return homeCardH4(t, { avatarUri, folio, nsid: o.nsid || 'is.dame.page', homeIndex: o.homeIndex || [] });
   }
   if (o.record) {
-    return recordCard(t, { segs, title: o.label, subtitle: o.subtitle || '', nsid: o.nsid || '', avatarUri, folio });
+    return recordCard(t, { segs, title: o.label, subtitle: o.subtitle || '', nsid: o.nsid || '', avatarUri, folio, body: o.body });
   }
   const args = { segs, label: o.label, subtitle: o.subtitle || '', nsid: o.nsid || '', avatarUri, folio };
   return SUBPAGE_LAYOUT === 's0' ? subCardS0(t, args) : subCardS4(t, args);

--- a/og/records.js
+++ b/og/records.js
@@ -29,7 +29,25 @@ const SNAPSHOT_TIMEOUT_MS = 2000;
 const PDS_TIMEOUT_MS = 2500;
 
 // Sections whose leaf pages render a single AT-Protocol record.
-const RECORD_SECTIONS = new Set(['blogging', 'creating', 'curating']);
+const RECORD_SECTIONS = new Set([
+  'blogging',
+  'creating',
+  'curating',
+  'posting',
+  'logging',
+  'listening',
+  'mothing',
+]);
+
+// rkey-addressed sections → the collection(s) a getRecord(rkey) should try, in
+// order. (blogging/creating are slug-addressed and resolve via snapshots;
+// curating pulls its title from the are.na-backed `curating` snapshot.)
+const SECTION_COLLECTIONS = {
+  posting: ['app.bsky.feed.post', 'net.anisota.feed.post'],
+  logging: [COLLECTIONS.now],
+  listening: [COLLECTIONS.listen],
+  mothing: ['is.dame.mothing.observation'],
+};
 
 /** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */
 function withTimeout(promise, ms) {
@@ -68,6 +86,73 @@ function endsWithRkey(uri, rkey) {
 function collectionFromUri(uri) {
   const m = String(uri || '').match(/^at:\/\/[^/]+\/([^/]+)\//);
   return m ? m[1] : null;
+}
+
+const firstText = (...vals) => {
+  for (const s of vals) {
+    const t = String(s == null ? '' : s).trim();
+    if (t) return t;
+  }
+  return '';
+};
+
+const humanizeSlug = (slug) =>
+  String(slug || '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\w/, (c) => c.toUpperCase());
+
+const artistNames = (v) =>
+  (Array.isArray(v?.artists) ? v.artists : [])
+    .map((a) => a?.artistName)
+    .filter(Boolean)
+    .join(', ');
+
+// value → { title, description, textOnly } for the OG card, keyed by lexicon.
+// `title` is the big line (the record's own text/name); `description` is the
+// secondary line; `textOnly` records (posts, statuses) have no title of their
+// own, so the card renders their text as body copy and the section name (not
+// the text) becomes the <title>.
+const CARD_EXTRACTORS = {
+  'app.bsky.feed.post': (v) => ({ title: firstText(v.text), description: '', textOnly: true }),
+  'net.anisota.feed.post': (v) => ({ title: firstText(v.text), description: '', textOnly: true }),
+  'is.dame.now': (v) => ({ title: firstText(v.status, v.text), description: '', textOnly: true }),
+  'fm.teal.alpha.feed.play': (v) => ({
+    title: firstText(v.trackName),
+    description: artistNames(v),
+    textOnly: false,
+  }),
+  'is.dame.mothing.observation': (v) => {
+    const common = firstText(v.taxon?.commonName);
+    const sci = firstText(v.taxon?.name);
+    return { title: common || sci || 'Moth observation', description: common && sci ? sci : '', textOnly: false };
+  },
+  'is.dame.arena.channel': (v, ctx) => ({
+    title: firstText(v.title, ctx?.title, humanizeSlug(ctx?.slug)),
+    description: firstText(v.description, ctx?.description),
+    textOnly: false,
+  }),
+};
+
+const docCard = (v) => ({
+  title: firstText(v.title, v.name),
+  description: firstText(v.description, v.summary, v.subtitle),
+  textOnly: false,
+});
+CARD_EXTRACTORS['site.standard.document'] = docCard;
+CARD_EXTRACTORS['pub.leaflet.document'] = docCard;
+CARD_EXTRACTORS['is.dame.creating.work'] = docCard;
+
+function extractCard(collection, value, ctx) {
+  const fn = CARD_EXTRACTORS[collection];
+  if (fn) return fn(value, ctx);
+  // Unknown lexicon: any title/name, else any text body.
+  const named = firstText(value.title, value.name);
+  const text = firstText(value.text, value.status, value.body);
+  return named
+    ? { title: named, description: firstText(value.description, value.summary), textOnly: false }
+    : { title: text, description: '', textOnly: Boolean(text) };
 }
 
 /** True if `pathname` looks like a slug-addressed record route we can resolve. */
@@ -112,9 +197,30 @@ async function resolveWork(origin, slug) {
   return withTimeout(liveWorkBySlug(slug), PDS_TIMEOUT_MS);
 }
 
-// /curating/:slug — slug is the channel rkey.
+// /curating/:slug — slug is the channel rkey. The record itself only carries
+// `arenaSlug`/`enabled`; the human title + description come from are.na and are
+// baked into the `curating` snapshot at build time, so read them from there
+// (falling back to a live getRecord + a humanized slug).
 async function resolveChannel(origin, slug) {
-  return withTimeout(liveByRkey(slug, [COLLECTIONS.arenaChannel]), PDS_TIMEOUT_MS);
+  const atUri = `at://${ME_DID}/${COLLECTIONS.arenaChannel}/${slug}`;
+  const snap = origin ? await fetchJson(`${origin}/data/curating.json`, SNAPSHOT_TIMEOUT_MS) : null;
+  const gallery = (Array.isArray(snap?.galleries) ? snap.galleries : []).find(
+    (g) => g?.slug === slug || g?.arenaSlug === slug,
+  );
+  if (gallery && firstText(gallery.title)) {
+    return {
+      uri: atUri,
+      cid: null,
+      value: { $type: COLLECTIONS.arenaChannel, title: gallery.title, description: gallery.description || '' },
+    };
+  }
+  const rec = await withTimeout(liveByRkey(slug, [COLLECTIONS.arenaChannel]), PDS_TIMEOUT_MS);
+  if (!rec) return null;
+  return {
+    uri: rec.uri || atUri,
+    cid: rec.cid || null,
+    value: { ...(rec.value || {}), title: firstText(rec.value?.title, humanizeSlug(slug)) },
+  };
 }
 
 async function liveByRkey(rkey, collections) {
@@ -142,29 +248,41 @@ async function liveWorkBySlug(slug) {
   return legacy.find((r) => !isDraft(r?.value) && workSlug(r?.value) === slug) || null;
 }
 
-function shapeMeta(record, section) {
+function shapeMeta(record, section, slug) {
   const v = (record && record.value) || {};
-  const title = String(v.title || v.name || '').trim();
-  if (!title) return null;
-  const description = String(v.description || v.summary || v.subtitle || '').trim();
   const atUri = record.uri || null;
+  const collection = collectionFromUri(atUri);
+  const { title, description, textOnly } = extractCard(collection, v, { slug });
+  const cleanTitle = firstText(title);
+  if (!cleanTitle) return null;
   const cid = record.cid || null;
   // `site` is the site.standard.document → site.standard.publication link
   // (an at:// URI). Bluesky needs it to render the Standard Site embed.
   const publication = typeof v.site === 'string' ? v.site : null;
   // When the record was made — drives the OG card's day-of-life folio so it
   // reflects the record's day, not the day the card is rendered.
-  const date = v.publishedAt || v.createdAt || null;
-  return { title, description, section, atUri, cid, nsid: collectionFromUri(atUri), publication, date };
+  const date = v.publishedAt || v.createdAt || v.playedTime || v.playedAt || null;
+  return {
+    title: cleanTitle,
+    description: firstText(description),
+    textOnly: Boolean(textOnly),
+    section,
+    atUri,
+    cid,
+    nsid: collection,
+    publication,
+    date,
+  };
 }
 
 /**
  * Resolve a record route to
- * `{ title, description, section, atUri, cid, nsid, publication }`, or null if
- * it's not a record route or the record can't be resolved. `title` is the
- * record's own title; `description` is its summary/subtitle when present;
- * `atUri`/`cid` point at the canonical record; `nsid` is its collection;
- * `publication` is the parent site.standard.publication at:// URI (or null).
+ * `{ title, description, textOnly, section, atUri, cid, nsid, publication, date }`,
+ * or null if it's not a record route or the record can't be resolved. `title`
+ * is the card's big line (the record's own title, or its text for `textOnly`
+ * records like posts); `description` is the secondary line; `atUri`/`cid` point
+ * at the canonical record; `nsid` is its collection; `publication` is the parent
+ * site.standard.publication at:// URI (or null); `date` is when it was made.
  */
 export async function recordMeta(pathname, origin) {
   const segs = (pathname || '').split('/').filter(Boolean);
@@ -180,8 +298,11 @@ export async function recordMeta(pathname, origin) {
     if (section === 'blogging') record = await resolveBlog(origin, slug);
     else if (section === 'creating') record = await resolveWork(origin, slug);
     else if (section === 'curating') record = await resolveChannel(origin, slug);
+    else if (SECTION_COLLECTIONS[section]) {
+      record = await withTimeout(liveByRkey(slug, SECTION_COLLECTIONS[section]), PDS_TIMEOUT_MS);
+    }
   } catch {
     record = null;
   }
-  return record ? shapeMeta(record, section) : null;
+  return record ? shapeMeta(record, section, slug) : null;
 }

--- a/src/pages/Mothing.css
+++ b/src/pages/Mothing.css
@@ -20,10 +20,6 @@
   color: var(--ink);
 }
 
-.mothing-stat-dates {
-  font-size: var(--text-lg);
-}
-
 .mothing-stat-label {
   letter-spacing: 0.16em;
   font-size: var(--text-xs);

--- a/src/pages/Mothing.jsx
+++ b/src/pages/Mothing.jsx
@@ -248,14 +248,6 @@ export default function Mothing() {
           <StatBlock value={stats.sessionCount ?? sessions.length} label="sessions" />
           <StatBlock value={stats.observationCount} label="observations" />
           <StatBlock value={stats.speciesCount} label="species" />
-          {stats.earliestDate && (
-            <div className="mothing-stat mothing-stat-range">
-              <span className="mothing-stat-value mothing-stat-dates">
-                {formatDate(stats.earliestDate)} &ndash; {formatDate(stats.latestDate)}
-              </span>
-              <span className="mothing-stat-label small-caps">span</span>
-            </div>
-          )}
         </section>
       )}
 


### PR DESCRIPTION
## OG record cards for the whole feed
Individual record cards, previously only blogging/creating, now cover every content route.

- **`og/records.js`** — per-lexicon card extractors:
  - Posts + statuses (`app.bsky.feed.post`, `is.dame.now`) are **textOnly** — no title of their own, so the section names the page and their text becomes the card.
  - Tracks (`fm.teal.alpha.feed.play` → track + artist), moth observations (common + scientific name), and are.na channels resolve to a titled card. **Fixes curating**, which returned the section card because arena records carry no title — it now reads the title/description from the `curating` snapshot.
- **`middleware.js`** — matches `/posting/:rkey`, `/logging/:rkey`, `/listening/:rkey`, `/mothing/:rkey`; textOnly records use the section as `<title>`, the text as `og:description`, and pass `body=1`.
- **`og/design.js`** — record card **body mode** renders a post/status as wrapped body copy on the fine rules (a notebook-page quote) instead of a big headline.
- **`api/og.js`** — threads the `body` flag through.

Each card pulls its own day-of-life folio from the record's date and tracks the current sky palette. Scoped to the content verbs; obscure ones (liking, following, reposting, …) still fall back to the section card.

## Mothing
Removes the earliest–latest **"span"** stat from the stats row (and its orphaned CSS).

## Verification
- All five record types resolve against the live PDS; rendered each card; confirmed middleware end-to-end (posting → body mode + section title; curating now resolves).
- Regression-checked blogging/creating (keep their publication + Standard Site tags).
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut48pAmRT8KdV5P3XShXzb)_