### PR TITLE
Fold the legacy "lofi" guestbook signatures into /guestbook

### DIFF
--- a/lexicons/GUESTBOOK.md
+++ b/lexicons/GUESTBOOK.md
@@ -56,6 +56,42 @@ only needs to index `is.dame.guestbook.entry` records from the firehose — the
 site would swap step 1–3 for one call without any schema change. And any other
 site can host its own book with the same two lexicons.
 
+## The original lofi guestbook (legacy signatures)
+
+Before `is.dame.guestbook`, this PDS hosted a "lofi" guestbook built on the same
+backlink idea but a different pair of ad-hoc collections. That book is **closed**
+— new signatures use `is.dame.guestbook.entry` — but its signatures are real
+history, so the read path folds them in as older entries (see
+[`src/lib/guestbook.js`](../src/lib/guestbook.js) and `LEGACY_GUESTBOOK_*` in
+[`src/config.js`](../src/config.js)). Announced in
+[a-guestbook-and-welcome-message-for-my-pds](https://dame.is/blog/a-guestbook-and-welcome-message-for-my-pds/).
+
+```
+a.guestbook.for.my.pds (rkey 'guestbook')   ← the old book on MY repo
+        ▲
+        │ guestbook (at-uri)
+        │
+a.guestbook.i.signed                          ← each signer's repo: their signature
+  { $type, guestbook, message?, createdAt? }
+```
+
+Two shape differences from the modern records, handled at hydration:
+
+- The signature links the book through a **`guestbook`** field (not `subject`),
+  so the Constellation source is `a.guestbook.i.signed:guestbook`.
+- The note lives in **`message`** (surfaced as `text`), and `createdAt` is
+  usually absent. When it is, the timestamp is recovered from the signature's
+  **TID rkey** (`tidToTimestamp`); a couple of human-chosen rkeys have no
+  decodable time and simply render undated.
+
+Everything downstream is shared: legacy entries are hydrated (Slingshot →
+direct PDS), profiled, and moderated (the book's `hidden` list can name legacy
+at-uris too) exactly like modern ones, and each row carries a small "from the
+old guestbook" tag linking the retired book record. Merging is a plain tail:
+every legacy signature predates the modern book, so once the modern pages are
+exhausted the legacy set — small and closed — is loaded in one shot and
+appended, already in chronological order.
+
 ## Moderation & ownership
 
 - A visitor can **delete their signature** (it's their record; the site offers

--- a/src/components/GuestbookEntryRow.jsx
+++ b/src/components/GuestbookEntryRow.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { explorerPathFromAtUri } from '../lib/atproto.js';
 import { relativeTime } from '../lib/time.js';
+import { LEGACY_GUESTBOOK_SUBJECT } from '../config.js';
 import '../pages/Guestbook.css';
 
 /**
@@ -27,6 +28,10 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
     shortDid(entry.did);
   const handle = profile?.handle && profile.handle !== 'handle.invalid' ? profile.handle : null;
   const explorerPath = explorerPathFromAtUri(entry.uri);
+  // Legacy signatures often lack a createdAt (recovered from the TID rkey where
+  // possible); when even that isn't available, skip the time rather than
+  // rendering an empty permalink.
+  const when = relativeTime(value.createdAt);
 
   async function remove() {
     if (removing) return;
@@ -86,13 +91,11 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
           {value.location && (
             <span className="guestbook-entry-location gutter">from {value.location}</span>
           )}
-          <span className="guestbook-entry-time gutter">
-            {explorerPath ? (
-              <Link to={explorerPath}>{relativeTime(value.createdAt)}</Link>
-            ) : (
-              relativeTime(value.createdAt)
-            )}
-          </span>
+          {when && (
+            <span className="guestbook-entry-time gutter">
+              {explorerPath ? <Link to={explorerPath}>{when}</Link> : when}
+            </span>
+          )}
           {entry.hidden && moderating && (
             <span className="guestbook-entry-hidden-badge small-caps">hidden</span>
           )}
@@ -134,6 +137,15 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
             {value.mark}
           </p>
         ) : null}
+        {entry.legacy && (
+          <Link
+            to={explorerPathFromAtUri(LEGACY_GUESTBOOK_SUBJECT)}
+            className="guestbook-entry-legacy small-caps"
+            title="Signed on the original a.guestbook lofi guestbook, before this one."
+          >
+            from the old guestbook
+          </Link>
+        )}
       </div>
     </li>
   );

--- a/src/config.js
+++ b/src/config.js
@@ -61,6 +61,17 @@ export const GUESTBOOK_NSID = 'is.dame.guestbook';
 export const GUESTBOOK_ENTRY_NSID = 'is.dame.guestbook.entry';
 export const GUESTBOOK_SUBJECT = `at://${ME_DID}/${GUESTBOOK_NSID}/self`;
 
+// The retired "lofi" guestbook that predated is.dame.guestbook. Visitors signed
+// it by writing an `a.guestbook.i.signed` record whose `guestbook` field pointed
+// at the book record below (rkey `guestbook`, not `self`). That book is closed —
+// new signatures use is.dame.guestbook.entry — but its signatures are real
+// history, so the guestbook read path folds them in as older entries. Same
+// backlink-assembly mechanism, just a different collection + field name.
+// See lexicons/GUESTBOOK.md → "The original lofi guestbook".
+export const LEGACY_GUESTBOOK_NSID = 'a.guestbook.for.my.pds';
+export const LEGACY_GUESTBOOK_ENTRY_NSID = 'a.guestbook.i.signed';
+export const LEGACY_GUESTBOOK_SUBJECT = `at://${ME_DID}/${LEGACY_GUESTBOOK_NSID}/guestbook`;
+
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';

--- a/src/lib/atproto.js
+++ b/src/lib/atproto.js
@@ -223,6 +223,34 @@ export function rkeyFromAtUri(atUri) {
   return m ? m[1] : null;
 }
 
+// The base32-sortable alphabet atproto TIDs are encoded with.
+const TID_ALPHABET = '234567abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Recover the timestamp embedded in a TID record key.
+ *
+ * A TID is a 13-char base32-sortable string whose bits are
+ * `0 | 53-bit microseconds-since-epoch | 10-bit clock id`, so the key alone
+ * pins when the record was minted. Useful when a record omits an explicit
+ * `createdAt` (the legacy guestbook signatures often do) — the rkey is then
+ * the only timestamp available. Returns an ISO string, or `null` when `rkey`
+ * isn't a well-formed TID (custom / human-chosen rkeys aren't).
+ */
+export function tidToTimestamp(rkey) {
+  const s = String(rkey || '');
+  if (s.length !== 13) return null;
+  let n = 0n;
+  for (const ch of s) {
+    const i = TID_ALPHABET.indexOf(ch);
+    if (i < 0) return null; // not a TID — bail rather than decode garbage
+    n = n * 32n + BigInt(i);
+  }
+  const ms = Number((n >> 10n) / 1000n); // drop the clock id, µs → ms
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
 /**
  * Convert an `at://` URI (or a bare DID) into the corresponding
  * `/exploring/...` SPA path. Returns `null` for empty/unparseable input.

--- a/src/lib/guestbook.js
+++ b/src/lib/guestbook.js
@@ -10,19 +10,29 @@
 // Falls back to a direct DID-doc + PDS fetch per record when Slingshot is
 // unavailable. See lexicons/GUESTBOOK.md for the full design.
 
-import { getBacklinks } from './constellation.js';
+import { getBacklinks, getBacklinkCount } from './constellation.js';
 import { getRecordCached } from './slingshot.js';
-import { resolvePds, getRecord, toAtUri } from './atproto.js';
+import { resolvePds, getRecord, toAtUri, tidToTimestamp } from './atproto.js';
+import { compareIsoDesc } from './time.js';
 import {
   APPVIEW,
   ME_DID,
   GUESTBOOK_NSID,
   GUESTBOOK_ENTRY_NSID,
   GUESTBOOK_SUBJECT,
+  LEGACY_GUESTBOOK_ENTRY_NSID,
+  LEGACY_GUESTBOOK_SUBJECT,
 } from '../config.js';
 
 /** Constellation source tuple: which records/fields point at the book. */
 export const GUESTBOOK_SOURCE = `${GUESTBOOK_ENTRY_NSID}:subject`;
+
+/**
+ * Constellation source for the retired "lofi" guestbook. Its signatures are
+ * `a.guestbook.i.signed` records that link the old book through a `guestbook`
+ * field (not `subject`). The book is closed, so this source only ever shrinks.
+ */
+export const LEGACY_GUESTBOOK_SOURCE = `${LEGACY_GUESTBOOK_ENTRY_NSID}:guestbook`;
 
 /** Page size for the entries list. Also the Constellation page size. */
 export const GUESTBOOK_PAGE_SIZE = 25;
@@ -48,39 +58,96 @@ export async function fetchGuestbookBook() {
 }
 
 /**
- * One page of the book.
+ * One page of the book, newest first.
+ *
+ * Two backlink sources feed the book: the current `is.dame.guestbook.entry`
+ * records and the retired `a.guestbook.i.signed` ones (the old "lofi" book).
+ * The modern source paginates through Constellation as usual; the legacy book
+ * is a small *closed* set, so once the modern pages run out its signatures are
+ * loaded in one shot and merged onto the tail. Because every legacy signature
+ * predates the modern book, "modern pages, then the legacy tail" is already
+ * chronological — no cross-source interleaving is needed. The compound `cursor`
+ * that threads this two-phase walk is opaque to callers (they pass it back).
  *
  * Returns `{ total, publicTotal, hiddenCount, cursor, entries, book }` where
- * each entry is `{ uri, did, rkey, value, profile, hidden }` (profile may be
- * null), newest first. `hidden` reflects the book's moderation list; callers
- * decide whether to render hidden entries (the public page filters them, the
- * moderation surfaces show them dimmed). `publicTotal` is the backlink total
- * minus the hidden list, for the public signature count.
- * Returns `null` only when Constellation itself is unreachable; signatures
- * whose records can't be hydrated (deleted, PDS down) are dropped from the
- * page rather than failing it.
+ * each entry is `{ uri, did, rkey, collection, legacy, value, profile, hidden }`,
+ * newest first. `value` is normalized so both record shapes render through one
+ * row (a legacy `message` surfaces as `text`, and a missing `createdAt` is
+ * recovered from the TID rkey where possible). `hidden` reflects the book's
+ * moderation list — which may name legacy at-uris too, so hiding spans both
+ * books. Returns `null` only when the backlink index is unreachable with
+ * nothing to show; individual records that can't be hydrated are dropped from
+ * the page rather than failing it.
  */
 export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, cursor } = {}) {
-  const [page, book] = await Promise.all([
-    getBacklinks(GUESTBOOK_SUBJECT, GUESTBOOK_SOURCE, { limit, cursor }),
-    fetchGuestbookBook(),
-  ]);
-  if (!page) return null;
-  const refs = Array.isArray(page.records) ? page.records : [];
+  const state = decodeGuestbookCursor(cursor);
+  const book = await fetchGuestbookBook();
   const hiddenUris = new Set(book?.value?.hidden || []);
 
-  const hydrated = await Promise.all(refs.map(hydrateEntry));
-  const entries = hydrated.filter(Boolean);
-  for (const entry of entries) {
-    entry.hidden = hiddenUris.has(entry.uri);
+  // Phase 2: the legacy tail. Reached inline once the modern pages are spent
+  // (below), or as a standalone retry if the legacy index was briefly down on
+  // the page that should have appended it.
+  if (state?.phase === 'legacy') {
+    const legacy = await fetchLegacyEntries(hiddenUris);
+    if (!legacy) return null;
+    return finalizePage({
+      entries: sortByCreatedAt(legacy.entries),
+      total: (state.modernTotal ?? 0) + legacy.total,
+      hiddenUris,
+      book,
+      cursor: null,
+    });
   }
 
-  const profiles = await fetchProfiles(entries.map((e) => e.did));
-  for (const entry of entries) {
-    entry.profile = profiles.get(entry.did) || null;
+  // Phase 1: the modern book, paginated by Constellation.
+  const page = await getBacklinks(GUESTBOOK_SUBJECT, GUESTBOOK_SOURCE, {
+    limit,
+    cursor: state?.modernCursor,
+  });
+  if (!page) return null;
+  const modernRefs = Array.isArray(page.records) ? page.records : [];
+  const modernEntries = await hydrateEntries(modernRefs, hydrateModernRef, hiddenUris);
+  const modernTotal = page.total ?? modernEntries.length;
+
+  // Still more modern pages to come — leave the legacy book untouched for now,
+  // but fold its count into the total so the signature caption is honest.
+  if (page.cursor) {
+    const legacyCount = await getBacklinkCount(LEGACY_GUESTBOOK_SUBJECT, LEGACY_GUESTBOOK_SOURCE);
+    return finalizePage({
+      entries: modernEntries,
+      total: modernTotal + (legacyCount?.total ?? 0),
+      hiddenUris,
+      book,
+      cursor: encodeGuestbookCursor({ phase: 'modern', modernCursor: page.cursor }),
+    });
   }
 
-  const total = page.total ?? null;
+  // Modern book exhausted — append the legacy tail on this same page.
+  const legacy = await fetchLegacyEntries(hiddenUris);
+  if (!legacy) {
+    // Legacy index momentarily down. Hand back a legacy-phase cursor so
+    // "earlier signatures" can retry the tail — unless there's nothing at all
+    // to show, in which case report the index as unreachable.
+    if (modernEntries.length === 0) return null;
+    return finalizePage({
+      entries: modernEntries,
+      total: modernTotal,
+      hiddenUris,
+      book,
+      cursor: encodeGuestbookCursor({ phase: 'legacy', modernTotal }),
+    });
+  }
+  return finalizePage({
+    entries: sortByCreatedAt([...modernEntries, ...legacy.entries]),
+    total: modernTotal + legacy.total,
+    hiddenUris,
+    book,
+    cursor: null,
+  });
+}
+
+/** Assemble the public return shape shared by every page and phase. */
+function finalizePage({ entries, total, hiddenUris, book, cursor }) {
   return {
     total,
     // Approximate when a hidden record has since been deleted by its signer
@@ -88,43 +155,126 @@ export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, curso
     // close enough for a count caption.
     publicTotal: total != null ? Math.max(0, total - hiddenUris.size) : null,
     hiddenCount: hiddenUris.size,
-    cursor: page.cursor || null,
+    cursor: cursor || null,
     entries,
     book,
   };
 }
 
 /**
- * Hydrate one Constellation ref (`{did, collection, rkey}`) into an entry.
- * Slingshot first; on a miss, resolve the signer's PDS and fetch directly.
- * Returns `null` when the record is gone or malformed.
+ * Every signature on the retired legacy book, hydrated + profiled. The old
+ * book is closed and tiny, so there's no legacy cursor — one Constellation
+ * page (limit 100) holds every `a.guestbook.i.signed` record. Returns
+ * `{ entries, total }`, or `null` if Constellation is unreachable.
  */
-async function hydrateEntry(ref) {
+async function fetchLegacyEntries(hiddenUris) {
+  const page = await getBacklinks(LEGACY_GUESTBOOK_SUBJECT, LEGACY_GUESTBOOK_SOURCE, { limit: 100 });
+  if (!page) return null;
+  const refs = Array.isArray(page.records) ? page.records : [];
+  const entries = await hydrateEntries(refs, hydrateLegacyRef, hiddenUris);
+  return { entries, total: page.total ?? entries.length };
+}
+
+/**
+ * Hydrate a list of Constellation refs with `hydrate`, drop the misses, flag
+ * the hidden ones, and attach signer profiles. Shared by both books.
+ */
+async function hydrateEntries(refs, hydrate, hiddenUris) {
+  const hydrated = (await Promise.all(refs.map(hydrate))).filter(Boolean);
+  for (const entry of hydrated) entry.hidden = hiddenUris.has(entry.uri);
+  const profiles = await fetchProfiles(hydrated.map((e) => e.did));
+  for (const entry of hydrated) entry.profile = profiles.get(entry.did) || null;
+  return hydrated;
+}
+
+/**
+ * Fetch the record for one Constellation ref (`{did, collection, rkey}`) —
+ * Slingshot first, direct PDS on a miss. Returns the raw getRecord shape or
+ * `null` when the record is gone; the per-book hydrators below normalize it.
+ */
+async function fetchRefRecord(ref) {
   const { did, collection, rkey } = ref || {};
   if (!did || !collection || !rkey) return null;
-
-  let record = await getRecordCached({ repo: did, collection, rkey });
-  if (!record) {
-    try {
-      const pds = await resolvePds(did);
-      record = await getRecord(pds, { repo: did, collection, rkey });
-    } catch {
-      return null;
-    }
+  const cached = await getRecordCached({ repo: did, collection, rkey });
+  if (cached) return cached;
+  try {
+    const pds = await resolvePds(did);
+    return await getRecord(pds, { repo: did, collection, rkey });
+  } catch {
+    return null;
   }
+}
 
+/** Hydrate a modern `is.dame.guestbook.entry` ref into an entry. */
+async function hydrateModernRef(ref) {
+  const record = await fetchRefRecord(ref);
   const value = record?.value;
-  // Belt-and-braces: Constellation already filtered on subject, but a
-  // record may have been rewritten to point elsewhere since indexing.
+  // Belt-and-braces: Constellation already filtered on subject, but a record
+  // may have been rewritten to point elsewhere since indexing.
   if (!value || value.subject !== GUESTBOOK_SUBJECT) return null;
-
   return {
-    uri: record.uri || toAtUri({ did, collection, rkey }),
-    did,
-    rkey,
+    uri: record.uri || toAtUri(ref),
+    did: ref.did,
+    rkey: ref.rkey,
+    collection: GUESTBOOK_ENTRY_NSID,
+    legacy: false,
     value,
     profile: null,
   };
+}
+
+/**
+ * Hydrate a legacy `a.guestbook.i.signed` ref into the same entry shape. The
+ * old lexicon carried the note in `message` and rarely set `createdAt`, so we
+ * surface `message` as `text` and fall back to the TID rkey for a timestamp
+ * (the couple of human-chosen rkeys just stay timeless).
+ */
+async function hydrateLegacyRef(ref) {
+  const record = await fetchRefRecord(ref);
+  const raw = record?.value;
+  if (!raw || raw.guestbook !== LEGACY_GUESTBOOK_SUBJECT) return null;
+  const message = typeof raw.message === 'string' ? raw.message : '';
+  const createdAt = normalizeIso(raw.createdAt) || tidToTimestamp(ref.rkey) || undefined;
+  return {
+    uri: record.uri || toAtUri(ref),
+    did: ref.did,
+    rkey: ref.rkey,
+    collection: LEGACY_GUESTBOOK_ENTRY_NSID,
+    legacy: true,
+    value: { ...raw, text: message, createdAt },
+    profile: null,
+  };
+}
+
+/** Sort entries newest-first by their (normalized) createdAt; timeless last. */
+function sortByCreatedAt(entries) {
+  return entries.slice().sort((a, b) => compareIsoDesc(a.value?.createdAt, b.value?.createdAt));
+}
+
+/** ISO string if `value` parses as a date, else `null`. */
+function normalizeIso(value) {
+  if (!value) return null;
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
+// The read walk spans two books (modern pages, then the legacy tail); the
+// cursor threading them is just JSON handed back to callers opaquely.
+function encodeGuestbookCursor(state) {
+  try {
+    return encodeURIComponent(JSON.stringify(state));
+  } catch {
+    return null;
+  }
+}
+
+function decodeGuestbookCursor(cursor) {
+  if (!cursor) return null;
+  try {
+    return JSON.parse(decodeURIComponent(cursor));
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -219,13 +369,15 @@ export async function signGuestbook(agent, { text, signature, mark, location } =
 
 /**
  * Remove one of the signer's own entries. Their record, their eraser —
- * Constellation drops the backlink once the delete propagates.
+ * Constellation drops the backlink once the delete propagates. `collection`
+ * defaults to the modern entry NSID but is passed through from the entry, so
+ * a legacy `a.guestbook.i.signed` signature deletes from the right collection.
  */
-export async function deleteGuestbookEntry(agent, rkey) {
+export async function deleteGuestbookEntry(agent, rkey, collection = GUESTBOOK_ENTRY_NSID) {
   if (!agent) throw new Error('Sign in first.');
   await agent.com.atproto.repo.deleteRecord({
     repo: agent.assertDid,
-    collection: GUESTBOOK_ENTRY_NSID,
+    collection,
     rkey,
   });
 }

--- a/src/pages/Guestbook.css
+++ b/src/pages/Guestbook.css
@@ -273,6 +273,21 @@
   color: var(--accent);
 }
 
+/* Provenance tag under a signature carried over from the retired lofi
+   guestbook — links to the old book record for the curious. */
+.guestbook-entry-legacy {
+  align-self: flex-start;
+  font-family: var(--sans);
+  letter-spacing: 0.12em;
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  text-decoration: none;
+}
+
+.guestbook-entry-legacy:hover {
+  color: var(--accent);
+}
+
 /* --- moderation (owner edit mode) ---------------------------------------- */
 
 .guestbook-hidden-count {

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -98,7 +98,7 @@ export default function Guestbook() {
 
   async function handleRemove(entry) {
     if (!agent) return;
-    await deleteGuestbookEntry(agent, entry.rkey);
+    await deleteGuestbookEntry(agent, entry.rkey, entry.collection);
     setEntries((prev) => (prev || []).filter((e) => e.uri !== entry.uri));
     setTotal((t) => (typeof t === 'number' && t > 0 ? t - 1 : t));
   }


### PR DESCRIPTION
Before `is.dame.guestbook`, visitors signed a "lofi" guestbook by writing an `a.guestbook.i.signed` record that linked the old book (`a.guestbook.for.my.pds/guestbook`) through a `guestbook` field. That book is closed — but its signatures are real history, and right now they're the *only* signatures the site has (the modern book has zero entries). This folds them into `/guestbook` as older entries instead of ignoring them.

## How it works

The read path assembles the book from **both** backlink sources through one shared hydrate → profile → moderate pipeline, keeping the "no database, just backlinks" design:

- **`src/config.js`** — adds `LEGACY_GUESTBOOK_{NSID,ENTRY_NSID,SUBJECT}` for the retired `a.guestbook.for.my.pds` / `a.guestbook.i.signed` pair.
- **`src/lib/guestbook.js`** — a second Constellation source (`a.guestbook.i.signed:guestbook`) feeds the same assembly. The modern book paginates as before; the legacy book is a small *closed* set, so once the modern pages run out its signatures load in one shot and merge onto the tail. Every legacy entry predates the modern book, so "modern pages, then legacy tail" is already chronological. A compound, caller-opaque cursor threads the two phases, so the page/admin components are unchanged.
- **Normalization** — legacy `message` surfaces as `text`; a missing `createdAt` is recovered from the TID rkey via a new `tidToTimestamp()` helper in `src/lib/atproto.js` (a couple of human-chosen rkeys stay gracefully undated).
- **Moderation & deletion span both books** — the book's `hidden` list may name legacy at-uris, and `deleteGuestbookEntry` now takes the entry's collection so a legacy signer can still remove their own record.
- **`src/components/GuestbookEntryRow.jsx`** — each legacy row shows a subtle "from the old guestbook" tag linking the retired book record; the timestamp is skipped when a signature is undated.
- **`lexicons/GUESTBOOK.md`** — documents the legacy book and the merge.

## Verification

- Ran the real `fetchGuestbookEntries()` against **live** Constellation/Slingshot: legacy entries assemble, normalize, and sort newest-first, with profiles resolving to handles. ~10 of the ~12 indexed backlinks render — the rest are stale backlinks whose records were deleted by their signers (confirmed one signer's collection is now empty), the same graceful drop the modern path already does.
- Stubbed-network flow test covers what live data can't (the modern book is empty): modern pagination → legacy-tail merge, combined totals, moderation hiding legacy entries, and TID / explicit / timeless `createdAt`.
- `tidToTimestamp` unit-tested against decoded references; `npm run build` clean.

## Note

The heading counts Constellation's backlink total, so it may read slightly higher than the number of rendered rows when stale backlinks point at deleted records — consistent with the existing modern behavior, just newly visible. Happy to tighten the count to rendered-only in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnjSwno54FKWneN1WHhCdB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnjSwno54FKWneN1WHhCdB)_