### PR TITLE
Recover two unmigrated legacy blog posts

### DIFF
--- a/writing/blogs/a-guestbook-and-welcome-message-for-my-pds.md
+++ b/writing/blogs/a-guestbook-and-welcome-message-for-my-pds.md
@@ -1,0 +1,158 @@
+---
+layout: post
+title: "A guestbook and welcome message for my atproto PDS"
+date: "2025-05-08"
+time: "1:00pm EST"
+author: "Dame"
+excerpt: "We all know by now that I believe in the lexicon black market and an enjoy illegal atproto records. It's not my fault that Bluesky PBC allowed for such shenanigans! If the good lord had intended for us to walk, she wouldn't have invented roller skates."
+blueskyUri: "3loof6k33lc26"
+ogImage: "/images/blog/guestbook-blog.png"
+---
+
+We all know by now that [I believe in the lexicon black market](https://bsky.app/profile/dame.is/post/3lo56xss6hk2n) and thus enjoy [illegal atproto records](https://bsky.app/profile/dame.is/post/3lnyoz6es2k2b). It's not my fault that Bluesky PBC allowed for such shenanigans! If the good lord had intended for us to walk, [she wouldn't have invented roller skates](https://www.youtube.com/watch?v=K8Gmd8y_Aiw).
+
+My latest lexicon experiment is geared towards the real atproto nerds, so if you're not familiar with how this stuff works, you might want to [read my previous blog post where I explained lexicons](https://dame.is/writing/blogs/creating-a-decentralized-bathroom-at-protocol). Ok, let's jump in.
+
+If you spend time browsing PDS tools like [pdsls.dev](https://pdsls.dev) or [atp.tools](https://atp.tools), then you've probably picked up on the fact that by default they sort lexicon collections alphabetically. This means that 99.99% of PDSes currently begin with app.bsky records at the top. This got me thinking... what if I made some "welcome" records that would go at the top of my PDS so that nerds browsing it would get a friendly hello?
+
+![A screenshot of pdsls.dev showing the welcome message lexicons at the top of the collections list](/images/blog/guestbook-blog.png)
+
+So, I created [a.welcome.message.for.my.pds](https://pdsls.dev/at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/a.welcome.message.for.my.pds). At the moment it contains a little greeting + a list of links where people can find me and my projects.
+
+```
+{
+
+"text": "Hi there ATmosphere explorer! My name is Dame, and this is my PDS. Glad to see you here!",
+
+"$type": "a.welcome.message.for.my.pds",
+
+"follow me on bsky": "https://bsky.app/profile/dame.is",
+
+"check out my links": "at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/a.welcome.message.for.my.pds/links-to-check-out"
+
+}
+```
+
+I couldn't stop there though. Thanks to the fact that pdsls.dev and atp.tools support [@bad-example.com's](https://bsky.app/profile/bad-example.com) project called [Constellation](https://constellation.microcosm.blue/), I realized I could create another lexicon at the top of my PDS that took advantage of backlinks.
+
+So, I created [a.guestbook.for.my.pds](https://pdsls.dev/at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/a.guestbook.for.my.pds/guestbook). You can sign my guestbook by simply creating a record in your own PDS under any arbitrary lexicon such as `a.guestbook.i.signed` that points to the at:// URI of my guestbook. Then, thanks to the power of [Constellation](https://constellation.microcosm.blue/), it will automatically appear as a backlink when viewing my guestbook via a tool like pdsls.dev.
+
+```
+{
+
+"$type": "a.guestbook.for.my.pds",
+
+"readme": "Sign my guestbook by creating a record in your PDS that points to my guestbook's URI. It will then appear as a backlink via constellation. You can view all of the guestbook messages on an atproto explorer like pdsls.dev that supports constellation backlinks.",
+
+"uri-to-link-to": "at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/a.guestbook.for.my.pds/guestbook"
+
+}
+```
+
+![constellation backlinks for the guestbook as seen underneath the record on pdsls.dev](/images/blog/backlinks-example.png)
+
+Because of the technical nature of this setup, it's not exactly a guestbook that anyone can enjoy. It's geared specifically towards developers and freaks like me who aren't engineers but who know enough to get in trouble. What if there was an atproto-based guestbook that more people could enjoy?
+
+Well, there might soon be one... [Ms Boba](https://bsky.app/profile/essentialrandom.bsky.social) is working on [an atproto guestbook AppView and Lexicon](https://github.com/FujoWebDev/lexicon-guestbook) that is worth checking out.
+
+In the meantime, here's a step-by-step guide to making your own nerd version.
+
+## How to create your own PDS guestbook and welcome message
+
+### Guestbook Instructions
+1. Go to [pdsls.dev](https://pdsls.dev) and sign in with your ATmosphere account.
+2. Tap the "Create record" icon in the top right that looks like a pencil/pen.
+3. In the `Collection` field, type `a.guestbook.for.my.pds`.
+4. In the `Record key` field, type `guestbook`.
+5. `Validate` can stay as `Unset`.
+6. In the code editor, paste the following code and hit `Create`.
+
+```
+{
+
+"$type": "a.guestbook.for.my.pds",
+
+"readme": "Sign my guestbook by creating a record in your PDS under the Collection 'a.guestbook.i.signed' and include a link to my guestbook's at:// URI that's listed below. It will then appear as a backlink via Constellation. You can view all of the guestbook messages on an atproto explorer like pdsls.dev that supports Constellation backlinks.",
+
+"guestbook": "REPLACE WITH URI after record creation by editing the record via recreation",
+
+"more-info": "https://dame.is/writing/blogs/a-guestbook-and-welcome-message-for-my-pds/"
+
+}
+```
+
+7. Navigate to the record you just created and tap the `Edit` button.
+8. In your browser's URL bar, copy the part of the pdsls.dev link that looks like this: `at://did:plc:gq4fo3u6tqzzdkjlwzpb23tj/a.welcome.message.for.my.pds/start-here`
+9. Paste this into the `guestbook` value that says "REPLACE WITH URI".
+10. Check the `Recreate record` box and then tap the `Edit` button.
+
+### Welcome Message Instructions
+1. Go to [pdsls.dev](https://pdsls.dev) and sign in with your ATmosphere account.
+2. Tap the "Create record" icon in the top right that looks like a pencil/pen.
+3. In the `Collection` field, type `a.welcome.message.for.my.pds`.
+4. In the `Record key` field, type a name like `start-here`.
+5. `Validate` can stay as `Unset`.
+6. In the code editor, paste the following code or something similar:
+
+```
+{
+
+"text": "Hi there ATmosphere explorer! This is my PDS. Glad to see you here!",
+
+"$type": "a.welcome.message.for.my.pds",
+
+"follow me on bsky": "https://bsky.app/profile/USERNAME",
+
+"sign my guestbook": "REPLACE WITH URI of your guestbook",
+
+}
+```
+
+## How to sign someone's guestbook
+1. Go to [pdsls.dev](https://pdsls.dev) and sign in with your ATmosphere account.
+2. Tap the "Create record" icon in the top right that looks like a pencil/pen.
+3. In the `Collection` field, type `a.guestbook.i.signed`.
+4. Leave the `Record key` field blank or type a name (no spaces).
+5. `Validate` can stay as `Unset`.
+6. In the code editor, paste the following code or something similar and hit `Create`:
+
+```
+{
+
+"$type": "a.guestbook.i.signed",
+
+"message": "hi there",
+
+"guestbook": "REPLACE WITH URI of the guestbook you want to sign"
+
+}
+```
+
+The interesting thing about lexicons and at:// URIs is that you can even create a record that points to someone's guestbook that doesn't even exist (yet). All you'd have to do is swap out the account's DID in the URI like this:
+
+`at://did:plc:fnhrjbkwjiw6iyxxg2o3rljw/a.guestbook.for.my.pds/guestbook`
+
+Then, theoretically, if that person ever creates a guestbook down the line using this lexicon schema, the backlink would work.
+
+## The guestbook record generator
+
+To cut down on some of the time that it takes to put together the data for guestbook signing, I've created a little tool below to simplify things. Type in the username of the account whose guestbook you want to sign, write your message, and then it will output the JSON for you to copy to your clipboard. Then you can just paste that into [pdsls.dev](https://pdsls.dev).
+
+<div class="guestbook-generator">
+    <form id="guestbook-form">
+        <div>
+            <label for="handle">Handle (e.g., dame.is):</label>
+            <input type="text" id="handle" name="handle" placeholder="dame.is" required>
+        </div>
+        <div>
+            <label for="message">Message:</label>
+            <textarea id="message" name="message" placeholder="hi there, good to see you" required></textarea>
+        </div>
+        <button type="submit">Generate JSON</button>
+    </form>
+    <pre id="guestbook-result"></pre>
+    <button id="copy-json">Copy JSON</button>
+</div>
+
+<link rel="stylesheet" href="/css/guestbook-generator.css">
+<script src="/js/guestbook-generator.js"></script>

--- a/writing/blogs/examining-my-2025-goal-progress.md
+++ b/writing/blogs/examining-my-2025-goal-progress.md
@@ -1,0 +1,68 @@
+---
+layout: post
+title: "Examining my 2025 goal progress"
+date: "2025-05-07"
+time: "1:48pm EST"
+author: "Dame"
+excerpt: "Today is my birthday, and we're almost halfway through the year already, so it feels like a good time to check in on my goals."
+blueskyUri: "3lolyfg6qis2m"
+ogImage: "/images/blog/social-images/examining-my-2025-goal-progress.png"
+---
+
+Today is my birthday, and we're almost halfway through the year already, so it feels like a good time to check in on my goals. Let's see how I'm doing...
+
+## Completed goals
+- Built another web app
+- Made a custom website for myself for the first time
+- Launch cred.blue
+- Finally got Bluesky OAuth working
+- Created one minor art project
+- Began publishing longer form content on my blog at least once a month
+- Played in a tennis league
+- Cleaned the garage
+- Ended my sabbatical
+
+## Unplanned achievements
+- Created Flushes
+- Created atpota.to
+- Created several smaller atproto projects
+- Tennis team made it to state championship
+- Started live streaming
+- Cleaned spare bedroom + finished unboxing
+
+## On track
+- Create some sort of helpful + free "evergreen" content series
+- Continue microblogging daily
+- Read at least one book a month
+- Meditate more than I did in 2024
+- Land my next job (ideally thru relationships and discovery rather than applications) OR begin to generate income from a project
+- Continue playing tennis 2-3 times a week
+- Use are.na on a daily/weekly basis
+- Create a new series of photographs
+
+## Still to do
+- Create one major art project
+- Start exercising outside of tennis on a regular basis
+- Start going back to the dentist after ~1 year off
+- Try to consume a lower amount of added sugar
+- Volunteer for something
+- Join a book club
+- Make some new friends within a 50 mile radius of where I live
+- Research sigils and magick finally
+- Start journaling again
+- Take a solo trip
+- Travel someplace new
+- Take some private tennis lessons to improve fundamentals
+- Get to bed earlier
+
+## New goals
+- Reduce meat intake further
+- Rely more on solar power + track my energy consumption
+- Setup PDS on raspberry pi, maybe make it solar only
+- Launch Unnamed Challenges app
+- Launch Types (app)
+- Launch Unnamed ATProto Client
+- Launch v2 of cred.blue
+- Launch merch + art store
+
+Overall I'm happy with my progress so far. My remaining goals are quite ambitious, and I know I won't finish all of them, but it gives me plenty to aim towards.


### PR DESCRIPTION
## Summary

The pre-rewrite Eleventy site (final state at tag `v1.17.87`) carried **seven** posts under `writing/blogs/`, but only five made it into the SPA rewrite. Two were dropped and never migrated:

- `a-guestbook-and-welcome-message-for-my-pds`
- `examining-my-2025-goal-progress`

This restores both **verbatim** from `v1.17.87` so they appear in the admin "Legacy blog migration" panel and can be migrated to `site.standard.document` records like the others.

## Verification

- Both posts parse cleanly through `src/lib/legacyBlogMarkdown.js` (29 and 12 blocks, no malformed output).
- All referenced images (`guestbook-blog.png`, `backlinks-example.png`, `social-images/examining-my-2025-goal-progress.png`) already exist in `images/blog/`.
- The five previously-migrated posts are byte-identical between `v1.17.87` and `main`, confirming this restore matches the migration's fidelity.

## Root cause

The guestbook post's front matter was reused as a template for the imported "Bluesky for Brands" guide (`writing/blogs/how-to-use-bluesky-to-grow-your-brand.md`), so the guestbook post itself never got its own file. That file's stale front matter is left untouched here to keep this change scoped.

## Follow-up (manual)

Restoring the markdown only surfaces these posts in the admin migration panel. To make them live at `dame.is/blogging/…`, run the migration there while signed in — that step needs PDS auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S7mCTokoTNwbkrSB4iEUs

---
_Generated by [Claude Code](https://claude.ai/code/session_015S7mCTokoTNwbkrSB4iEUs)_