### PR TITLE
Make /exploring a personal repository landing

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -19,6 +19,7 @@ const ROUTES = [
   { to: '/curating', label: 'curating' },
   { to: '/mothing', label: 'mothing' },
   { to: '/guestbook', label: 'guestbook' },
+  { to: '/exploring', label: 'exploring' },
 ];
 
 export default function ActionDock() {

--- a/src/components/ExploringHome.css
+++ b/src/components/ExploringHome.css
@@ -1,0 +1,303 @@
+/* Personal repository landing — paired with src/components/ExploringHome.jsx,
+   rendered inside the Exploring page (so Exploring.css / Admin.css tokens like
+   `.placeholder-card`, `.exploring-muted`, `.small-caps`, `.gutter`, `.dropcap`
+   are already in scope). Semantic tokens only, square corners, hairline rules —
+   so it rides the always-on sky theme. */
+
+.exploring-home {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+  margin-top: var(--space-4);
+}
+
+.exploring-home-lead {
+  max-width: var(--measure);
+  margin: 0;
+  font-size: var(--text-lg);
+  line-height: var(--leading);
+  color: var(--ink-soft);
+}
+
+/* Sections ------------------------------------------------------------- */
+
+.exploring-home-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.exploring-home-section-title {
+  margin: 0;
+  font-size: var(--text-sm);
+  letter-spacing: 0.18em;
+  color: var(--ink-muted);
+}
+.exploring-home-section-note {
+  max-width: var(--measure);
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+}
+.exploring-home-section-note code {
+  font-family: var(--code);
+  font-size: 0.9em;
+}
+
+/* Repo at a glance ----------------------------------------------------- */
+
+.exploring-home-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+}
+.exploring-home-stat {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-2);
+  background: var(--page);
+  padding: var(--space-3);
+  transition: transform 200ms ease, border-color 200ms ease;
+}
+.exploring-home-stat.is-link:hover {
+  border-color: var(--accent-soft);
+  transform: translateY(-2px);
+}
+.exploring-home-stat-inner {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+.exploring-home-stat-label {
+  display: block;
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+  margin-bottom: var(--space-2);
+}
+.exploring-home-stat-value {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: var(--text-2xl);
+  line-height: var(--leading-tight);
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.exploring-home-stat-sub {
+  display: block;
+  margin-top: var(--space-1);
+  font-family: var(--mono-ui, var(--mono));
+  font-size: var(--text-xs);
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+}
+
+/* Custom lexicons ------------------------------------------------------ */
+
+.exploring-home-lexicons {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: var(--space-3);
+}
+.exploring-home-lexicon {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--rule-soft, var(--rule));
+  border-radius: var(--radius-2);
+  background: var(--page-edge);
+  transition: transform 200ms ease, border-color 200ms ease;
+}
+.exploring-home-lexicon:hover {
+  border-color: var(--accent-soft);
+  transform: translateY(-2px);
+}
+.exploring-home-lexicon-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.exploring-home-lexicon-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: var(--text-lg);
+  font-style: italic;
+  color: var(--accent);
+}
+.exploring-home-lexicon-nsid {
+  word-break: break-all;
+}
+.exploring-home-lexicon-blurb {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading);
+  color: var(--ink-soft);
+}
+.exploring-home-lexicon-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: auto;
+  padding-top: var(--space-1);
+}
+
+/* Shared text links ---------------------------------------------------- */
+
+.exploring-home-textlink {
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  text-decoration: none;
+}
+.exploring-home-textlink:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-underline-offset: 3px;
+}
+.exploring-home-textlink-muted {
+  color: var(--ink-soft);
+}
+.exploring-home-textlink-muted:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink-soft);
+}
+
+/* Identity ------------------------------------------------------------- */
+
+.exploring-home-identity {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-2);
+  background: var(--page);
+}
+.exploring-home-identity-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+.exploring-home-identity-row dt {
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+}
+.exploring-home-identity-row dd {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  margin: 0;
+  font-size: var(--text-sm);
+  word-break: break-all;
+}
+.exploring-home-identity-mono {
+  font-family: var(--mono-ui, var(--mono));
+}
+.exploring-home-copy {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  padding: var(--space-1);
+  background: transparent;
+  border: 0;
+  color: var(--ink-faint);
+  cursor: pointer;
+  line-height: 0;
+}
+.exploring-home-copy:hover {
+  color: var(--accent);
+}
+.exploring-home-identity-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+/* Collections directory ------------------------------------------------ */
+
+.exploring-home-collections-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.exploring-home-collection-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: var(--space-4);
+}
+.exploring-home-collection-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.exploring-home-collection-group-title {
+  margin: 0;
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+}
+.exploring-home-collection-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-faint);
+  font-size: var(--text-xs);
+}
+.exploring-home-collection-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-2);
+  overflow: hidden;
+}
+.exploring-home-collection-row {
+  border-bottom: 1px solid var(--rule-soft, var(--rule));
+}
+.exploring-home-collection-row:last-child {
+  border-bottom: 0;
+}
+.exploring-home-collection-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--mono-ui, var(--mono));
+  font-size: var(--text-sm);
+  color: var(--ink);
+  text-decoration: none;
+  word-break: break-all;
+}
+.exploring-home-collection-link:hover {
+  color: var(--accent);
+  background: var(--rule-soft, transparent);
+}
+
+/* "Look inside another repo" — the generic explorer's entry point, kept
+   reachable below the personal landing (markup lives in Exploring.jsx). */
+.exploring-home-elsewhere {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-7);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--rule);
+}
+
+@media (max-width: 700px) {
+  .exploring-home {
+    gap: var(--space-6);
+  }
+  .exploring-home-identity-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
+}

--- a/src/components/ExploringHome.jsx
+++ b/src/components/ExploringHome.jsx
@@ -1,0 +1,335 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Check, Copy } from 'lucide-react';
+import { ME_HANDLE } from '../config.js';
+import {
+  describeRepo,
+  getLatestCommit,
+  getPlcAuditLog,
+  tidToTimestamp,
+} from '../lib/atproto.js';
+import { flattenSources, getBacklinkSources } from '../lib/constellation.js';
+import { formatDateFull, relativeTime } from '../lib/time.js';
+import './ExploringHome.css';
+
+/**
+ * The personal front door for dame's repository — rendered at the bare
+ * `/exploring` route (see Exploring.jsx). Where the generic explorer treats
+ * every repo the same, this reads as *mine*: a plain-language tour of what a
+ * repository is, the stats at a glance, the custom `is.dame.*` record types I
+ * invented, and every collection — each linking into the generic browser at
+ * `/exploring/dame.is/...` for the deep dive.
+ *
+ * `identity` ({ did, handle, pds }) is already resolved by the parent.
+ */
+
+// Hand-written tour of the record types I designed. Blurbs are authored here
+// rather than pulled from the bundled lexicon schemas (whose `description`
+// fields are terse and technical). `route` is the site surface a type powers,
+// when it has one.
+const CUSTOM_LEXICONS = [
+  { nsid: 'is.dame.now', title: 'now', blurb: 'What I’m up to right now — a single line. “dame is hiking.”', route: '/logging' },
+  { nsid: 'is.dame.hero.phrase', title: 'hero phrase', blurb: 'The rotating “dame is…” sentences that greet you on the home page.', route: '/' },
+  { nsid: 'is.dame.profile', title: 'profile', blurb: 'My long-form bio — the part that never fits in a social blurb.', route: '/themself' },
+  { nsid: 'is.dame.page', title: 'page', blurb: 'The title and intro copy for each page of this site, kept as records I can edit in place.' },
+  { nsid: 'is.dame.creating.work', title: 'creating', blurb: 'Things I’ve made — art, software, writing — each with its own page.', route: '/creating' },
+  { nsid: 'is.dame.resume', title: 'resume', blurb: 'My work history and education, kept as records instead of a PDF.', route: '/available' },
+  { nsid: 'is.dame.mothing', title: 'mothing', blurb: 'Moths I’ve found, mirrored from iNaturalist. No location is ever stored.', route: '/mothing' },
+  { nsid: 'is.dame.observing', title: 'observing', blurb: 'Everything else I’ve noticed in the wild — birds, plants, fungi.' },
+  { nsid: 'is.dame.guestbook', title: 'guestbook', blurb: 'The book you can sign — from your own repository, in your own words.', route: '/guestbook' },
+  { nsid: 'is.dame.arena.channel', title: 'arena channel', blurb: 'The are.na channels I’m curating, mirrored back here.', route: '/curating' },
+  { nsid: 'is.dame.annotating', title: 'annotating', blurb: 'Margin notes pinned to other records — a work in progress.' },
+];
+
+const OWNER = ME_HANDLE;
+
+/**
+ * Best collection to link into for a lexicon "family". Prefers the exact NSID;
+ * falls back to the shortest sub-collection that exists (e.g. `is.dame.resume`
+ * → `is.dame.resume.job`). Returns the base NSID as a best-effort guess when
+ * the collection list failed to load, or `null` when the family is genuinely
+ * absent from the repo.
+ */
+function browsableCollection(baseNsid, collections) {
+  if (!collections) return baseNsid; // describeRepo failed — best-effort link
+  if (collections.includes(baseNsid)) return baseNsid;
+  const sub = collections
+    .filter((c) => c.startsWith(`${baseNsid}.`))
+    .sort((a, b) => a.length - b.length);
+  return sub[0] || null;
+}
+
+export default function ExploringHome({ identity }) {
+  const { did, handle, pds } = identity;
+  const isPlc = did.startsWith('did:plc:');
+
+  // Core facts — collections, account age + operation count, last-active —
+  // all come from fast, cached endpoints and load together. Constellation
+  // backlinks load separately (below) so a slow or offline index never holds
+  // up the rest of the page.
+  const [core, setCore] = useState({ loading: true });
+  const [inbound, setInbound] = useState(undefined); // undefined=loading · null=unavailable · number
+
+  useEffect(() => {
+    let cancelled = false;
+    setCore({ loading: true });
+    Promise.allSettled([
+      describeRepo(pds, did),
+      isPlc ? getPlcAuditLog(did) : Promise.resolve(null),
+      getLatestCommit(pds, did),
+    ]).then(([descR, auditR, commitR]) => {
+      if (cancelled) return;
+      const collections =
+        descR.status === 'fulfilled' && Array.isArray(descR.value?.collections)
+          ? [...descR.value.collections].sort()
+          : null;
+      const audit =
+        auditR.status === 'fulfilled' && Array.isArray(auditR.value) ? auditR.value : null;
+      const created = audit?.[0]?.createdAt || null; // audit log is oldest → newest
+      const ops = audit ? audit.length : null;
+      const rev = commitR.status === 'fulfilled' ? commitR.value?.rev : null;
+      const lastActive = rev ? tidToTimestamp(rev) : null;
+      setCore({ loading: false, collections, created, ops, lastActive });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [pds, did, isPlc]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setInbound(undefined);
+    getBacklinkSources(did).then((raw) => {
+      if (cancelled) return;
+      const flat = flattenSources(raw);
+      if (!flat) {
+        setInbound(null);
+        return;
+      }
+      setInbound(flat.reduce((sum, s) => sum + (s.count || 0), 0));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [did]);
+
+  const { loading, collections, created, ops, lastActive } = core;
+
+  const lexicons = useMemo(
+    () =>
+      CUSTOM_LEXICONS.map((lex) => ({
+        ...lex,
+        browse: browsableCollection(lex.nsid, collections),
+      })).filter((lex) => (collections ? lex.browse : true)),
+    [collections],
+  );
+
+  const mine = useMemo(
+    () => (collections || []).filter((c) => c.startsWith('is.dame.')),
+    [collections],
+  );
+  const external = useMemo(
+    () => (collections || []).filter((c) => !c.startsWith('is.dame.')),
+    [collections],
+  );
+
+  const dash = loading ? '…' : '—';
+
+  return (
+    <div className="exploring-home">
+      <p className="exploring-home-lead dropcap">
+        A repository is a signed, public collection of records — kept on a personal data
+        server out in the atmosphere, and readable by anyone. This whole website is only a
+        view onto mine. Here’s what’s inside it: the shape of the thing, the record types I
+        invented, and every collection, open for you to wander through.
+      </p>
+
+      {/* Repo at a glance ------------------------------------------------ */}
+      <section className="exploring-home-section">
+        <h2 className="exploring-home-section-title small-caps">Repo at a glance</h2>
+        <dl className="exploring-home-stats">
+          <Stat label="Collections" value={collections ? collections.length : dash} />
+          <Stat
+            label="Created"
+            value={created ? formatDateFull(created) : dash}
+            sub={created ? relativeTime(created) : null}
+          />
+          <Stat label="Identity ops" value={ops != null ? ops : dash} />
+          <Stat
+            label="Last active"
+            value={lastActive ? relativeTime(lastActive) : dash}
+            sub={lastActive ? formatDateFull(lastActive) : null}
+          />
+          <Stat
+            label="Inbound links"
+            value={
+              inbound === undefined
+                ? '…'
+                : inbound === null
+                  ? 'unavailable'
+                  : inbound.toLocaleString()
+            }
+            to={inbound ? `/exploring/${OWNER}?tab=backlinks` : null}
+          />
+        </dl>
+      </section>
+
+      {/* Custom lexicons ------------------------------------------------- */}
+      <section className="exploring-home-section">
+        <h2 className="exploring-home-section-title small-caps">Record types I made</h2>
+        <p className="exploring-home-section-note">
+          Most of what’s here rides on custom <code>is.dame.*</code> lexicons — little
+          schemas I designed for the way I live online.
+        </p>
+        <ul className="exploring-home-lexicons">
+          {lexicons.map((lex) => (
+            <li key={lex.nsid} className="exploring-home-lexicon">
+              <div className="exploring-home-lexicon-head">
+                <h3 className="exploring-home-lexicon-title">{lex.title}</h3>
+                <code className="exploring-home-lexicon-nsid gutter">{lex.nsid}</code>
+              </div>
+              <p className="exploring-home-lexicon-blurb">{lex.blurb}</p>
+              <div className="exploring-home-lexicon-links">
+                {lex.browse && (
+                  <Link to={`/exploring/${OWNER}/${lex.browse}`} className="exploring-home-textlink">
+                    browse records →
+                  </Link>
+                )}
+                {lex.route && (
+                  <Link to={lex.route} className="exploring-home-textlink exploring-home-textlink-muted">
+                    on the site: {lex.route}
+                  </Link>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Identity -------------------------------------------------------- */}
+      <section className="exploring-home-section">
+        <h2 className="exploring-home-section-title small-caps">Identity</h2>
+        <dl className="exploring-home-identity">
+          <IdentityRow label="handle" value={handle ? `@${handle}` : '—'} copy={handle ? `@${handle}` : null} />
+          <IdentityRow label="did" value={did} copy={did} mono />
+          <IdentityRow label="pds" value={pds} copy={pds} mono />
+        </dl>
+        {isPlc && (
+          <div className="exploring-home-identity-links">
+            <Link to={`/exploring/${OWNER}?tab=identity`} className="exploring-home-textlink">
+              identity document →
+            </Link>
+            <Link to={`/exploring/${OWNER}?tab=audit`} className="exploring-home-textlink">
+              full audit history →
+            </Link>
+          </div>
+        )}
+      </section>
+
+      {/* Collections directory ------------------------------------------ */}
+      <section className="exploring-home-section">
+        <div className="exploring-home-collections-head">
+          <h2 className="exploring-home-section-title small-caps">Collections</h2>
+          <Link to={`/exploring/${OWNER}`} className="exploring-home-textlink">
+            browse the whole repo →
+          </Link>
+        </div>
+        {collections === null && !loading && (
+          <p className="exploring-muted">Couldn’t load the collection list right now.</p>
+        )}
+        {loading && <p className="placeholder-card">Loading collections…</p>}
+        {collections && (
+          <div className="exploring-home-collection-groups">
+            <CollectionGroup title="mine" nsids={mine} />
+            <CollectionGroup title="from elsewhere" nsids={external} />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value, sub, to }) {
+  const body = (
+    <>
+      <dt className="exploring-home-stat-label small-caps">{label}</dt>
+      <dd className="exploring-home-stat-value">
+        {value}
+        {sub && <span className="exploring-home-stat-sub">{sub}</span>}
+      </dd>
+    </>
+  );
+  return (
+    <div className={`exploring-home-stat${to ? ' is-link' : ''}`}>
+      {to ? (
+        <Link to={to} className="exploring-home-stat-inner">
+          {body}
+        </Link>
+      ) : (
+        body
+      )}
+    </div>
+  );
+}
+
+function IdentityRow({ label, value, copy, mono }) {
+  return (
+    <div className="exploring-home-identity-row">
+      <dt className="small-caps">{label}</dt>
+      <dd>
+        <span className={mono ? 'exploring-home-identity-mono' : undefined}>{value}</span>
+        {copy && <CopyButton text={copy} label={label} />}
+      </dd>
+    </div>
+  );
+}
+
+function CopyButton({ text, label }) {
+  const [copied, setCopied] = useState(false);
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
+
+  async function onClick() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => {
+        if (mounted.current) setCopied(false);
+      }, 1200);
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — no-op.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className="exploring-home-copy"
+      onClick={onClick}
+      aria-label={`Copy ${label}`}
+      title={copied ? 'Copied' : `Copy ${label}`}
+    >
+      {copied ? <Check size={14} aria-hidden /> : <Copy size={14} aria-hidden />}
+    </button>
+  );
+}
+
+function CollectionGroup({ title, nsids }) {
+  if (!nsids || nsids.length === 0) return null;
+  return (
+    <section className="exploring-home-collection-group">
+      <h3 className="exploring-home-collection-group-title small-caps">
+        {title} <span className="exploring-home-collection-count">{nsids.length}</span>
+      </h3>
+      <ul className="exploring-home-collection-list">
+        {nsids.map((nsid) => (
+          <li key={nsid} className="exploring-home-collection-row">
+            <Link to={`/exploring/${OWNER}/${nsid}`} className="exploring-home-collection-link">
+              <code>{nsid}</code>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/atproto.js
+++ b/src/lib/atproto.js
@@ -208,6 +208,17 @@ export async function getRecord(pds, { repo, collection, rkey }) {
 }
 
 /**
+ * PDS — `com.atproto.sync.getLatestCommit`. Returns `{ cid, rev }` for the
+ * repo's current head commit. The `rev` is a TID, so `tidToTimestamp(rev)`
+ * recovers when the repo was last written to — a cheap "last active" signal
+ * with no extra call to list records.
+ */
+export async function getLatestCommit(pds, did) {
+  const params = new URLSearchParams({ did });
+  return fetchJson(`${pds}/xrpc/com.atproto.sync.getLatestCommit?${params}`);
+}
+
+/**
  * Build an `at://` URI from parts.
  */
 export function toAtUri({ did, collection, rkey }) {

--- a/src/pages/Exploring.jsx
+++ b/src/pages/Exploring.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
+import ExploringHome from '../components/ExploringHome.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
 import AtUriLink from '../components/AtUriLink.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -25,7 +26,7 @@ import './Exploring.css';
  * Atmosphere PDS explorer.
  *
  * Routes (registered in App.jsx) all resolve here; we branch on params:
- *   /exploring                             → defaults to ME_HANDLE
+ *   /exploring                             → dame's own repo (personal landing)
  *   /exploring/:repo                       → repo overview (tabs)
  *   /exploring/:repo/:collection           → record list
  *   /exploring/:repo/:collection/:rkey     → record detail
@@ -34,6 +35,10 @@ export default function Exploring() {
   const params = useParams();
   const repoInput = params.repo || ME_HANDLE;
   const { collection, rkey } = params;
+  // The bare `/exploring` (no repo in the path) is dame's own repository,
+  // rendered as a personal landing (ExploringHome). Any explicit repo —
+  // including `/exploring/dame.is` — keeps the generic multi-repo browser.
+  const isOwnerHome = !params.repo;
 
   const [identity, setIdentity] = useState(null); // { did, handle, pds }
   const [error, setError] = useState(null);
@@ -63,9 +68,14 @@ export default function Exploring() {
   return (
     <PageShell
       title="Exploring"
-      headTitle={`${title} — Exploring — dame.is`}
+      intro={
+        isOwnerHome
+          ? 'Everything on this site is a record in my public repository on the atproto network — and it’s open for anyone to read.'
+          : undefined
+      }
+      headTitle={isOwnerHome ? 'Exploring — dame.is' : `${title} — Exploring — dame.is`}
     >
-      <SearchBox initial={repoInput} />
+      {!isOwnerHome && <SearchBox initial={repoInput} />}
 
       {error && (
         <div className="exploring-error">
@@ -80,7 +90,7 @@ export default function Exploring() {
         <p className="placeholder-card">Resolving <code>{repoInput}</code>…</p>
       )}
 
-      {identity && (
+      {identity && !isOwnerHome && (
         <RepoBreadcrumb
           identity={identity}
           collection={collection}
@@ -88,12 +98,20 @@ export default function Exploring() {
         />
       )}
 
-      {identity && !collection && <RepoOverview identity={identity} />}
+      {identity && isOwnerHome && <ExploringHome identity={identity} />}
+      {identity && !isOwnerHome && !collection && <RepoOverview identity={identity} />}
       {identity && collection && !rkey && (
         <CollectionView identity={identity} collection={collection} />
       )}
       {identity && collection && rkey && (
         <RecordView identity={identity} collection={collection} rkey={rkey} />
+      )}
+
+      {isOwnerHome && identity && (
+        <section className="exploring-home-elsewhere">
+          <h2 className="exploring-home-section-title small-caps">Look inside another repo</h2>
+          <SearchBox initial="" />
+        </section>
       )}
     </PageShell>
   );


### PR DESCRIPTION
The bare `/exploring` route now renders a personal, on-brand overview of my own atproto repository instead of the generic multi-repo overview — a window anyone can open to see what's inside my repo and read about it. It's the Aturi idea, but tailored to one repo and dressed in the site's own book/atmospheric vibe.

## What's on the page
- **Narrative intro** — a drop-capped lead explaining what a repository/PDS is, and that anyone can look inside.
- **Repo at a glance** — flat hairline stat tiles: number of collections, account age / created date, identity operations, last active, and total inbound links.
- **Record types I made** — a plain-language showcase of the custom `is.dame.*` lexicons (auto-hides any type that isn't actually in the repo).
- **Identity** — handle / DID / PDS with one-click copy, plus links into the PLC identity document and audit history.
- **Collections** — a directory split into *mine* vs *from elsewhere*, each row linking into the browser.

Every section deep-links into the existing `/exploring/dame.is/…` browser, so nothing is duplicated. Any explicit repo — including `/exploring/dame.is` — keeps the generic tabbed tool, and a "look inside another repo" search sits below the personal landing.

## How it's built (mostly reuse)
- **New** `src/components/ExploringHome.jsx` + `ExploringHome.css` — semantic tokens only, square corners, hairline rules, so it rides the always-on sky theme.
- `src/pages/Exploring.jsx` branches the bare route via `isOwnerHome = !params.repo` to `ExploringHome`; the generic browser is untouched for every other route.
- One small helper added to `src/lib/atproto.js`: `getLatestCommit()` for the "last active" signal, decoded from the head commit `rev` via the existing `tidToTimestamp()`. Backlinks, PLC audit log, and `describeRepo` all reuse the existing client.
- `/exploring` now appears in the `ActionDock` nav ("Dame is… exploring").

## Verification
- `vite build` passes.
- Drove `/exploring` in headless Chromium with real-shaped mock atproto responses: every section rendered with correctly derived values (stats, lexicon filtering, mine/elsewhere split, working copy button), no JS errors, and the layout matched the site's aesthetic under the sky theme.
- Confirmed the regression path: explicit `/exploring/dame.is` still renders the generic tabbed overview.
- Rebased onto latest `main` (on top of the x-ray change) with no conflicts; rebuilt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yJK4Et6SAMuq1wTGezbFB

---
_Generated by [Claude Code](https://claude.ai/code/session_015yJK4Et6SAMuq1wTGezbFB)_