### PR TITLE
Remove emoji and hover record links from the resume page

### DIFF
--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -149,23 +149,6 @@
   letter-spacing: 0.02em;
 }
 
-.resume-record-link {
-  font-family: var(--mono);
-  font-size: calc(var(--text-xs) * var(--mono-scale));
-  color: var(--ink-faint);
-  text-decoration: none;
-  opacity: 0;
-  transition: opacity 160ms ease, color 160ms ease;
-}
-
-.resume-role:hover .resume-record-link {
-  opacity: 1;
-}
-
-.resume-record-link:hover {
-  color: var(--accent);
-}
-
 .resume-role-summary {
   font-size: var(--text-sm);
   color: var(--ink-soft);
@@ -288,8 +271,9 @@ a.resume-work-link:hover .resume-work-title {
 
 .resume-work-ext {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
   color: var(--ink-faint);
-  font-size: var(--text-xs);
 }
 
 /* --- Skills --------------------------------------------------------- */
@@ -351,7 +335,6 @@ a.resume-work-link:hover .resume-work-title {
 
 /* --- Print: a clean one-document resume ----------------------------- */
 @media print {
-  .resume-record-link,
   .resume-footnote {
     display: none !important;
   }

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { ExternalLink } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
-import { resolvePds, listRecords, explorerPathFromAtUri } from '../lib/atproto.js';
+import { resolvePds, listRecords } from '../lib/atproto.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { transformRecords } from '../lib/feedBuilder.js';
 import { ResumeSkeleton } from '../components/Skeleton.jsx';
@@ -90,7 +91,9 @@ function ResumeWorkLink({ item }) {
         <span className="resume-work-title">{item.title}</span>
         {item.description && <span className="resume-work-desc">{item.description}</span>}
       </span>
-      {item.external && item.href && <span className="resume-work-ext" aria-hidden="true">↗</span>}
+      {item.external && item.href && (
+        <span className="resume-work-ext" aria-hidden="true"><ExternalLink size={12} /></span>
+      )}
     </>
   );
   if (!item.href) return <span className="resume-work-link is-static">{inner}</span>;
@@ -230,15 +233,6 @@ export default function Resume() {
                         {[role.employmentType, role.locationType, role.location]
                           .filter(Boolean)
                           .join(' · ')}
-                        {explorerPathFromAtUri(role.uri) && (
-                          <Link
-                            className="resume-record-link"
-                            to={explorerPathFromAtUri(role.uri)}
-                            title="View the underlying job record"
-                          >
-                            ↗ record
-                          </Link>
-                        )}
                       </div>
                       {role.summary && <p className="resume-role-summary">{role.summary}</p>}
                       {role.highlights.length > 0 && (


### PR DESCRIPTION
Cleans up the résumé (`/available`) page so it renders no emoji and drops the per-role record links.

## What changed

- **Removed the per-role "↗ record" hover link** in the Experience section. The underlying job record is still reachable via the debug pane, so nothing is lost.
- **Replaced the `↗` external-link glyph** on "Selected work" links with the lucide `ExternalLink` icon (the same SVG icon the admin already uses) — `↗` renders as a color emoji on iOS, so this removes the last emoji on the page.
- Dropped the now-unused `explorerPathFromAtUri` import and the dead `.resume-record-link` CSS (including its print-hide selector); tidied `.resume-work-ext` alignment for the icon.

Verified with a clean `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTxGm4TMwZxZBS8fy8De9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTxGm4TMwZxZBS8fy8De9U)_