### PR TITLE
Count are.na mirror write points locally instead of reading rate-limit headers

### DIFF
--- a/arena-mirror/README.md
+++ b/arena-mirror/README.md
@@ -106,13 +106,16 @@ new settings instead of serving a mix.
   out, 429s honour `Retry-After`, transient errors retry with backoff. An
   [are.na personal access token](https://www.are.na/developers) raises the
   rate ceiling and lets the mirror see your private channels.
-- **Write-rate aware.** A PDS caps record writes per-account on a points budget
-  (the reference/Bluesky PDS: CREATE=3, UPDATE=2, DELETE=1 points; ~5,000/hour,
-  ~35,000/day — so ~1,666 new records/hour, ~11,666/day). The mirror reads the
-  PDS's own `ratelimit-*` headers and slows down as it nears the wall; for a
-  short wait it sleeps, for a sustained one it ends the run **partial** and
-  resumes next time. It adapts to whatever your PDS actually enforces rather
-  than assuming a number.
+- **Write-rate aware.** An atproto repo caps writes per-account on a points
+  budget — CREATE=3, UPDATE=2, DELETE=1 points; 5,000/hour and 35,000/day
+  (Bluesky's limits, which the reference PDS enforces even when self-hosted, and
+  without advertising them in `ratelimit-*` headers). So the mirror **counts
+  points locally** against an hourly and a daily window and holds before a write
+  that wouldn't fit: for a short wait it sleeps, for a full window it ends the
+  run **partial** and resumes next time. A 429 is honoured as a backstop for
+  budget spent by other writers on the same repo (a prior run, the mothing
+  mirror). Limits/headroom are configurable (`writeHourlyPoints`,
+  `writeDailyPoints`, `writePointsSafety`) if your PDS differs.
 
 Known staleness window: editing a block (say, its title) without touching any
 channel may not bump the containing channel's `updated_at`, so the edit rides
@@ -121,11 +124,12 @@ along with the next change to any channel containing it — or a `--full` run.
 ## Rate limits & the first backfill
 
 Mirroring a large account is a **multi-day** job — not because the mirror is
-slow, but because the PDS won't accept the writes faster. A 15k–20k-record
-account is 45k–60k write points, well past a single day's ~35k budget. This is
-expected and handled: every run does as much as the budget allows, then stops
-cleanly and the next run continues (the sync-state record tracks exactly where
-it left off; re-listed records upsert rather than duplicate).
+slow, but because the repo won't accept the writes faster. A 15k–20k-record
+account is 45k–60k write points, well past a single day's 35k budget. This is
+expected and handled: the pacer counts points locally against the hourly/daily
+windows, so every run does as much as the budget allows, then stops cleanly and
+the next run continues (the sync-state record tracks exactly where it left off;
+re-listed records upsert rather than duplicate).
 
 Two ways to run the backfill:
 

--- a/arena-mirror/src/defaults.js
+++ b/arena-mirror/src/defaults.js
@@ -64,12 +64,19 @@ export function normalizeOptions(opts = {}) {
     full: Boolean(opts.full),
     dryRun: Boolean(opts.dryRun),
     timeBudgetMs: opts.timeBudgetMs ? Number(opts.timeBudgetMs) : null,
-    // How long the write pacer will sleep at a rate-limit wall before instead
-    // ending the run partial (to resume later). Small = "stop and resume"
-    // (cron); large = "sleep through the window and keep going" (attended
-    // backfill). Default splits the difference: ride out short waits, stop for
-    // hourly/daily walls.
+    // How long the write pacer will sleep at a points-budget wall before
+    // instead ending the run partial (to resume later). Small = "stop and
+    // resume" (cron); large = "sleep through the hourly window and keep going"
+    // (attended backfill). Default rides out short waits, stops for a full
+    // hourly/daily window.
     writeMaxSleepMs: opts.writeMaxSleepMs != null ? Number(opts.writeMaxSleepMs) : 120_000,
+    // The account's write-points budget. Defaults are Bluesky's limits, which
+    // the reference PDS enforces (CREATE=3/UPDATE=2/DELETE=1 points). Override
+    // only if your PDS is configured differently. `safety` (<1) leaves headroom
+    // for window skew and other writers on the same repo.
+    writeHourlyPoints: opts.writeHourlyPoints != null ? Number(opts.writeHourlyPoints) : 5000,
+    writeDailyPoints: opts.writeDailyPoints != null ? Number(opts.writeDailyPoints) : 35000,
+    writePointsSafety: opts.writePointsSafety != null ? Number(opts.writePointsSafety) : 0.95,
   };
 }
 

--- a/arena-mirror/src/engine.js
+++ b/arena-mirror/src/engine.js
@@ -53,11 +53,18 @@ export async function syncArenaMirror(options) {
   const client =
     arenaClient || new ArenaClient({ token, userAgent: 'arena-pds-mirror (+https://dame.is)', log });
 
-  // Paces PDS writes against the account's points budget. maxSleepMs is the
-  // stop-vs-wait ceiling: the cron keeps it small (stop cleanly, resume next
-  // firing); an attended `--drain` backfill raises it to sleep through the
+  // Paces PDS writes against the account's points budget (counted locally,
+  // since the PDS enforces the limit but doesn't advertise it). maxSleepMs is
+  // the stop-vs-wait ceiling: the cron keeps it small (stop cleanly, resume
+  // next firing); an attended `--drain` backfill raises it to sleep through the
   // hourly window and keep going until the daily budget is spent.
-  const pacer = new WritePacer({ maxSleepMs: o.writeMaxSleepMs, log });
+  const pacer = new WritePacer({
+    hourlyPoints: o.writeHourlyPoints,
+    dailyPoints: o.writeDailyPoints,
+    safety: o.writePointsSafety,
+    maxSleepMs: o.writeMaxSleepMs,
+    log,
+  });
 
   // --- 1. are.na identity + channel enumeration -----------------------------
   const profile = await client.user(o.user);
@@ -436,6 +443,7 @@ export async function syncArenaMirror(options) {
     channelsUnvisited,
     suspectChannels: suspectChannels || undefined,
     rateLimited: rateLimited || undefined,
+    writePoints: pacer.spentPoints || undefined,
     pausedMs: pacer.paused || undefined,
     blocksExternal,
     writes,

--- a/arena-mirror/src/pds.js
+++ b/arena-mirror/src/pds.js
@@ -3,14 +3,20 @@
 // unauthenticated one for read-only dry runs — listRecords/getRecord are
 // public XRPC).
 //
-// Why pacing lives here: a PDS rate-limits record writes per-DID on a points
-// budget (the reference/Bluesky PDS: CREATE=3, UPDATE=2, DELETE=1 points;
-// 5,000/hour and 35,000/day). A full backfill of a large are.na account is
-// tens of thousands of creates — well over a single day's budget — so the
-// mirror must (a) slow down as it approaches the limit and (b) stop cleanly
-// and resume later when the wait would be long, rather than error out. The
-// pacer reads the PDS's own `ratelimit-*` headers, so it adapts to whatever
-// limit the PDS actually enforces instead of hard-coding one.
+// Why pacing lives here: writes to an atproto repo are capped per-account on a
+// points budget — CREATE=3, UPDATE=2, DELETE=1 points, 5,000/hour and
+// 35,000/day. These are Bluesky's limits, and the reference PDS enforces them
+// itself (a self-hosted PDS is still subject to them), but it does NOT return
+// `ratelimit-*` headers, so we can't read a live budget off the wire. Instead
+// the mirror COUNTS points locally against those two windows: it waits when a
+// window is full and, when the wait is long (a fresh hourly or daily window),
+// stops cleanly and resumes on the next run rather than erroring. A 429 is
+// honoured as a backstop for budget spent outside this process — earlier runs,
+// the mothing mirror, anything else writing to the same repo.
+//
+// A full backfill of a large are.na account is tens of thousands of creates —
+// well past a single day's 35k-point budget — so it is inherently a multi-day,
+// multi-run job, and that's expected.
 
 const rkeyFromUri = (uri) => String(uri || '').split('/').pop() || null;
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,33 +34,80 @@ export class WritePauseNeeded extends Error {
   }
 }
 
-/** ms until a rate-limit window resets, from response/error headers. */
+/** ms until a rate-limit window resets, or null if the server didn't say. */
 function resetWaitMs(headers) {
   const h = headers || {};
   const reset = Number(h['ratelimit-reset']); // unix seconds
   if (Number.isFinite(reset) && reset > 1e9) return Math.max(0, reset * 1000 - Date.now());
   const retryAfter = Number(h['retry-after']); // delta seconds
   if (Number.isFinite(retryAfter) && retryAfter >= 0) return retryAfter * 1000;
-  return 0;
+  return null;
+}
+
+/** Write-point cost of each op type, per atproto's points system. */
+export const OP_POINTS = { create: 3, update: 2, delete: 1 };
+
+/** A fixed-window points counter: up to `limit` points per `ms`-long window. */
+class PointWindow {
+  constructor(limit, ms) {
+    this.limit = limit;
+    this.ms = ms;
+    this.start = null; // when the current window opened
+    this.spent = 0;
+  }
+
+  /** ms to wait before `cost` points would fit (0 = now). */
+  waitMs(cost, now) {
+    if (this.start == null || now - this.start >= this.ms) return 0; // no window / expired
+    if (this.spent + cost <= this.limit) return 0; // fits in the current window
+    return this.start + this.ms - now; // full — wait for it to reset
+  }
+
+  charge(cost, now) {
+    if (this.start == null || now - this.start >= this.ms) {
+      this.start = now;
+      this.spent = 0;
+    }
+    this.spent += cost;
+  }
 }
 
 /**
- * Adapts write throughput to the PDS's advertised budget. `observe` is called
- * after every successful write with that response's headers; `backoff` is
- * called on a 429. Both sleep for short waits and throw WritePauseNeeded when
- * the wait exceeds `maxSleepMs` — that ceiling is the whole knob: small (the
- * cron) means "stop and resume next run", large (an attended `--drain`
- * backfill) means "sleep through the hourly window and keep grinding".
+ * Paces record writes to stay under the account's points budget by counting
+ * locally against an hourly and a daily window (defaults: Bluesky's 5,000/hour
+ * and 35,000/day). `gate(cost)` waits before a write until `cost` points fit in
+ * BOTH windows; `charge(cost)` records the spend after the write succeeds.
+ *
+ * `maxSleepMs` is the stop-vs-wait ceiling: a wait longer than it (a fresh
+ * hourly or daily window) throws WritePauseNeeded so the run ends partial and
+ * resumes later. Small = the cron ("stop, resume next firing"); large = an
+ * attended `--drain` backfill ("sleep through the hourly window and keep
+ * going"). `safety` (<1) reserves headroom for skew and other writers.
+ *
+ * `backoff` handles a real 429 — the backstop for budget spent outside this
+ * process (earlier runs, other tools). With no `ratelimit-*` headers to read,
+ * it escalates and, after enough consecutive rejections, pauses the run.
  */
 export class WritePacer {
-  constructor({ minRemaining = 50, maxSleepMs = 120_000, log = () => {} } = {}) {
-    this.minRemaining = minRemaining;
+  constructor({
+    hourlyPoints = 5000,
+    dailyPoints = 35000,
+    safety = 0.95,
+    maxSleepMs = 120_000,
+    hourlyMs = 3_600_000,
+    dailyMs = 86_400_000,
+    log = () => {},
+  } = {}) {
+    this.hourly = new PointWindow(Math.max(1, Math.floor(hourlyPoints * safety)), hourlyMs);
+    this.daily = new PointWindow(Math.max(1, Math.floor(dailyPoints * safety)), dailyMs);
     this.maxSleepMs = maxSleepMs;
     this.log = log;
-    this.paused = 0; // total ms spent sleeping on rate limits (for the report)
+    this.paused = 0; // total ms spent waiting (for the report)
+    this.spentPoints = 0;
+    this._consec429 = 0;
   }
 
-  async _waitOrPause(waitMs, why) {
+  async _sleepOrPause(waitMs, why) {
     if (waitMs > this.maxSleepMs) throw new WritePauseNeeded(waitMs);
     if (waitMs <= 0) return;
     this.log(`${why} — waiting ${Math.round(waitMs / 1000)}s`);
@@ -62,18 +115,38 @@ export class WritePacer {
     await sleep(waitMs);
   }
 
-  async observe(headers) {
-    const remaining = Number(headers?.['ratelimit-remaining']);
-    if (!Number.isFinite(remaining) || remaining > this.minRemaining) return;
-    await this._waitOrPause(resetWaitMs(headers) || 1000, `approaching write limit (remaining ${remaining})`);
+  /** Hold BEFORE a write of `cost` points until it fits both windows. */
+  async gate(cost) {
+    for (;;) {
+      const now = Date.now();
+      const wait = Math.max(this.hourly.waitMs(cost, now), this.daily.waitMs(cost, now));
+      if (wait <= 0) return;
+      await this._sleepOrPause(wait, 'write points budget reached');
+    }
+  }
+
+  /** Record a successful write's spend. */
+  charge(cost) {
+    const now = Date.now();
+    this.hourly.charge(cost, now);
+    this.daily.charge(cost, now);
+    this.spentPoints += cost;
+    this._consec429 = 0;
   }
 
   async backoff(headers) {
-    await this._waitOrPause(resetWaitMs(headers) || 15_000, 'write rate limited (429)');
+    this._consec429 += 1;
+    // Prefer a server-provided reset; otherwise escalate 60s → 2m → 4m … (cap
+    // 15m), and pause the run after several straight rejections.
+    const fromHeader = resetWaitMs(headers);
+    const wait = fromHeader != null ? fromHeader : Math.min(60_000 * 2 ** (this._consec429 - 1), 15 * 60_000);
+    if (this._consec429 > 5) throw new WritePauseNeeded(wait);
+    await this._sleepOrPause(wait, `write rejected (429×${this._consec429})`);
   }
 }
 
 const is429 = (err) => err?.status === 429 || /rate ?limit/i.test(err?.message || '');
+const batchPoints = (batch) => batch.reduce((sum, op) => sum + (OP_POINTS[op.type] || 1), 0);
 
 /** Every record in a collection as `{ rkey, value }`. */
 export async function listCollection(agent, did, collection) {
@@ -121,35 +194,40 @@ export async function applyOps(agent, did, ops, { batchSize = 50, log = () => {}
 
   for (let i = 0; i < ops.length; ) {
     const batch = ops.slice(i, i + batchSize);
+    const cost = batchPoints(batch);
+    if (pacer) await pacer.gate(cost); // hold until the batch fits the budget
     try {
-      const res = await agent.com.atproto.repo.applyWrites({ repo: did, writes: batch.map(toWrite), validate: false });
+      await agent.com.atproto.repo.applyWrites({ repo: did, writes: batch.map(toWrite), validate: false });
       ok += batch.length;
       i += batch.length;
-      if (pacer) await pacer.observe(res?.headers);
+      if (pacer) pacer.charge(cost);
     } catch (err) {
       if (is429(err)) {
-        // Not a bad batch — we're over budget. Wait (or pause the run) and
-        // retry the SAME batch; nothing was written.
+        // Server says we're over budget (spend from another run/tool our local
+        // counter didn't see). Back off and retry the SAME batch — not charged,
+        // so gate won't double-count.
         if (pacer) await pacer.backoff(err.headers);
-        else throw err; // no pacer (shouldn't happen for writes) → surface it
+        else throw err;
         continue;
       }
       log(`applyWrites batch failed (${err.message}) — retrying ${batch.length} op(s) individually`);
       for (const op of batch) {
+        const opCost = OP_POINTS[op.type] || 1;
         for (;;) {
+          if (pacer) await pacer.gate(opCost);
           try {
             if (op.type === 'delete') {
               await agent.com.atproto.repo.deleteRecord({ repo: did, collection: op.collection, rkey: op.rkey });
             } else {
-              const res = await agent.com.atproto.repo.putRecord({
+              await agent.com.atproto.repo.putRecord({
                 repo: did,
                 collection: op.collection,
                 rkey: op.rkey,
                 record: op.value,
                 validate: false,
               });
-              if (pacer) await pacer.observe(res?.headers);
             }
+            if (pacer) pacer.charge(opCost);
             ok++;
             break;
           } catch (opErr) {
@@ -178,7 +256,9 @@ export async function uploadBlob(agent, bytes, contentType, { pacer } = {}) {
   for (;;) {
     try {
       const res = await agent.uploadBlob(bytes, { encoding: contentType });
-      if (pacer) await pacer.observe(res?.headers);
+      // Not charged to the points budget: a blob upload isn't a record write —
+      // the record CREATE that references it is what costs points. A 429 here
+      // (blobs have their own limits) is still honoured below.
       return res?.data?.blob || null;
     } catch (err) {
       if (is429(err) && pacer) {


### PR DESCRIPTION
Follow-up to #248. That pacer steered off the PDS's `ratelimit-*` response headers — but a direct check of `pds.atpota.to` shows it's the stock reference PDS (`x-powered-by: Express`) returning **no** `ratelimit-*` headers, while still enforcing the write-points limit. So the header-driven pacer was inert against a self-hosted reference PDS.

## Change

Pace by **counting points locally** against the known budget instead of reading it off the wire:

- CREATE=3 / UPDATE=2 / DELETE=1 points; **5,000/hour** and **35,000/day** (Bluesky's limits, which the reference PDS enforces even self-hosted).
- An hourly and a daily fixed-window counter. `gate(cost)` holds before a write until it fits both windows; `charge(cost)` records the spend after success. A full window's wait exceeds `maxSleepMs` → run ends **partial** and resumes next run; a short wait sleeps through.
- A **429** stays as the backstop for budget spent by other writers on the same repo (a prior run, the mothing mirror), with escalating backoff that pauses the run after repeated rejections.
- Blob uploads aren't charged — the record CREATE that references a blob is what costs points.
- 5% safety headroom; limits/windows configurable (`writeHourlyPoints` / `writeDailyPoints` / `writePointsSafety`).

Net behaviour: ~1,580 records/hour, ~11,080/day, then a clean pause — a large first backfill is a deterministic multi-day, multi-run job that won't trip the limit on its own.

## Verification

Unit tests cover hourly-cap enforcement, an independent daily cap, pause-on-full-window, no double-charge when a 429 retries a batch, and mixed-op point costs. The tests caught and fixed a real bug (`retry-after: 0` swallowed into a 60s escalation). Dry run and site build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q)_