### PR TITLE
Edit pencil opens the page editor directly on pages with nothing to select

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -362,8 +362,29 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   // Info button and flips the site into a selectable "edit mode" (see
   // EditModeBar + useEditMode).
   const { did } = useAtprotoSession();
-  const { active: editActive, toggle: toggleEdit, exit: exitEdit } = useEditMode();
+  const {
+    active: editActive,
+    toggle: toggleEdit,
+    exit: exitEdit,
+    pageRecord,
+    selectionPage,
+    editSheet,
+    openEditSheet,
+    closeEditSheet,
+  } = useEditMode();
   const isOwner = did === ME_DID;
+  // The owner's edit record for THIS page, if any — guarded on the stamped path
+  // so a stale value can't leak across a route change, and on the owner's repo
+  // (only those are editable). Home has no such record, so it stays null.
+  const pageEditUri =
+    pageRecord &&
+    pageRecord.path === location.pathname &&
+    String(pageRecord.atUri).startsWith(`at://${ME_DID}/`)
+      ? pageRecord.atUri
+      : null;
+  // The pencil reads as "open" both in select/moderation mode and while a
+  // page editor it opened directly is showing.
+  const chromeEditOpen = editActive || !!editSheet;
   // Trigger buttons highlight when the corresponding URL state is
   // populated — search has a `?q=`, filter has a custom verb set.
   const searchActive = !!params.get('q');
@@ -580,21 +601,36 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 {isOwner && (
                   <button
                     type="button"
-                    className={`chrome-nav chrome-edit-btn ${editActive ? 'is-open' : ''}`}
+                    className={`chrome-nav chrome-edit-btn ${chromeEditOpen ? 'is-open' : ''}`}
                     onClick={() => {
                       // Entering/leaving edit mode owns the bottom chrome —
                       // fold any open search/filter/info panel away first.
                       closePanel();
-                      toggleEdit();
+                      if (editActive) {
+                        // In select / moderation mode → leave it.
+                        toggleEdit();
+                      } else if (editSheet) {
+                        // A page editor the pencil opened is showing → close it.
+                        closeEditSheet();
+                      } else if (pageEditUri && !selectionPage) {
+                        // Nothing to select on this page, but it has its own
+                        // editable record — jump straight into its page editor
+                        // instead of an empty "tap items to select" bar.
+                        openEditSheet(pageEditUri);
+                      } else {
+                        // Feeds / guestbook (or a page with no record): the
+                        // usual selectable edit mode.
+                        toggleEdit();
+                      }
                     }}
-                    aria-pressed={editActive}
-                    aria-label={editActive ? 'Exit edit mode' : 'Enter edit mode'}
-                    title={editActive ? 'Exit edit mode' : 'Edit mode'}
+                    aria-pressed={chromeEditOpen}
+                    aria-label={chromeEditOpen ? 'Exit edit mode' : 'Enter edit mode'}
+                    title={chromeEditOpen ? 'Exit edit mode' : 'Edit mode'}
                   >
                     <Pencil className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                   </button>
                 )}
-                {isOwner && editActive && (
+                {isOwner && chromeEditOpen && (
                   <button
                     type="button"
                     className="chrome-nav chrome-edit-exit"

--- a/src/components/PageShell.jsx
+++ b/src/components/PageShell.jsx
@@ -5,14 +5,31 @@ import { useEditMode } from '../hooks/useEditMode.jsx';
 /**
  * Shared page container — optional title + intro (each only renders when
  * provided), plus the AT URI <head> hints for the route's backing record.
+ *
+ * `selectable` marks a route that hosts its own owner edit-mode UI: feed-row
+ * selection (the home / posting / logging / listening feeds) or guestbook
+ * moderation. Those keep the pencil's "tap items to select" flow; every other
+ * page has nothing to select, so the pencil opens its record editor directly
+ * (see ChromeBar). Defaults to false — set it on new feed-style pages.
  */
-export default function PageShell({ title, intro, atUri, cid, children, headTitle }) {
+export default function PageShell({
+  title,
+  intro,
+  atUri,
+  cid,
+  children,
+  headTitle,
+  selectable = false,
+}) {
   // Publish the route's backing record to edit mode so the owner's quick-edit
   // sheet can target "this page" (a blog post, the home page record, etc.).
-  const { registerPageRecord } = useEditMode();
+  const { registerPageRecord, registerSelectionPage } = useEditMode();
   useEffect(() => {
     registerPageRecord(atUri ? { atUri, cid } : null);
   }, [atUri, cid, registerPageRecord]);
+  useEffect(() => {
+    registerSelectionPage(selectable);
+  }, [selectable, registerSelectionPage]);
 
   return (
     <article className="page">

--- a/src/hooks/useEditMode.jsx
+++ b/src/hooks/useEditMode.jsx
@@ -41,6 +41,12 @@ export function EditModeProvider({ children }) {
   // with the path it was registered on so a stale value from a mid-transition
   // page never leaks onto the next route. Used by the quick-edit sheet.
   const [pageRecord, setPageRecord] = useState(null);
+  // Whether the current page hosts its own edit-mode UI — feed-row selection
+  // (home / posting / logging / listening) or guestbook moderation. Declared
+  // by PageShell's `selectable` prop. The owner's edit pencil reads this: on a
+  // page WITHOUT its own selection, tapping the pencil jumps straight to the
+  // page's record editor instead of an empty select bar (see ChromeBar).
+  const [selectionPage, setSelectionPage] = useState(false);
   // The record currently open in the quick-edit sheet: { atUri } or null.
   const [editSheet, setEditSheet] = useState(null);
   // A controller published by the open sheet's RecordEditor so the edit
@@ -88,6 +94,14 @@ export function EditModeProvider({ children }) {
   pathRef.current = location.pathname;
   const registerPageRecord = useCallback((rec) => {
     setPageRecord(rec && rec.atUri ? { ...rec, path: pathRef.current } : null);
+  }, []);
+
+  // PageShell reports whether its route carries its own selection / moderation
+  // UI. Each page re-declares this on mount, so the last page to mount wins and
+  // a stale value can't linger — no route-change reset needed (and a page that
+  // registers no record leaves the pencil in plain select mode regardless).
+  const registerSelectionPage = useCallback((on) => {
+    setSelectionPage((prev) => (prev === !!on ? prev : !!on));
   }, []);
 
   // A selection from one page shouldn't linger onto the next. Clearing on
@@ -174,6 +188,8 @@ export function EditModeProvider({ children }) {
       markRemoved,
       pageRecord,
       registerPageRecord,
+      selectionPage,
+      registerSelectionPage,
       editSheet,
       openEditSheet,
       closeEditSheet,
@@ -197,6 +213,8 @@ export function EditModeProvider({ children }) {
       markRemoved,
       pageRecord,
       registerPageRecord,
+      selectionPage,
+      registerSelectionPage,
       editSheet,
       openEditSheet,
       closeEditSheet,

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -122,6 +122,7 @@ export default function Guestbook() {
       intro={intro}
       atUri={GUESTBOOK_SUBJECT}
       headTitle="dame.is hosting a guestbook"
+      selectable
     >
       {session ? (
         <SignForm agent={agent} did={did} profile={myProfile} onSigned={handleSigned} />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -550,6 +550,7 @@ export default function Home() {
     <PageShell
       title={<HeroSentence shuffleRef={shuffleRef} />}
       headTitle="dame.is"
+      selectable
     >
       <nav className="home-hero-cta" aria-label="Primary destinations">
         <Link className="home-hero-cta-btn home-hero-cta-primary" to="/available">

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -85,6 +85,7 @@ export default function Listening() {
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/listening`}
       headTitle="dame.is listening"
+      selectable
     >
       {!loading && statsItems.length > 0 && <ListeningStats items={statsItems} />}
       {loading ? (

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -54,6 +54,7 @@ export default function Logging() {
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/logging`}
       headTitle="dame.is logging"
+      selectable
     >
       {loading ? (
         <FeedSkeleton rows={5} label="Loading status updates" />

--- a/src/pages/Posting.jsx
+++ b/src/pages/Posting.jsx
@@ -61,6 +61,7 @@ export default function Posting() {
       intro={intro}
       atUri={`at://${ME_DID}/is.dame.page/posting`}
       headTitle="dame.is posting"
+      selectable
     >
       <PostingFilters counts={counts} />
       {loading ? (


### PR DESCRIPTION
On a page that hosts no owner selection of its own — the content and record pages (about, blogging, creating, curating, mothing, available, sharing, and the per-record detail pages) — tapping the edit pencil now jumps straight into that page's record editor, instead of dropping into an empty "tap items to select" bar and making the owner hunt for the "Edit page" button.

## How it works

`PageShell` gains a `selectable` prop that marks the routes which **do** host their own edit-mode UI:

- **feed-row selection** — home / posting / logging / listening
- **guestbook moderation** — hide/unhide entries

Those routes keep the existing select-mode flow (and the "Edit page" button in the action bar). Every other page, having nothing to select, gets the one-tap shortcut. The flag is registered into `useEditMode`, and `ChromeBar`'s pencil handler reads it:

- has its own editable record **and** nothing to select → open that record's page editor immediately
- hosts selection / moderation → enter select mode (unchanged)
- a pencil-opened editor is showing → the pencil closes it

An explicit prop is used rather than a DOM heuristic because `FlatLedger` (creating / blogging / curating) renders `.feed-item` rows that aren't actually selectable, so a class check would misclassify those pages.

## Note on the guestbook

Guestbook moderation is triggered by this same pencil and has no other entry point, so it's marked `selectable` (keeps moderation) rather than routed to the page editor — otherwise moderation would become unreachable. Its "Edit page" button still edits the page record.

## Verification

- Offline production build compiles cleanly.
- Headless render smoke-test across a feed page and five content pages: zero console/page errors. (The owner-only pencil flow needs an authenticated owner session, so that path was verified by tracing every route type through the final logic.)

Files: `useEditMode.jsx`, `PageShell.jsx`, `ChromeBar.jsx`, and the five selection pages (Home, Posting, Logging, Listening, Guestbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Dxrx3HC7rahrhqPDRp3Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dxrx3HC7rahrhqPDRp3Ry)_