### PR TITLE
Source the /available OG description from the PDS page record

### DIFF
--- a/api/og.js
+++ b/api/og.js
@@ -75,7 +75,10 @@ export default async function handler(req, res) {
       pathname = cleanPath(String(q.page));
       const meta = pageMeta(pathname);
       label = meta.label;
-      subtitle = meta.desc;
+      // Middleware injects a `subtitle` resolved from the live / snapshotted
+      // is.dame.page record; a direct hit with no subtitle uses the static copy.
+      const passed = q.subtitle != null ? String(q.subtitle).trim() : '';
+      subtitle = passed || meta.desc;
       nsid = meta.nsid;
     } else if (q.section) {
       // Per-record card: breadcrumb = /{section}, headline = the record title.

--- a/middleware.js
+++ b/middleware.js
@@ -14,6 +14,7 @@
 
 import { pageMeta, SITE, cleanPath, segsFor } from './og/pages.js';
 import { recordMeta } from './og/records.js';
+import { pageContentMeta } from './og/pageContent.js';
 import { ME_DID, COLLECTIONS, BLOG_PUBLICATION, PORTFOLIO_PUBLICATION } from './src/config.js';
 
 const ORIGIN = 'https://dame.is';
@@ -189,7 +190,16 @@ export default async function middleware(request) {
       const meta = pageMeta(path);
       title = meta.title;
       desc = meta.desc;
-      ogImage = `${ORIGIN}/api/og?page=${encodeURIComponent(path)}`;
+      // Prefer the live / snapshotted is.dame.page copy over the static default,
+      // so editing the record on the PDS updates the crawler description AND the
+      // card. Returns null (→ keep the static copy) when no record exists.
+      const pageContent = await pageContentMeta(path, url.origin);
+      if (pageContent?.desc) desc = pageContent.desc;
+      const ogParams = new URLSearchParams({ page: path });
+      // Hand the resolved copy to the card generator so it renders the same
+      // description without re-fetching (mirrors the record-card path above).
+      if (pageContent?.desc) ogParams.set('subtitle', pageContent.desc);
+      ogImage = `${ORIGIN}/api/og?${ogParams.toString()}`;
       atUri = topLevelAtUri(path);
       // Publication home pages advertise their publication for the embed.
       stdPub = SECTION_PUBLICATION[path] || null;

--- a/og/pageContent.js
+++ b/og/pageContent.js
@@ -1,0 +1,97 @@
+// Edge-safe resolver for a top-level page surface's editable copy, sourced from
+// the is.dame.page record the SPA itself renders. Lets the crawler-facing <head>
+// description and the OG card subtitle track what's on the user's PDS instead of
+// the static defaults in og/pages.js — so the social card is editable, not
+// hardcoded.
+//
+// Resolution order (mirrors src/hooks/usePageContent.js + og/records.js):
+//   1. the build/deploy snapshot at /data/pages.json  (the "latest deployment")
+//   2. a time-boxed live is.dame.page getRecord         (records newer than the build)
+//   3. null → caller keeps the static og/pages.js copy
+//
+// Everything is defensive: any miss/hiccup returns null so a slow or broken PDS
+// never blocks the card. Plain fetch only, so it runs in the Edge runtime.
+
+import { ME_DID, COLLECTIONS } from '../src/config.js';
+import { resolvePds, getRecord } from '../src/lib/atproto.js';
+
+const SNAPSHOT_TIMEOUT_MS = 2000;
+const PDS_TIMEOUT_MS = 2500;
+
+// Top-level routes whose OG copy is backed by an is.dame.page/<rkey> record.
+// The URL and the record key can differ — /available is backed by the
+// is.dame.page/resume record. Add a route here to let it drive its own social
+// copy from the PDS; unlisted routes keep their static og/pages.js copy.
+const PAGE_RKEY_FOR_PATH = {
+  '/available': 'resume',
+};
+
+/** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */
+function withTimeout(promise, ms) {
+  return Promise.race([
+    Promise.resolve(promise).catch(() => null),
+    new Promise((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+async function fetchJson(url, ms) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const firstText = (...vals) => {
+  for (const s of vals) {
+    const t = String(s == null ? '' : s).trim();
+    if (t) return t;
+  }
+  return '';
+};
+
+/** The is.dame.page record for a route's rkey: snapshot first, then a live PDS fallback. */
+async function resolvePageRecord(origin, rkey) {
+  // 1. Build snapshot — public/data/pages.json is a { [rkey]: record } map.
+  if (origin) {
+    const pages = await fetchJson(`${origin}/data/pages.json`, SNAPSHOT_TIMEOUT_MS);
+    const rec = pages && typeof pages === 'object' ? pages[rkey] : null;
+    if (rec?.value) return rec;
+  }
+  // 2. Live PDS — catches a record authored/edited since the last build.
+  const live = await withTimeout(livePageRecord(rkey), PDS_TIMEOUT_MS);
+  if (live?.value) return live;
+  return null;
+}
+
+async function livePageRecord(rkey) {
+  const pds = await resolvePds(ME_DID).catch(() => null);
+  if (!pds) return null;
+  return getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.page, rkey }).catch(() => null);
+}
+
+/**
+ * Resolve a top-level page route to its PDS-backed OG copy, or null when the
+ * route isn't page-backed or no record exists yet (→ caller keeps the static
+ * og/pages.js defaults).
+ *
+ *   { title, desc }  — `desc` prefers a dedicated `description` on the record,
+ *   else its `intro`; `title` is the record's own title. Empty strings when the
+ *   record omits them.
+ */
+export async function pageContentMeta(pathname, origin) {
+  const rkey = PAGE_RKEY_FOR_PATH[pathname];
+  if (!rkey) return null;
+  const rec = await resolvePageRecord(origin, rkey);
+  const v = rec?.value || {};
+  const desc = firstText(v.description, v.intro);
+  const title = firstText(v.title);
+  if (!desc && !title) return null;
+  return { title, desc };
+}


### PR DESCRIPTION
Makes the `/available` social-card description editable from the PDS instead of hardcoded in `og/pages.js`.

## What changed

The résumé card's description now resolves in this order:

1. **Build/deploy snapshot** — the `resume` entry in `/data/pages.json` (the `is.dame.page` map the prefetch step already writes each deploy + 6h cron)
2. **Live PDS** — a time-boxed `getRecord(is.dame.page/resume)` fallback, so edits since the last build still show
3. **Static `og/pages.js` copy** — final fallback (what renders today, since no record exists yet)

## How

- New edge-safe resolver `og/pageContent.js`, mirroring `og/records.js`'s snapshot→PDS→null pattern (defensive timeouts; a slow PDS never blocks the card). Prefers a dedicated `description` field on the record, else its `intro`.
- `middleware.js` resolves the copy once for the crawler `<head>` and hands it to the card generator via the `subtitle` param — the same path per-record cards already use.
- `api/og.js` prefers that injected `subtitle`, falling back to the static copy on a direct hit.

Scoped to `/available` via a one-entry route→rkey map, so other pages' cards are unaffected. Behavior is unchanged until an `is.dame.page/resume` record exists.

Verified: syntax + full module-graph imports in Node, and the resolver's snapshot-hit / dedicated-description / PDS-fallback-to-null paths via stubbed `fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTxGm4TMwZxZBS8fy8De9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTxGm4TMwZxZBS8fy8De9U)_