### PR TITLE
Atmosphere x-ray — reveal the AT Protocol records under the page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ const Exploring = lazy(() => import('./pages/Exploring.jsx'));
 import ChromeBar from './components/ChromeBar.jsx';
 import AutoUpdater from './components/AutoUpdater.jsx';
 import ActionDock from './components/ActionDock.jsx';
+import XrayLayer from './components/XrayLayer.jsx';
 import EditModeBar from './components/EditModeBar.jsx';
 import EditSheet from './components/EditSheet.jsx';
 import RouteTransition from './components/RouteTransition.jsx';
@@ -43,6 +44,8 @@ import { AtprotoSessionProvider } from './hooks/useAtprotoSession.jsx';
 import { WaypointsModalProvider } from './hooks/useWaypointsModal.jsx';
 import { FeedFooterProvider } from './hooks/useFeedFooter.jsx';
 import { EditModeProvider } from './hooks/useEditMode.jsx';
+import { XrayProvider } from './hooks/useXray.jsx';
+import './components/Xray.css';
 
 /**
  * Verbs whose record page is handled by a bespoke page component (not the
@@ -103,6 +106,7 @@ export default function App() {
       <ChromePanelProvider>
       <WaypointsModalProvider>
       <EditModeProvider>
+      <XrayProvider>
       <FeedFooterProvider>
           <div className="app-shell">
             <ChromeBar />
@@ -163,12 +167,14 @@ export default function App() {
               </div>
             </main>
             <ActionDock />
+            <XrayLayer />
             <EditModeBar />
             <EditSheet />
             <AutoUpdater />
             <Analytics />
           </div>
       </FeedFooterProvider>
+      </XrayProvider>
       </EditModeProvider>
       </WaypointsModalProvider>
       </ChromePanelProvider>

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Search, Type, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Pencil, Printer, Scan, Search, Type, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { skyAvatarUrl } from '../lib/skyAvatars.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
+import { useXray } from '../hooks/useXray.jsx';
 import { useFeedFilter } from '../hooks/useFeedFilter.jsx';
 import { useChromePanel } from '../hooks/useChromePanel.jsx';
 import { useTheme } from '../hooks/useTheme.jsx';
@@ -372,6 +373,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
     openEditSheet,
     closeEditSheet,
   } = useEditMode();
+  const { active: xrayActive, toggle: toggleXray, exit: exitXray } = useXray();
   const isOwner = did === ME_DID;
   // The owner's edit record for THIS page, if any — guarded on the stamped path
   // so a stale value can't leak across a route change, and on the owner's repo
@@ -587,6 +589,24 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 >
                   <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
+                {/* Atmosphere x-ray — the marquee "turn the page inside out"
+                    mode. Toggling it reveals the AT Protocol records beneath
+                    the page; entering it folds away any open panel and the
+                    owner's edit mode (they compete for the same surface). */}
+                <button
+                  type="button"
+                  className={`chrome-nav chrome-xray ${xrayActive ? 'is-open' : ''}`}
+                  onClick={() => {
+                    closePanel();
+                    if (editActive) exitEdit();
+                    toggleXray();
+                  }}
+                  aria-pressed={xrayActive}
+                  aria-label={xrayActive ? 'Exit x-ray' : 'X-ray this page'}
+                  title="Atmosphere x-ray — reveal the records under the page"
+                >
+                  <Scan className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+                </button>
                 {onResumePage && (
                   <button
                     type="button"
@@ -604,8 +624,12 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                     className={`chrome-nav chrome-edit-btn ${chromeEditOpen ? 'is-open' : ''}`}
                     onClick={() => {
                       // Entering/leaving edit mode owns the bottom chrome —
-                      // fold any open search/filter/info panel away first.
+                      // fold any open search/filter/info panel away first, and
+                      // leave x-ray (the two modes compete for the same rows).
                       closePanel();
+                      // Edit mode and x-ray compete for the same rows — leave
+                      // x-ray before entering any edit flow.
+                      if (xrayActive) exitXray();
                       if (editActive) {
                         // In select / moderation mode → leave it.
                         toggleEdit();

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Check, CornerDownRight } from 'lucide-react';
 import { useEditMode } from '../hooks/useEditMode.jsx';
+import { useXray } from '../hooks/useXray.jsx';
+import { XrayTag, XraySubstratePanel } from './XraySubstrate.jsx';
 import StatusEntry from './StatusEntry.jsx';
 import PostCard, { postCardShowsStandaloneTime } from './PostCard.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
@@ -101,6 +103,7 @@ function hrefFor(item) {
 export default function FeedItem({ item, showVerb = true, layout = 'cards', onOpenLightbox = null }) {
   const navigate = useNavigate();
   const edit = useEditMode();
+  const xray = useXray();
   // Ledger-only: whether a collapsed listening session is showing its
   // full track list (see handleRowClick / FeedLedgerRow).
   const [ledgerExpanded, setLedgerExpanded] = useState(false);
@@ -122,6 +125,22 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards', onOp
   const listeningEdit = edit.active && item.verb === 'listening';
   const selectable = edit.active && !!item.atUri && !listeningEdit;
   const selected = selectable && edit.isSelected(item.atUri);
+
+  // Atmosphere x-ray: while the mode is on, a record-backed row is inspectable.
+  // A tap anywhere on it (outside its own links) drills into the substrate
+  // rather than navigating, and toggling it off returns to the manifest.
+  const xrayActive = xray.active && !!item.atUri;
+  const xrayFocused = xrayActive && xray.focusUri === item.atUri;
+
+  function handleXrayClick(e) {
+    if (e.defaultPrevented) return;
+    if (e.button !== undefined && e.button !== 0) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (e.target.closest('a, button, input, textarea, label, select, [role="button"], [role="link"]')) return;
+    const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+    if (sel && sel.toString().length > 0) return;
+    xray.toggleFocus(item.atUri);
+  }
 
   function handleSelectCapture(e) {
     if (!selectable) return;
@@ -231,6 +250,7 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards', onOp
     threadContinuation ? 'feed-item-thread-continuation' : '',
     selectable ? 'feed-item-selectable' : '',
     selected ? 'is-selected' : '',
+    xrayFocused ? 'is-xray-focus' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -239,13 +259,18 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards', onOp
       className={liClassName}
       data-verb={item.verb}
       data-nsid={nsidFromAtUri(item.atUri) || undefined}
+      data-atproto={item.atUri ? '' : undefined}
+      data-at-uri={item.atUri || undefined}
+      data-cid={item.cid || undefined}
       data-thread-position={item._thread?.position}
       data-thread-length={item._thread?.length}
       onClickCapture={selectable ? handleSelectCapture : undefined}
       onClick={
-        !selectable && !listeningEdit && (href || ledgerListenBatch || canLightbox)
-          ? handleRowClick
-          : undefined
+        xrayActive
+          ? handleXrayClick
+          : !selectable && !listeningEdit && (href || ledgerListenBatch || canLightbox)
+            ? handleRowClick
+            : undefined
       }
       role={selectable ? 'button' : undefined}
       aria-pressed={selectable ? selected : undefined}
@@ -299,6 +324,15 @@ export default function FeedItem({ item, showVerb = true, layout = 'cards', onOp
           verb={item.verb}
           suppressReplyBadge={showVerb ? isReplyVerb || threadContinuation : threadContinuation}
         />
+      )}
+      {/* X-ray: cards wear a calm substrate tag; the ledger has its own
+          in-grid data line (see FeedLedgerRow). Focusing either opens the
+          full substrate panel below the row. */}
+      {!ledger && xrayActive && (
+        <XrayTag atUri={item.atUri} onOpen={() => xray.focus(item.atUri)} />
+      )}
+      {xrayFocused && (
+        <XraySubstratePanel atUri={item.atUri} cid={item.cid} value={item.payload} />
       )}
     </li>
   );

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { formatTime, formatWallClockTime } from '../lib/time.js';
+import { atUriParts, shortenCid } from '../lib/xray.js';
 import { renderPostText } from '../lib/postRichText.jsx';
 import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
@@ -98,6 +99,11 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
         )}
       </div>
       <span className="ledger-time">{timeText}</span>
+      {/* X-ray manifest line: the same three columns re-expressed as the
+          record's address (collection highlighted) + content hash. Absolutely
+          positioned over the row so it stays one line and column-aligned;
+          revealed by the data-xray root attribute (see Xray.css). */}
+      {item.atUri && <LedgerXrayLine atUri={item.atUri} cid={item.cid} />}
       {expanded && isListenBatch(item) && item.plays.map((play) => {
         const playTs = play?.createdAt || play?.payload?.playedTime || null;
         const playHref = recordPathFromAtUri(play?.atUri);
@@ -117,6 +123,28 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
         );
       })}
     </>
+  );
+}
+
+/**
+ * The x-ray manifest line for a ledger row: `at://…/<nsid>/<rkey>` (the
+ * collection highlighted inside the address) on the left two columns, the
+ * short content hash on the right — overlaid on the row's own grid so it
+ * stays a single aligned line. Hidden until the data-xray root attribute is
+ * set; see Xray.css.
+ */
+function LedgerXrayLine({ atUri, cid }) {
+  const parts = atUriParts(atUri);
+  if (!parts) return null;
+  return (
+    <div className="ledger-xray" aria-hidden="true">
+      <span className="bp-uri ledger-xray-uri">
+        <span className="did">{parts.prefix}</span>
+        <span className="nsid">{parts.nsid}</span>
+        <span className="rkey">{parts.rkey}</span>
+      </span>
+      {cid && <span className="ledger-xray-cid">{shortenCid(cid)}</span>}
+    </div>
   );
 }
 

--- a/src/components/Xray.css
+++ b/src/components/Xray.css
@@ -1,0 +1,310 @@
+/* ======================================================================
+   Atmosphere X-ray — the reveal layer.
+
+   Most of the reveal is CSS-driven off <html data-xray="on"> (and
+   data-xray-focus) so it stays cheap across a long feed, mirroring how
+   the site already drives data-theme / data-font. The "blueprint" ink is
+   derived from the live theme accent, so the whole treatment adapts to
+   light, dark, and the hourly sky palette for free.
+   ====================================================================== */
+
+:root {
+  --xr-ease: cubic-bezier(0.32, 0.72, 0, 1);
+  --xr-ink: var(--accent);
+  --xr-field: var(--highlight);
+  --xr-frame: color-mix(in srgb, var(--accent) 52%, transparent);
+  --xr-glow: color-mix(in srgb, var(--accent) 30%, transparent);
+  --xr-dim: 0.08;         /* how far revealed content recedes behind its data */
+}
+
+/* Affordance: on a fine pointer, record-backed elements read as inspectable
+   while the mode is armed. Touch keeps the native caret. */
+@media (pointer: fine) {
+  :root[data-xray="on"] [data-atproto] { cursor: crosshair; }
+}
+
+/* ----------------------------------------------------------------------
+   Shared blueprint atoms
+   ---------------------------------------------------------------------- */
+.bp-uri { font-family: var(--code); color: var(--ink-soft); }
+.bp-uri .did { color: var(--ink-faint); }
+.bp-uri .nsid { color: var(--xr-ink); }
+.bp-uri .rkey { color: var(--ink-soft); }
+.bp-cid { font-family: var(--code); color: var(--ink-muted); }
+
+/* ----------------------------------------------------------------------
+   A · FEED (ledger) — a records manifest.
+   The row keeps its exact grid; a single-line data layer is absolutely
+   positioned over the same tracks and crossfades in, so columns stay
+   aligned and nothing can overflow the row.
+   ---------------------------------------------------------------------- */
+.feed-ledger .feed-item-ledger { position: relative; }
+
+.ledger-xray {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  /* Its own two tracks (address · hash) rather than the row's three, so the
+     content hash gets room to read instead of clipping in the narrow time
+     column. */
+  grid-template-columns: minmax(0, 1fr) max-content;
+  column-gap: var(--space-4);
+  align-items: baseline;
+  padding: var(--space-3) 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s var(--xr-ease);
+}
+.ledger-xray-uri {
+  grid-column: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--code);
+  font-size: calc(var(--text-xs) * 0.95);
+}
+.ledger-xray-cid {
+  grid-column: 2;
+  text-align: right;
+  font-family: var(--code);
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+  white-space: nowrap;
+}
+
+/* Mobile: the shared DID prefix eats the line and clips the identifying tail,
+   so drop it (lead with the collection) and hide the hash — the nsid + rkey
+   is what tells rows apart. */
+@media (max-width: 600px) {
+  .ledger-xray .bp-uri .did { display: none; }
+  .ledger-xray-cid { display: none; }
+}
+
+:root[data-xray="on"] .feed-item-ledger > .ledger-verb,
+:root[data-xray="on"] .feed-item-ledger > .ledger-body,
+:root[data-xray="on"] .feed-item-ledger > .ledger-time {
+  opacity: var(--xr-dim);
+  transition: opacity 0.28s var(--xr-ease);
+}
+:root[data-xray="on"] .feed-item-ledger .ledger-xray { opacity: 1; pointer-events: auto; }
+:root[data-xray="on"] .feed-item-ledger .ledger-xray .ledger-xray-uri { cursor: pointer; }
+.ledger-xray-uri:hover .nsid { text-decoration: underline; }
+
+/* A focused ledger row drops its full substrate panel below, spanning the
+   row's whole grid rather than landing in a single column. */
+.feed-item-ledger > .xray-substrate { grid-column: 1 / -1; }
+
+/* ----------------------------------------------------------------------
+   B · CARDS — every card wears a calm substrate tag; focusing one opens
+   the full panel and recedes the rest.
+   ---------------------------------------------------------------------- */
+.xray-tag {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+  flex-wrap: wrap;
+  font-family: var(--code);
+  font-size: calc(var(--text-xs) * 0.95);
+  color: var(--ink-muted);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  margin-top: 0;
+  transition: max-height 0.3s var(--xr-ease), opacity 0.25s var(--xr-ease), margin-top 0.3s var(--xr-ease);
+}
+.xray-tag .bp-uri { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.xray-tag-open { color: var(--xr-ink); background: none; border: 0; padding: 0; font: inherit; cursor: pointer; white-space: nowrap; }
+.xray-tag-open:hover { text-decoration: underline; }
+
+:root[data-xray="on"] .feed-item:not(.feed-item-ledger) .xray-tag {
+  max-height: 4rem;
+  opacity: 1;
+  margin-top: var(--space-2);
+}
+
+/* Recede everything that isn't the focused record. Scoped to leaf record
+   elements (never page containers) so a focused child never dims its own
+   surroundings into itself. */
+:root[data-xray-focus="on"] [data-atproto]:not(.is-xray-focus) {
+  opacity: 0.24;
+  filter: grayscale(0.85) blur(1.1px);
+  transition: opacity 0.34s var(--xr-ease), filter 0.34s var(--xr-ease);
+}
+:root[data-xray-focus="on"] [data-atproto].is-xray-focus {
+  transition: opacity 0.34s var(--xr-ease);
+}
+
+/* ----------------------------------------------------------------------
+   Substrate panel — the full readout for a focused element (cards, and
+   the resume/record inspectors). Rendered in flow beneath its element.
+   ---------------------------------------------------------------------- */
+.xray-substrate {
+  border: 1px solid var(--xr-frame);
+  background: var(--xr-field);
+  padding: var(--space-3);
+  margin-top: var(--space-3);
+  display: grid;
+  gap: var(--space-3);
+  font-family: var(--code);
+}
+@media (min-width: 720px) {
+  .xray-substrate { grid-template-columns: 1fr 1fr; align-items: start; }
+  .xray-substrate-wide { grid-column: 1 / -1; }
+}
+.xray-substrate-h {
+  font-size: 0.64rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+}
+.xray-uri-line { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-3); align-items: baseline; }
+.xray-uri-line .bp-uri { word-break: break-all; font-size: var(--text-xs); }
+
+.xray-fields { list-style: none; margin: 0; padding: 0; display: grid; gap: 5px; }
+.xray-fields li { display: grid; grid-template-columns: 16px 1fr; gap: var(--space-2); align-items: start; font-size: var(--text-xs); }
+.xray-fields .num { width: 16px; height: 16px; display: grid; place-items: center; background: var(--xr-ink); color: var(--page); font-size: 0.58rem; }
+.xray-fields .p { color: var(--xr-ink); }
+.xray-fields .v { color: var(--ink-muted); display: block; word-break: break-word; }
+
+.xray-meta { font-size: var(--text-xs); color: var(--ink-soft); }
+.xray-meta div { display: flex; gap: var(--space-2); padding: 1px 0; }
+.xray-meta dt { color: var(--ink-faint); min-width: 68px; flex: none; }
+.xray-meta dd { margin: 0; word-break: break-all; }
+
+.xray-depth { font-size: 0.72rem; color: var(--ink-soft); }
+.xray-depth .lvl { display: block; white-space: pre; line-height: 1.6; }
+.xray-depth .lead { color: var(--xr-frame); }
+.xray-depth .k { color: var(--xr-ink); }
+.xray-depth .v { color: var(--ink-muted); }
+.xray-depth .lvl.top .k { color: var(--ink); }
+
+.xray-actions { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-top: var(--space-1); }
+.xray-actions a, .xray-actions button {
+  font-family: var(--code); font-size: 0.68rem; letter-spacing: 0.04em;
+  color: var(--ink-soft); background: var(--page); border: 1px solid var(--rule);
+  padding: 3px var(--space-2); text-decoration: none; cursor: pointer;
+}
+.xray-actions a:hover, .xray-actions button:hover { color: var(--accent); border-color: var(--accent-soft); }
+
+/* ----------------------------------------------------------------------
+   A · DOCUMENT (resume) — backlinked composition. Each role/education
+   entry is its own is.dame.resume.job/.education record that the resume
+   version backlinks; x-ray keeps the structure, recedes the prose, and
+   reveals the record behind each part — inline on mobile, a right gutter
+   on desktop.
+   ---------------------------------------------------------------------- */
+.resume-xray { position: relative; }
+.resume-xray-content { transition: opacity 0.3s var(--xr-ease); }
+:root[data-xray="on"] .resume-xray-content { opacity: 0.5; }
+:root[data-xray="on"] .resume-xray.is-page .resume-xray-content { opacity: 0.66; }
+
+.resume-xray-tag {
+  font-family: var(--code);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.32s var(--xr-ease), opacity 0.28s var(--xr-ease), margin-top 0.32s var(--xr-ease);
+}
+.resume-xray-tag .nsid { color: var(--xr-ink); display: block; font-size: 0.68rem; }
+.resume-xray-tag .uri { color: var(--ink-muted); font-size: 0.66rem; word-break: break-all; }
+.resume-xray-tag .note { color: var(--ink-faint); display: block; font-size: 0.63rem; margin-top: 2px; }
+:root[data-xray="on"] .resume-xray-tag {
+  max-height: 7rem;
+  opacity: 1;
+  margin-top: var(--space-2);
+  padding-left: var(--space-3);
+  border-left: 1px dashed var(--xr-frame);
+}
+
+/* Desktop: float the record into a right-margin gutter so the reveal reads
+   as data sliding out beside the document, not stacked under it. */
+@media (min-width: 860px) {
+  :root[data-xray="on"] .resume-xray {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 15rem;
+    column-gap: var(--space-5);
+    align-items: start;
+  }
+  :root[data-xray="on"] .resume-xray-tag {
+    max-height: none;
+    margin-top: 0;
+    padding-left: var(--space-4);
+  }
+}
+
+/* ----------------------------------------------------------------------
+   Page HUD — a status strip that names the record backing the whole page,
+   riding just above the bottom chrome. Rendered by XrayLayer with motion.
+   ---------------------------------------------------------------------- */
+.xray-hud {
+  position: fixed;
+  left: 0; right: 0;
+  bottom: var(--chrome-h, 56px);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-2) var(--space-4);
+  background: var(--surface-deep);
+  border-top: 1px solid var(--xr-frame);
+  border-bottom: 1px solid var(--rule);
+  box-shadow: 0 -10px 26px -22px var(--shadow);
+  font-family: var(--code);
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+}
+.xray-hud-mark { display: inline-flex; align-items: center; gap: var(--space-2); color: var(--accent); letter-spacing: 0.1em; text-transform: uppercase; font-size: 0.64rem; }
+.xray-hud-mark svg { width: 13px; height: 13px; }
+.xray-hud-field { display: inline-flex; align-items: baseline; gap: var(--space-2); min-width: 0; }
+.xray-hud-field b { color: var(--ink-faint); font-weight: 400; }
+.xray-hud .bp-uri { display: inline-block; min-width: 0; max-width: min(46ch, 60vw); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; }
+.xray-hud-uri-link { text-decoration: none; }
+.xray-hud-uri-link:hover .nsid { text-decoration: underline; }
+.xray-hud-spacer { flex: 1 1 auto; }
+.xray-hud-inspect {
+  font-family: var(--code); font-size: 0.66rem; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--ink-soft); background: transparent; border: 1px solid var(--rule); padding: 3px var(--space-2); cursor: pointer;
+}
+.xray-hud-inspect:hover { color: var(--accent); border-color: var(--accent-soft); }
+@media (max-width: 560px) {
+  .xray-hud-field.is-optional { display: none; }
+  .xray-hud .bp-uri { max-width: 62vw; }
+}
+
+/* ----------------------------------------------------------------------
+   Desktop reticule — a corner-tick target that locks onto record-backed
+   elements. Rendered by XrayReticule (motion drives position/size/rotate).
+   ---------------------------------------------------------------------- */
+.xray-reticule { position: fixed; top: 0; left: 0; z-index: 55; pointer-events: none; will-change: transform; }
+.xray-reticule-box { position: absolute; inset: 0; }
+.xray-reticule-corner { position: absolute; width: 10px; height: 10px; border: 1.5px solid var(--accent); filter: drop-shadow(0 0 3px var(--xr-glow)); }
+.xray-reticule-corner.tl { top: 0; left: 0; border-right: 0; border-bottom: 0; }
+.xray-reticule-corner.tr { top: 0; right: 0; border-left: 0; border-bottom: 0; }
+.xray-reticule-corner.bl { bottom: 0; left: 0; border-right: 0; border-top: 0; }
+.xray-reticule-corner.br { bottom: 0; right: 0; border-left: 0; border-top: 0; }
+.xray-reticule-dot { position: absolute; top: 50%; left: 50%; width: 5px; height: 5px; margin: -2.5px 0 0 -2.5px; background: var(--accent); }
+.xray-reticule.is-locked .xray-reticule-dot { opacity: 0; }
+.xray-reticule-label {
+  position: absolute; left: 0; top: -18px; font-family: var(--code); font-size: 0.6rem;
+  letter-spacing: 0.04em; color: var(--page); background: var(--accent); padding: 0 5px; white-space: nowrap;
+  opacity: 0; transition: opacity 0.18s var(--xr-ease);
+}
+.xray-reticule.is-locked .xray-reticule-label { opacity: 1; }
+
+/* Toggle button (chrome) active pulse when armed. */
+.chrome-xray.is-open .chrome-nav-glyph { animation: xray-pulse 2.4s ease-in-out infinite; }
+@keyframes xray-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+
+/* ----------------------------------------------------------------------
+   Reduced motion — keep the reveal, drop the travel.
+   ---------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ledger-xray, .xray-tag, .rz-block, .rz-block-content, .rz-gutter,
+  :root[data-xray-focus="on"] [data-atproto]:not(.is-xray-focus) {
+    transition-duration: 0.14s !important;
+  }
+  .chrome-xray.is-open .chrome-nav-glyph { animation: none; }
+}

--- a/src/components/XrayLayer.jsx
+++ b/src/components/XrayLayer.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { Scan } from 'lucide-react';
+import { useXray } from '../hooks/useXray.jsx';
+import { useAtUri } from '../hooks/useAtUri.js';
+import { useActionDock } from '../hooks/useActionDock.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
+import { useEditMode } from '../hooks/useEditMode.jsx';
+import { explorerPathFromAtUri } from '../lib/atproto.js';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
+import { AtUriMono } from './XraySubstrate.jsx';
+import XrayReticule from './XrayReticule.jsx';
+
+/**
+ * Global x-ray furniture, portaled to <body> so no transformed route
+ * ancestor traps its fixed positioning:
+ *   - the page HUD (a status strip naming the record backing the whole page)
+ *   - the desktop reticule cursor (gated to fine pointers + wider viewports)
+ *
+ * Both only exist while the mode is on. The HUD is split into its own
+ * component so useAtUri's PDS/record work never runs when x-ray is off.
+ */
+export default function XrayLayer() {
+  const { active } = useXray();
+  const { open: dockOpen } = useActionDock();
+  const { panel } = useChromePanel();
+  const canReticule = useFinePointer();
+
+  // The HUD + reticule share the bottom edge with the nav dock and the
+  // search/filter/info panels. When one of those opens, yield the space (hide
+  // the furniture) rather than exiting the mode — closing them brings it back.
+  const suppressed = dockOpen || Boolean(panel);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <>
+      <AnimatePresence>{active && !suppressed && <XrayHud key="xray-hud" />}</AnimatePresence>
+      {active && !suppressed && canReticule && <XrayReticule />}
+    </>,
+    document.body,
+  );
+}
+
+function XrayHud() {
+  const reduce = useReducedMotion();
+  const derived = useAtUri();
+  const { pageRecord } = useEditMode();
+  const { openDock, setView } = useActionDock();
+
+  // Prefer the route-derived record; else fall back to whatever backing record
+  // the current page registered through PageShell (e.g. the resume version at
+  // /available, which useAtUri doesn't derive on its own).
+  const route = derived.route;
+  const fallback = !derived.atUri && pageRecord?.path === route ? pageRecord : null;
+  const atUri = derived.atUri || fallback?.atUri || null;
+  const lexicon = derived.lexicon || (atUri ? nsidFromAtUri(atUri) : null);
+  const pds = derived.pds;
+  const explorerPath = atUri ? explorerPathFromAtUri(atUri) : null;
+
+  function inspect() {
+    setView('debug');
+    openDock();
+  }
+
+  return (
+    <motion.div
+      className="xray-hud"
+      role="status"
+      aria-live="polite"
+      initial={reduce ? { opacity: 0 } : { y: '100%', opacity: 0 }}
+      animate={reduce ? { opacity: 1 } : { y: '0%', opacity: 1 }}
+      exit={reduce ? { opacity: 0 } : { y: '100%', opacity: 0 }}
+      transition={{ duration: reduce ? 0.12 : 0.32, ease: [0.32, 0.72, 0, 1] }}
+    >
+      <span className="xray-hud-mark">
+        <Scan aria-hidden="true" strokeWidth={1.75} /> x-ray
+      </span>
+      <span className="xray-hud-field">
+        <b>route</b> {route || '/'}
+      </span>
+      {atUri ? (
+        <span className="xray-hud-field">
+          <b>record</b>{' '}
+          {explorerPath ? (
+            <Link to={explorerPath} className="xray-hud-uri-link">
+              <AtUriMono atUri={atUri} />
+            </Link>
+          ) : (
+            <AtUriMono atUri={atUri} />
+          )}
+        </span>
+      ) : (
+        <span className="xray-hud-field">
+          <b>view</b> aggregate — this page is a join over many records
+        </span>
+      )}
+      {lexicon && (
+        <span className="xray-hud-field is-optional">
+          <b>lexicon</b> {lexicon}
+        </span>
+      )}
+      {pds && (
+        <span className="xray-hud-field is-optional">
+          <b>pds</b> {String(pds).replace(/^https?:\/\//, '')}
+        </span>
+      )}
+      <span className="xray-hud-spacer" />
+      <button type="button" className="xray-hud-inspect" onClick={inspect}>
+        inspect ↗
+      </button>
+    </motion.div>
+  );
+}
+
+/** True on devices with a fine pointer and enough width for the reticule to
+ *  make sense. Re-evaluated on resize so a window narrowing drops it. */
+function useFinePointer() {
+  const [ok, setOk] = useState(false);
+  useEffect(() => {
+    const check = () => {
+      const fine = typeof window.matchMedia === 'function' && window.matchMedia('(pointer: fine)').matches;
+      setOk(fine && window.innerWidth >= 900);
+    };
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+  return ok;
+}

--- a/src/components/XrayReticule.jsx
+++ b/src/components/XrayReticule.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react';
+import { animate, motion, useMotionValue, useReducedMotion } from 'motion/react';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
+
+/**
+ * Our own take on a magnetic reticule cursor (no motion-plus dependency —
+ * just the `motion` primitives already in the bundle). While x-ray is armed
+ * on a desktop / fine-pointer device, a corner-tick target follows the
+ * cursor and springs to lock onto whatever record-backed element ([data-
+ * atproto]) is under it, labelling it with the collection. With no target it
+ * shrinks to a small idly-rotating diamond.
+ *
+ * Mounted (and gated to fine pointers + wider viewports) by XrayLayer, so it
+ * only ever runs where it makes sense.
+ */
+export default function XrayReticule() {
+  const reduce = useReducedMotion();
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const w = useMotionValue(24);
+  const h = useMotionValue(24);
+  const rotate = useMotionValue(0);
+  const [locked, setLocked] = useState(false);
+  const [label, setLabel] = useState('');
+
+  const spinRef = useRef(null);
+  const lockedRef = useRef(false);
+  const rafRef = useRef(0);
+  const pending = useRef(null);
+
+  // Keep the collection label upright while the frame rotates: mirror the
+  // frame's rotation back off so it reads level even as the reticule settles.
+  const counterRotate = useMotionValue(0);
+  useEffect(() => rotate.on('change', (v) => counterRotate.set(-v)), [rotate, counterRotate]);
+
+  useEffect(() => {
+    // Idle spin management — an endless slow rotation while we have no target.
+    function startSpin() {
+      if (reduce || spinRef.current) return;
+      spinRef.current = animate(rotate, rotate.get() + 360, {
+        duration: 3,
+        ease: 'linear',
+        repeat: Infinity,
+      });
+    }
+    function stopSpin() {
+      if (spinRef.current) {
+        spinRef.current.stop();
+        spinRef.current = null;
+      }
+    }
+
+    const springify = (mv, to) =>
+      animate(mv, to, reduce ? { duration: 0.12 } : { type: 'spring', bounce: 0.28, duration: 0.5 });
+
+    function apply(e) {
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      const target = el && el.closest ? el.closest('[data-atproto]') : null;
+
+      if (target) {
+        const r = target.getBoundingClientRect();
+        const pad = 6;
+        springify(x, r.left - pad);
+        springify(y, r.top - pad);
+        springify(w, r.width + pad * 2);
+        springify(h, r.height + pad * 2);
+        stopSpin();
+        // Settle to the nearest FULL turn (a multiple of 360, not 180) so the
+        // frame always lands upright — keeps the collection label the right way
+        // up in its top-left corner instead of flipping to the far side.
+        animate(rotate, Math.round(rotate.get() / 360) * 360, { type: 'spring', bounce: 0.3 });
+        if (!lockedRef.current) {
+          lockedRef.current = true;
+          setLocked(true);
+        }
+        const uri = target.getAttribute('data-at-uri');
+        const nsid = uri ? nsidFromAtUri(uri) : target.getAttribute('data-nsid');
+        setLabel(nsid || '');
+      } else {
+        // No target — a small diamond centred on the pointer, idly spinning.
+        const size = 24;
+        springify(x, e.clientX - size / 2);
+        springify(y, e.clientY - size / 2);
+        springify(w, size);
+        springify(h, size);
+        startSpin();
+        if (lockedRef.current) {
+          lockedRef.current = false;
+          setLocked(false);
+          setLabel('');
+        }
+      }
+    }
+
+    function onMove(e) {
+      pending.current = e;
+      if (rafRef.current) return;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = 0;
+        if (pending.current) apply(pending.current);
+      });
+    }
+
+    // Seed at the current center so it doesn't fly in from the corner.
+    x.set(window.innerWidth / 2 - 12);
+    y.set(window.innerHeight / 2 - 12);
+    startSpin();
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      stopSpin();
+    };
+  }, [reduce, x, y, w, h, rotate]);
+
+  return (
+    <motion.div
+      className={`xray-reticule${locked ? ' is-locked' : ''}`}
+      style={{ x, y, width: w, height: h, rotate }}
+      aria-hidden="true"
+    >
+      <div className="xray-reticule-box">
+        <span className="xray-reticule-corner tl" />
+        <span className="xray-reticule-corner tr" />
+        <span className="xray-reticule-corner bl" />
+        <span className="xray-reticule-corner br" />
+        <span className="xray-reticule-dot" />
+      </div>
+      {label && (
+        <motion.span className="xray-reticule-label" style={{ rotate: counterRotate }}>
+          {label}
+        </motion.span>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/XraySubstrate.jsx
+++ b/src/components/XraySubstrate.jsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ME_DID, ME_HANDLE } from '../config.js';
+import { resolvePds, explorerPathFromAtUri } from '../lib/atproto.js';
+import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import {
+  atUriParts,
+  parseAtUri,
+  shortenCid,
+  substrateFields,
+  depthStack,
+} from '../lib/xray.js';
+
+/**
+ * The one-line "there's a record under here" tag a card wears while x-ray is
+ * armed: the record's address (collection highlighted) plus an inspect
+ * affordance that drills into the full substrate.
+ */
+export function XrayTag({ atUri, onOpen }) {
+  const parts = atUriParts(atUri);
+  if (!parts) return null;
+  return (
+    <div className="xray-tag" aria-hidden="true">
+      <span className="bp-uri">
+        <span className="did">{parts.prefix}</span>
+        <span className="nsid">{parts.nsid}</span>
+        <span className="rkey">{parts.rkey}</span>
+      </span>
+      {onOpen && (
+        <button type="button" className="xray-tag-open" onClick={onOpen}>
+          inspect ↓
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Highlighted at-uri fragment reused by the tag + panel. */
+export function AtUriMono({ atUri }) {
+  const parts = atUriParts(atUri);
+  if (!parts) return <span className="bp-uri">{atUri}</span>;
+  return (
+    <span className="bp-uri">
+      <span className="did">{parts.prefix}</span>
+      <span className="nsid">{parts.nsid}</span>
+      <span className="rkey">{parts.rkey}</span>
+    </span>
+  );
+}
+
+/**
+ * The full substrate readout for a focused record: the field map (with
+ * numbered markers), the record's coordinates, the depth stack, and jump-offs
+ * into the explorer / the record's own page. Owns a lazy PDS resolve so the
+ * "pds" line and depth stack can name where the record actually lives.
+ */
+export function XraySubstratePanel({ atUri, cid, value, leadField }) {
+  const [pds, setPds] = useState(null);
+  const { did } = parseAtUri(atUri);
+  const isMe = did === ME_DID;
+
+  useEffect(() => {
+    let cancelled = false;
+    // Only our own records get a live PDS resolve here; foreign repos would
+    // need their own identity lookup, which the explorer page already does.
+    if (!isMe) return undefined;
+    resolvePds(ME_DID)
+      .then((endpoint) => {
+        if (!cancelled) setPds(endpoint);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isMe]);
+
+  const { rkey } = parseAtUri(atUri);
+  const fields = substrateFields(value, 5);
+  const pdsHost = pds ? String(pds).replace(/^https?:\/\//, '') : isMe ? 'resolving…' : '—';
+  // Lead the depth stack with the most telling field, not the boilerplate
+  // $type, so "the element you tapped → value.text" reads meaningfully.
+  const leadFieldPath =
+    leadField || fields.find((f) => f.path !== 'value.$type')?.path || fields[0]?.path || null;
+  const stack = depthStack(atUri, {
+    handle: isMe ? ME_HANDLE : null,
+    pds: pdsHost,
+    leadField: leadFieldPath,
+  });
+  const explorerPath = explorerPathFromAtUri(atUri);
+  const recordPath = recordPathFromAtUri(atUri);
+
+  return (
+    <div className="xray-substrate" role="group" aria-label="record substrate">
+      <div className="xray-substrate-wide xray-uri-line">
+        <AtUriMono atUri={atUri} />
+        {cid && <span className="bp-cid">cid {shortenCid(cid)}</span>}
+      </div>
+
+      <div>
+        <p className="xray-substrate-h">this element = these fields</p>
+        <ul className="xray-fields">
+          {fields.length === 0 && <li><span className="v">—</span></li>}
+          {fields.map((f, i) => (
+            <li key={f.path}>
+              <span className="num">{i + 1}</span>
+              <span>
+                <span className="p">{f.path}</span>
+                <span className="v">{f.value}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <p className="xray-substrate-h">where it lives</p>
+        <dl className="xray-meta">
+          <div><dt>rkey</dt><dd>{rkey || '—'}</dd></div>
+          {cid && <div><dt>cid</dt><dd>{shortenCid(cid)}</dd></div>}
+          <div><dt>repo</dt><dd>{isMe ? `@${ME_HANDLE}` : did}</dd></div>
+          <div><dt>pds</dt><dd>{pdsHost}</dd></div>
+        </dl>
+      </div>
+
+      <div className="xray-substrate-wide">
+        <p className="xray-substrate-h">where you are in the atmosphere</p>
+        <div className="xray-depth">
+          {stack.map((row, i) => (
+            <span className={`lvl${i === 0 ? ' top' : ''}`} key={i}>
+              <span className="lead">{row.lead}</span>
+              <span className="k">{row.key}</span>
+              {row.value && <span className="v">  {row.value}</span>}
+            </span>
+          ))}
+        </div>
+        <div className="xray-actions">
+          {explorerPath && <Link to={explorerPath}>open in explorer</Link>}
+          {recordPath && <Link to={recordPath}>view record page</Link>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useXray.jsx
+++ b/src/hooks/useXray.jsx
@@ -1,0 +1,111 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+const XrayContext = createContext(null);
+
+/**
+ * Atmosphere X-ray — the site's signature "turn the page inside out" mode.
+ *
+ * When x-ray is on, every record-backed element on the page reveals the AT
+ * Protocol record beneath it: the ledger feed becomes a manifest of at-uris,
+ * a document shows the records it's composed from, and any single element can
+ * be focused for its full substrate (fields, coordinates, depth stack).
+ *
+ * State lives here (like edit mode) so the chrome toggle, the feed rows, the
+ * page banner, and the desktop reticule all read one source of truth:
+ *   - active     — is x-ray on?
+ *   - focusUri   — the at-uri of the element currently drilled into (or null).
+ *                  Setting it spotlights that element and recedes the rest.
+ *
+ * The mode is intentionally NOT persisted — it always starts off — but it DOES
+ * survive navigation (walking the site in x-ray is half the fun); only the
+ * focused element clears on a route change, since a focus made on one page is
+ * meaningless on the next.
+ */
+export function XrayProvider({ children }) {
+  const [active, setActive] = useState(false);
+  const [focusUri, setFocusUri] = useState(null);
+  const location = useLocation();
+
+  // Reflect the mode onto <html data-xray> so CSS can drive the bulk of the
+  // reveal declaratively — the same pattern as data-theme / data-font. A
+  // second attribute marks whether an element is focused, so the recede-the-
+  // rest styling can gate on it without every consumer subscribing.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (active) root.setAttribute('data-xray', 'on');
+    else root.removeAttribute('data-xray');
+    return () => root.removeAttribute('data-xray');
+  }, [active]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (active && focusUri) root.setAttribute('data-xray-focus', 'on');
+    else root.removeAttribute('data-xray-focus');
+  }, [active, focusUri]);
+
+  const enter = useCallback(() => setActive(true), []);
+  const exit = useCallback(() => {
+    setActive(false);
+    setFocusUri(null);
+  }, []);
+  const toggle = useCallback(() => {
+    setActive((prev) => {
+      if (prev) setFocusUri(null);
+      return !prev;
+    });
+  }, []);
+
+  const focus = useCallback((uri) => setFocusUri(uri || null), []);
+  const clearFocus = useCallback(() => setFocusUri(null), []);
+  const toggleFocus = useCallback(
+    (uri) => setFocusUri((cur) => (cur === uri ? null : uri || null)),
+    [],
+  );
+
+  // Drop the focused element when the route changes — but keep the mode on.
+  useEffect(() => {
+    setFocusUri(null);
+  }, [location.pathname]);
+
+  // `x` toggles the mode from anywhere (ignoring keystrokes inside inputs).
+  // Esc pops a focused element back to the full-page x-ray (a no-op when
+  // nothing is focused, and it never preventDefaults, so the dock/modal Esc
+  // handlers still work).
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape') {
+        setFocusUri((f) => (f ? null : f));
+        return;
+      }
+      if (e.key !== 'x' && e.key !== 'X') return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const tag = e.target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) return;
+      e.preventDefault();
+      toggle();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toggle]);
+
+  const value = useMemo(
+    () => ({ active, focusUri, enter, exit, toggle, focus, clearFocus, toggleFocus }),
+    [active, focusUri, enter, exit, toggle, focus, clearFocus, toggleFocus],
+  );
+
+  return <XrayContext.Provider value={value}>{children}</XrayContext.Provider>;
+}
+
+export function useXray() {
+  const ctx = useContext(XrayContext);
+  if (!ctx) throw new Error('useXray must be used inside <XrayProvider>');
+  return ctx;
+}

--- a/src/lib/xray.js
+++ b/src/lib/xray.js
@@ -1,0 +1,119 @@
+// Helpers for the atmosphere x-ray mode — turning a record's AT URI and value
+// into the compact "substrate" a revealed element shows: the address (with its
+// collection highlighted), the content hash, a short field map, and the
+// pixel → field → record → collection → repo → PDS depth stack.
+//
+// All pure + framework-free so the reveal components, the ledger row, and the
+// reticule can share one vocabulary.
+
+/** Split an AT URI into `{ did, collection, rkey }` (any part may be null). */
+export function parseAtUri(atUri) {
+  const m = String(atUri || '').match(/^at:\/\/([^/]+)\/([^/]+)\/([^/?#]+)/);
+  if (!m) return { did: null, collection: null, rkey: null };
+  return { did: m[1], collection: m[2], rkey: m[3] };
+}
+
+/** `did:plc:gq4fo3u6tqzzdkjlwzpb23tj` → `did:plc:gq4f…23tj` (handles + web DIDs pass through short). */
+export function shortenDid(did) {
+  const s = String(did || '');
+  if (!s.startsWith('did:plc:')) return s;
+  const key = s.slice('did:plc:'.length);
+  if (key.length <= 10) return s;
+  return `did:plc:${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+/** A CID trimmed for a one-line cell: `bafyreib7q…q4a`. */
+export function shortenCid(cid) {
+  const s = String(cid || '');
+  if (s.length <= 14) return s;
+  return `${s.slice(0, 9)}…${s.slice(-3)}`;
+}
+
+/**
+ * The AT URI broken into display segments so the collection (nsid) can be
+ * highlighted inside it: `at://<did>/<nsid>/<rkey>`, with the DID shortened.
+ * Returns `{ prefix, nsid, rkey }` where prefix is `at://<shortDid>/`.
+ */
+export function atUriParts(atUri) {
+  const { did, collection, rkey } = parseAtUri(atUri);
+  if (!collection) return null;
+  return {
+    prefix: `at://${shortenDid(did)}/`,
+    nsid: collection,
+    rkey: rkey ? `/${rkey}` : '',
+  };
+}
+
+/**
+ * A compact, ordered field map for a record value: `[{ path, value }]`.
+ * Top-level keys only, formatted to a single short line each, capped at
+ * `max`. `$type` is surfaced first when present (it names the lexicon).
+ */
+export function substrateFields(value, max = 5) {
+  if (!value || typeof value !== 'object') return [];
+  const out = [];
+  const push = (key) => {
+    if (out.length >= max) return;
+    if (!(key in value)) return;
+    out.push({ path: `value.${key}`, value: formatFieldValue(value[key]) });
+  };
+
+  if (typeof value.$type === 'string') {
+    out.push({ path: 'value.$type', value: value.$type });
+  }
+  // A friendly priority so the most telling fields lead, then fill from the rest.
+  const priority = [
+    'text', 'status', 'title', 'name', 'displayName', 'trackName', 'artistName',
+    'scientificName', 'subject', 'createdAt', 'publishedAt', 'playedTime', 'observedAt',
+  ];
+  for (const key of priority) push(key);
+  for (const key of Object.keys(value)) {
+    if (key === '$type') continue;
+    push(key);
+  }
+  return out.slice(0, max);
+}
+
+/** Format one field value to a short single-line string for the substrate view. */
+export function formatFieldValue(v) {
+  if (v == null) return String(v);
+  if (typeof v === 'string') {
+    const s = v.trim().replace(/\s+/g, ' ');
+    const quoted = /^(at:\/\/|did:|https?:\/\/)/.test(s) ? s : `"${s}"`;
+    return quoted.length > 48 ? `${quoted.slice(0, 47)}…` : quoted;
+  }
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (Array.isArray(v)) {
+    if (v.length === 0) return '[]';
+    if (v.every((x) => typeof x === 'string')) {
+      const joined = JSON.stringify(v);
+      return joined.length > 40 ? `[${v.length} items]` : joined;
+    }
+    return `[${v.length} items]`;
+  }
+  if (typeof v === 'object') {
+    if (typeof v.$type === 'string') return `{ ${v.$type} }`;
+    if (typeof v.uri === 'string') return v.uri.length > 44 ? `${v.uri.slice(0, 43)}…` : v.uri;
+    const keys = Object.keys(v);
+    return keys.length ? `{ ${keys.slice(0, 3).join(', ')}${keys.length > 3 ? ', …' : ''} }` : '{}';
+  }
+  return String(v);
+}
+
+/**
+ * The depth stack for a record — the layers you're looking down through, from
+ * the pixels on screen to the PDS the record lives on. `{ handle, pds }` are
+ * optional decorations. Returns `[{ lead, key, value }]`, indentation baked in.
+ */
+export function depthStack(atUri, { handle, pds, leadField } = {}) {
+  const { did, collection, rkey } = parseAtUri(atUri);
+  const rows = [];
+  rows.push({ lead: '', key: leadField ? '◦ the element you tapped' : '◦ this view', value: '' });
+  if (leadField) rows.push({ lead: ' └ ', key: leadField, value: '' });
+  const base = leadField ? '   ' : ' ';
+  rows.push({ lead: `${base}└ `, key: 'record', value: rkey || '' });
+  rows.push({ lead: `${base}  └ `, key: 'collection', value: collection || '' });
+  rows.push({ lead: `${base}    └ `, key: 'repo', value: handle ? `@${handle}` : shortenDid(did) });
+  rows.push({ lead: `${base}      └ `, key: 'pds', value: pds || '…' });
+  return rows;
+}

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -15,10 +15,28 @@ import {
   pickDefaultResume,
   findResumeBySlug,
 } from '../lib/resumeHelpers.js';
+import { atUriParts } from '../lib/xray.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import './Resume.css';
 
 const STANDARD_DOC = 'site.standard.document';
+
+/**
+ * The x-ray annotation for a resume part — names the canonical record the
+ * resume version backlinks (a job / education entry), so the mode reveals
+ * the site's backlinked resume model: one version curating many records.
+ * Hidden until the data-xray root attribute is set; see Xray.css.
+ */
+function ResumeXrayTag({ nsid, atUri, note }) {
+  const parts = atUriParts(atUri);
+  return (
+    <div className="resume-xray-tag" aria-hidden="true">
+      <span className="nsid">{nsid}</span>
+      {parts && <span className="uri">…/{parts.nsid}{parts.rkey}</span>}
+      {note && <span className="note">{note}</span>}
+    </div>
+  );
+}
 
 async function fetchResumeBundle() {
   const pds = await resolvePds(ME_DID);
@@ -224,32 +242,44 @@ export default function Resume() {
                     </h3>
                   </div>
                   {org.roles.map((role) => (
-                    <div className="resume-role" key={role.uri}>
-                      <div className="resume-role-head">
-                        <h4 className="resume-role-title">{role.title}</h4>
-                        <span className="resume-role-dates gutter">{role.dateRange}</span>
+                    <div
+                      className="resume-role resume-xray"
+                      key={role.uri}
+                      data-atproto={role.uri ? '' : undefined}
+                      data-at-uri={role.uri || undefined}
+                    >
+                      <div className="resume-xray-content">
+                        <div className="resume-role-head">
+                          <h4 className="resume-role-title">{role.title}</h4>
+                          <span className="resume-role-dates gutter">{role.dateRange}</span>
+                        </div>
+                        <div className="resume-role-meta">
+                          {[role.employmentType, role.locationType, role.location]
+                            .filter(Boolean)
+                            .join(' · ')}
+                        </div>
+                        {role.summary && <p className="resume-role-summary">{role.summary}</p>}
+                        {role.highlights.length > 0 && (
+                          <ul className="resume-highlights">
+                            {role.highlights.map((h) => (
+                              <li
+                                key={h.refId || h.id}
+                                className={`resume-highlight ${h.featured ? 'is-featured' : ''} ${
+                                  h.metric ? 'is-metric' : ''
+                                }`}
+                              >
+                                {h.text}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                        <RoleWork links={role.links} />
                       </div>
-                      <div className="resume-role-meta">
-                        {[role.employmentType, role.locationType, role.location]
-                          .filter(Boolean)
-                          .join(' · ')}
-                      </div>
-                      {role.summary && <p className="resume-role-summary">{role.summary}</p>}
-                      {role.highlights.length > 0 && (
-                        <ul className="resume-highlights">
-                          {role.highlights.map((h) => (
-                            <li
-                              key={h.refId || h.id}
-                              className={`resume-highlight ${h.featured ? 'is-featured' : ''} ${
-                                h.metric ? 'is-metric' : ''
-                              }`}
-                            >
-                              {h.text}
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                      <RoleWork links={role.links} />
+                      <ResumeXrayTag
+                        nsid="is.dame.resume.job"
+                        atUri={role.uri}
+                        note="canonical role — the bullets live here, shared across resume versions"
+                      />
                     </div>
                   ))}
                 </div>
@@ -263,33 +293,45 @@ export default function Resume() {
             <h2 className="resume-section-title small-caps">Education</h2>
             <div className="resume-orgs">
               {resolved.education.map((e) => (
-                <div className="resume-role" key={e.uri}>
-                  <div className="resume-role-head">
-                    <h4 className="resume-role-title">
-                      {e.value.institutionUrl ? (
-                        <a href={e.value.institutionUrl} target="_blank" rel="noreferrer noopener">
-                          {e.value.institution}
-                        </a>
-                      ) : (
-                        e.value.institution
-                      )}
-                    </h4>
-                    {e.dateRange && <span className="resume-role-dates gutter">{e.dateRange}</span>}
+                <div
+                  className="resume-role resume-xray"
+                  key={e.uri}
+                  data-atproto={e.uri ? '' : undefined}
+                  data-at-uri={e.uri || undefined}
+                >
+                  <div className="resume-xray-content">
+                    <div className="resume-role-head">
+                      <h4 className="resume-role-title">
+                        {e.value.institutionUrl ? (
+                          <a href={e.value.institutionUrl} target="_blank" rel="noreferrer noopener">
+                            {e.value.institution}
+                          </a>
+                        ) : (
+                          e.value.institution
+                        )}
+                      </h4>
+                      {e.dateRange && <span className="resume-role-dates gutter">{e.dateRange}</span>}
+                    </div>
+                    {(e.value.studyType || e.value.area) && (
+                      <p className="resume-role-summary">
+                        {[e.value.studyType, e.value.area].filter(Boolean).join(', ')}
+                      </p>
+                    )}
+                    {e.highlights.length > 0 && (
+                      <ul className="resume-highlights">
+                        {e.highlights.map((h) => (
+                          <li key={h.refId || h.id} className="resume-highlight">
+                            {h.text}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
-                  {(e.value.studyType || e.value.area) && (
-                    <p className="resume-role-summary">
-                      {[e.value.studyType, e.value.area].filter(Boolean).join(', ')}
-                    </p>
-                  )}
-                  {e.highlights.length > 0 && (
-                    <ul className="resume-highlights">
-                      {e.highlights.map((h) => (
-                        <li key={h.refId || h.id} className="resume-highlight">
-                          {h.text}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <ResumeXrayTag
+                    nsid="is.dame.resume.education"
+                    atUri={e.uri}
+                    note="canonical education record"
+                  />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
Turns the debug pane into **x-ray**: a global mode that dissolves what you see into the AT Protocol record beneath it, adapting to what it's revealing.

## What it does

- **Feed → records manifest.** Each ledger row's `verb · summary · time` crossfades *in place* to the record's address (collection highlighted inside the at-uri) + content hash, on the row's own grid so columns stay aligned and nothing overflows.
- **Element → spotlight.** Tap any record-backed element to drill in: a substrate panel maps each field to its value, lists the record's coordinates, and draws the pixel → field → record → collection → repo → PDS depth stack — while everything around it recedes.
- **Document (resume) → backlinked composition.** Keeps the structure, recedes the prose, and slides a data gutter in from the margin tagging each role/education entry with the `is.dame.resume.job` / `.education` record the resume version backlinks.
- **Page HUD** naming the record behind the whole page, with a jump into the detailed inspector (the former debug pane, kept and repurposed).
- **Desktop reticule cursor** — our own build on `motion` (no `motion-plus`) that locks onto `[data-atproto]` elements and labels them by collection; idle diamond otherwise.

## Tailoring

Mobile drops the shared DID prefix so the nsid/rkey read and folds substrate inline; desktop gets the right-margin gutter and the reticule. Theme-aware through the existing accent token (light / dark / sky) and respects `prefers-reduced-motion`. Toggle from the bottom chrome (`Scan`) or the `x` key; `Esc` pops a focused element back to the full-page view.

## New files

`src/hooks/useXray.jsx`, `src/lib/xray.js`, `src/components/{Xray.css,XrayLayer,XrayReticule,XraySubstrate}` — plus wiring in `App`, `ChromeBar`, `FeedItem`, `FeedLedgerRow`, `Resume`.

## Verification

Offline build passes clean. Drove the dev build against the real feed (~1,898 records) at desktop + mobile widths: manifest reveal, page HUD, click-to-focus substrate panel, and reticule lock all confirmed. The only non-network console message is a pre-existing `<li>`-in-`<li>` warning from `Home`'s `motion.li` wrapper (not introduced here). The resume gutter compiles and is scoped but couldn't be exercised with live data in the sandbox (no build-time snapshot fallback), so give it a look running locally against the PDS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_