### PR TITLE
Make for-hire loading state mirror the real resume

### DIFF
--- a/src/components/Skeleton.css
+++ b/src/components/Skeleton.css
@@ -538,16 +538,161 @@
   height: 2.1rem;
 }
 
+/* Variant: for-hire / resume page skeleton. Mirrors the .resume article so
+   the swap to the real resume doesn't reflow — same measure, section gaps,
+   the left-ruled role blocks, and the skills label + chips grid. */
+.skeleton-resume {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: var(--measure);
+}
+
+.skeleton-resume-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.skeleton-resume-title {
+  width: 12rem;
+  max-width: 80%;
+  height: var(--text-3xl);
+}
+
+.skeleton-resume-headline {
+  width: 20rem;
+  max-width: 90%;
+  height: var(--text-lg);
+}
+
+.skeleton-resume-contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
+  margin-top: var(--space-1);
+}
+
+.skeleton-resume-contact-item {
+  height: 0.8rem;
+}
+
+.skeleton-resume-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.skeleton-resume-section-head {
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.skeleton-resume-section-title {
+  height: 0.85rem;
+}
+
+.skeleton-resume-orgs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.skeleton-resume-org {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.skeleton-resume-org-name {
+  height: var(--text-xl);
+}
+
+.skeleton-resume-role {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--rule-soft);
+}
+
+.skeleton-resume-role-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.skeleton-resume-role-title {
+  height: var(--text-base);
+}
+
+.skeleton-resume-role-dates {
+  flex: none;
+  width: 6rem;
+  height: 0.75rem;
+}
+
+.skeleton-resume-role-meta {
+  height: var(--text-xs);
+}
+
+.skeleton-resume-highlights {
+  list-style: none;
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-resume-skills {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.skeleton-resume-skill-group {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: var(--space-3);
+  align-items: baseline;
+}
+
+.skeleton-resume-skill-cat {
+  height: var(--text-sm);
+}
+
+.skeleton-resume-skill-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.skeleton-resume-skill {
+  height: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .skeleton-resume-skill-group {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
+}
+
 /* Stagger the breathing across multi-item skeletons so the list doesn't
    pulse in lockstep. Negative delays seed each row at a different phase
    in the cycle without changing the cycle length. */
-.skeleton-feed-item:nth-child(3n)       .skeleton,
-.skeleton-toc-entry:nth-child(3n)       .skeleton,
-.skeleton-grid-cell:nth-child(3n)       .skeleton,
-.skeleton-mothing-cell:nth-child(3n)    .skeleton,
-.skeleton-admin-row:nth-child(3n)       .skeleton,
-.skeleton-admin-panel:nth-child(3n)     .skeleton,
-.skeleton-comments-item:nth-child(3n)   .skeleton { animation-delay: -0.5s; }
+.skeleton-feed-item:nth-child(3n)         .skeleton,
+.skeleton-toc-entry:nth-child(3n)         .skeleton,
+.skeleton-grid-cell:nth-child(3n)         .skeleton,
+.skeleton-mothing-cell:nth-child(3n)      .skeleton,
+.skeleton-admin-row:nth-child(3n)         .skeleton,
+.skeleton-admin-panel:nth-child(3n)       .skeleton,
+.skeleton-resume-org:nth-child(3n)        .skeleton,
+.skeleton-resume-skill-group:nth-child(3n)     .skeleton,
+.skeleton-comments-item:nth-child(3n)     .skeleton { animation-delay: -0.5s; }
 
 .skeleton-feed-item:nth-child(3n + 1)     .skeleton,
 .skeleton-toc-entry:nth-child(3n + 1)     .skeleton,
@@ -555,6 +700,8 @@
 .skeleton-mothing-cell:nth-child(3n + 1)  .skeleton,
 .skeleton-admin-row:nth-child(3n + 1)     .skeleton,
 .skeleton-admin-panel:nth-child(3n + 1)   .skeleton,
+.skeleton-resume-org:nth-child(3n + 1)    .skeleton,
+.skeleton-resume-skill-group:nth-child(3n + 1) .skeleton,
 .skeleton-comments-item:nth-child(3n + 1) .skeleton { animation-delay: -1.2s; }
 
 .skeleton-feed-item:nth-child(3n + 2)     .skeleton,
@@ -563,6 +710,8 @@
 .skeleton-mothing-cell:nth-child(3n + 2)  .skeleton,
 .skeleton-admin-row:nth-child(3n + 2)     .skeleton,
 .skeleton-admin-panel:nth-child(3n + 2)   .skeleton,
+.skeleton-resume-org:nth-child(3n + 2)    .skeleton,
+.skeleton-resume-skill-group:nth-child(3n + 2) .skeleton,
 .skeleton-comments-item:nth-child(3n + 2) .skeleton { animation-delay: -1.9s; }
 
 /* -------------------------------------------------------------------- */

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -371,6 +371,118 @@ export function ProseSkeleton({ paragraphs = 3 }) {
   );
 }
 
+/**
+ * Skeleton for the "for hire" resume page (Resume.jsx). Mirrors the
+ * `.resume` article — a header (title + headline + contact row), a summary
+ * paragraph, and the Experience / Education / Skills sections — so the swap
+ * to the real resume doesn't reflow. Experience orgs carry the same left
+ * rule and role head (title beside a right-aligned date range) as the real
+ * layout; skills lay out on the same label + chips grid.
+ */
+export function ResumeSkeleton({ orgs = 3, education = 1, skillGroups = 3 }) {
+  return (
+    <SkeletonShell label="Loading resume" className="skeleton-resume reveal">
+      <header className="skeleton-resume-header">
+        <Skeleton className="skeleton-resume-title" />
+        <Skeleton className="skeleton-resume-headline" />
+        <div className="skeleton-resume-contact">
+          <Skeleton className="skeleton-resume-contact-item" style={{ width: '5rem' }} />
+          <Skeleton className="skeleton-resume-contact-item" style={{ width: '9.5rem' }} />
+          <Skeleton className="skeleton-resume-contact-item" style={{ width: '6.5rem' }} />
+        </div>
+      </header>
+
+      <div className="skeleton-resume-summary">
+        <SkeletonText lines={3} lineHeight="0.9em" lastLineWidth="52%" />
+      </div>
+
+      {/* Experience */}
+      <section className="skeleton-resume-section">
+        <div className="skeleton-resume-section-head">
+          <Skeleton className="skeleton-resume-section-title" style={{ width: '6rem' }} />
+        </div>
+        <div className="skeleton-resume-orgs">
+          {Array.from({ length: orgs }, (_, oi) => (
+            <div key={oi} className="skeleton-resume-org">
+              <Skeleton
+                className="skeleton-resume-org-name"
+                style={{ width: `${9 + ((oi * 5) % 6)}rem` }}
+              />
+              <div className="skeleton-resume-role">
+                <div className="skeleton-resume-role-head">
+                  <Skeleton
+                    className="skeleton-resume-role-title"
+                    style={{ width: `${8 + ((oi * 7) % 7)}rem` }}
+                  />
+                  <Skeleton className="skeleton-resume-role-dates" />
+                </div>
+                <Skeleton
+                  className="skeleton-resume-role-meta"
+                  style={{ width: `${10 + ((oi * 3) % 6)}rem` }}
+                />
+                <ul className="skeleton-resume-highlights">
+                  {Array.from({ length: 2 + (oi % 2) }, (_, hi) => (
+                    <li key={hi} className="skeleton-resume-highlight">
+                      <Skeleton block style={{ width: `${72 + ((hi * 13) % 24)}%`, height: '0.85em' }} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Education */}
+      <section className="skeleton-resume-section">
+        <div className="skeleton-resume-section-head">
+          <Skeleton className="skeleton-resume-section-title" style={{ width: '5.5rem' }} />
+        </div>
+        <div className="skeleton-resume-orgs">
+          {Array.from({ length: education }, (_, ei) => (
+            <div key={ei} className="skeleton-resume-role">
+              <div className="skeleton-resume-role-head">
+                <Skeleton
+                  className="skeleton-resume-role-title"
+                  style={{ width: `${10 + ((ei * 5) % 5)}rem` }}
+                />
+                <Skeleton className="skeleton-resume-role-dates" />
+              </div>
+              <Skeleton className="skeleton-resume-role-meta" style={{ width: '8rem' }} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Skills */}
+      <section className="skeleton-resume-section">
+        <div className="skeleton-resume-section-head">
+          <Skeleton className="skeleton-resume-section-title" style={{ width: '4rem' }} />
+        </div>
+        <div className="skeleton-resume-skills">
+          {Array.from({ length: skillGroups }, (_, gi) => (
+            <div key={gi} className="skeleton-resume-skill-group">
+              <Skeleton
+                className="skeleton-resume-skill-cat"
+                style={{ width: `${5 + ((gi * 3) % 5)}rem` }}
+              />
+              <div className="skeleton-resume-skill-items">
+                {Array.from({ length: 3 + (gi % 3) }, (_, si) => (
+                  <Skeleton
+                    key={si}
+                    className="skeleton-resume-skill"
+                    style={{ width: `${3 + ((si * 7) % 5)}rem` }}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonShell>
+  );
+}
+
 /* -------------------------------------------------------------------- */
 /* Admin variants                                                        */
 /* -------------------------------------------------------------------- */

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -6,6 +6,7 @@ import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords, explorerPathFromAtUri } from '../lib/atproto.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { transformRecords } from '../lib/feedBuilder.js';
+import { ResumeSkeleton } from '../components/Skeleton.jsx';
 import { showOnCreating, workSlug } from '../lib/publications.js';
 import { coverThumb } from '../lib/creatingHelpers.js';
 import {
@@ -135,7 +136,7 @@ export default function Resume() {
   if (status === 'loading') {
     return (
       <PageShell headTitle="dame.is for hire" atUri={`at://${ME_DID}/is.dame.page/resume`}>
-        <p className="placeholder-card">Loading resume…</p>
+        <ResumeSkeleton />
       </PageShell>
     );
   }


### PR DESCRIPTION
## What & why

The for-hire page previously showed a bare `Loading resume…` placeholder card while the resume records loaded — out of step with every other page on the site, which renders a layout-matched skeleton. This replaces it with a `ResumeSkeleton` that mirrors the actual resume content so the loading state reads as "the resume, arriving" and nothing reflows when the real data swaps in.

## Changes

- **`src/components/Skeleton.jsx`** — New `ResumeSkeleton` component reproducing the `.resume` article: header (title + headline + contact row), a summary paragraph, and the Experience / Education / Skills sections. Experience orgs carry the same left-ruled role blocks (role title beside a right-aligned date range, a meta line, highlight bullets); skills lay out on the same label + chips grid.
- **`src/components/Skeleton.css`** — `.skeleton-resume-*` styles copying the real layout's measure, section gaps, the 2px left rule on role blocks, and the `minmax(8rem, 12rem) 1fr` skills grid (collapsing to one column at 640px). Repeating org/skill-group rows are wired into the existing stagger selectors so they breathe out of phase.
- **`src/pages/Resume.jsx`** — Swapped the placeholder card for `<ResumeSkeleton />`.

Follows the established skeleton conventions: palette-driven breathing blocks, the `SkeletonShell` fade-in, and `.reveal` on the real article.

## Verification

- `vite build` compiles cleanly.
- Rendered the loading branch in a real browser (data fetches held pending) and screenshotted it in light, dark, and mobile — the placeholder lines up with the real resume's shape, inherits the palette in both themes, and the skills grid collapses to a single column on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdquH37rg5PKY6XVnx2GKo)_