### PR TITLE
Vitals: read physicalActivity; tighten the two-bar gap

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -110,10 +110,10 @@
 
 .chrome-bar-secondary > .chrome-signals {
   width: 100%;
-  /* Same vertical padding as the tertiary strip's crumbs (--space-2) so
-     this row and the timestamp/NSID strip stand the same height when each
-     is a single row. */
-  padding: var(--space-2) 0;
+  /* --space-2 up top (matching the tertiary crumb strip's height), but only
+     --space-1 below so the state/vitals bar beneath sits close to this row
+     rather than a full row's gap away. */
+  padding: var(--space-2) 0 var(--space-1);
 }
 
 /* State / vitals bar — a second expanded tier beneath the LISTENING TO /
@@ -129,7 +129,8 @@
 
 .chrome-bar-state > .chrome-signals {
   width: 100%;
-  padding: var(--space-2) 0;
+  /* Tight to the row above (--space-1 top), normal breathing room below. */
+  padding: var(--space-1) 0 var(--space-2);
 }
 
 /* Tertiary chrome: the scroll-driven breadcrumb strip. It's absolutely

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -34,7 +34,11 @@ export function clampPct(n) {
  */
 export function normalizeVitals(value) {
   if (!value) return null;
-  const activity = value.activity ? String(value.activity).trim().toLowerCase() : null;
+  // Accept the raw iOS key (`physicalActivity`, e.g. "Stationary") as well as
+  // the normalized `activity`, the same way charging/sound accept their raw
+  // keys below — the Shortcut posts whichever it has.
+  const rawActivity = value.activity ?? value.physicalActivity;
+  const activity = rawActivity ? String(rawActivity).trim().toLowerCase() : null;
   return {
     heartRate: nonZero(toInt(value.heartRate)),
     // `unknown` is the lexicon's "no reading" sentinel — treat it as absent too.


### PR DESCRIPTION
Two small fixes to the `is.dame.state` vitals display (follow-up to #262).

- **Activity now shows** — the Shortcut posts the raw iOS key `physicalActivity` (e.g. "Stationary"), but `normalizeVitals` only read `activity`, so it came back null and was hidden. It now accepts either key, the same way charging/sound already accept `isCharging`/`environmentSound`.
- **Tighter gap** — reduced the padding at the seam between the LISTENING TO / FOLLOWED BY bar and the state/vitals bar (`--space-1` per side instead of `--space-2`), so the vitals sit snug beneath the row above.

Verified against a real record (`physicalActivity: "Stationary"`, `isCharging: "false"`, `soundLevel: 0`): renders `❤ 69 · 🪑 stationary · 🔋 83% · 🔥 92 cal`, sound hidden, no charging bolt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_