### PR TITLE
Rewrite the /exploring copy to drop AI-slop patterns

### DIFF
--- a/src/components/ExploringHome.jsx
+++ b/src/components/ExploringHome.jsx
@@ -13,32 +13,31 @@ import { formatDateFull, relativeTime } from '../lib/time.js';
 import './ExploringHome.css';
 
 /**
- * The personal front door for dame's repository — rendered at the bare
- * `/exploring` route (see Exploring.jsx). Where the generic explorer treats
- * every repo the same, this reads as *mine*: a plain-language tour of what a
- * repository is, the stats at a glance, the custom `is.dame.*` record types I
- * invented, and every collection — each linking into the generic browser at
- * `/exploring/dame.is/...` for the deep dive.
+ * The personal landing for dame's repository, rendered at the bare
+ * `/exploring` route (see Exploring.jsx). The generic explorer treats every
+ * repo the same; this one is dame's: a plain-language tour of what a
+ * repository is, the stats, the custom `is.dame.*` record types, and every
+ * collection. Each row links into the generic browser at
+ * `/exploring/dame.is/...` for the record-level view.
  *
  * `identity` ({ did, handle, pds }) is already resolved by the parent.
  */
 
-// Hand-written tour of the record types I designed. Blurbs are authored here
-// rather than pulled from the bundled lexicon schemas (whose `description`
-// fields are terse and technical). `route` is the site surface a type powers,
-// when it has one.
+// Hand-written descriptions of the record types I designed. I write them here
+// rather than pull from the bundled lexicon schemas, whose `description` fields
+// are terse. `route` is the site page a type feeds, when it has one.
 const CUSTOM_LEXICONS = [
-  { nsid: 'is.dame.now', title: 'now', blurb: 'What I’m up to right now — a single line. “dame is hiking.”', route: '/logging' },
-  { nsid: 'is.dame.hero.phrase', title: 'hero phrase', blurb: 'The rotating “dame is…” sentences that greet you on the home page.', route: '/' },
-  { nsid: 'is.dame.profile', title: 'profile', blurb: 'My long-form bio — the part that never fits in a social blurb.', route: '/themself' },
-  { nsid: 'is.dame.page', title: 'page', blurb: 'The title and intro copy for each page of this site, kept as records I can edit in place.' },
-  { nsid: 'is.dame.creating.work', title: 'creating', blurb: 'Things I’ve made — art, software, writing — each with its own page.', route: '/creating' },
-  { nsid: 'is.dame.resume', title: 'resume', blurb: 'My work history and education, kept as records instead of a PDF.', route: '/available' },
-  { nsid: 'is.dame.mothing', title: 'mothing', blurb: 'Moths I’ve found, mirrored from iNaturalist. No location is ever stored.', route: '/mothing' },
-  { nsid: 'is.dame.observing', title: 'observing', blurb: 'Everything else I’ve noticed in the wild — birds, plants, fungi.' },
-  { nsid: 'is.dame.guestbook', title: 'guestbook', blurb: 'The book you can sign — from your own repository, in your own words.', route: '/guestbook' },
-  { nsid: 'is.dame.arena.channel', title: 'arena channel', blurb: 'The are.na channels I’m curating, mirrored back here.', route: '/curating' },
-  { nsid: 'is.dame.annotating', title: 'annotating', blurb: 'Margin notes pinned to other records — a work in progress.' },
+  { nsid: 'is.dame.now', title: 'now', blurb: 'A one-line status. The latest one reads something like “dame is hiking.”', route: '/logging' },
+  { nsid: 'is.dame.hero.phrase', title: 'hero phrase', blurb: 'The “dame is…” lines on the home page come from these records.', route: '/' },
+  { nsid: 'is.dame.profile', title: 'profile', blurb: 'My long-form bio. My Bluesky description holds the short version; this record holds the rest.', route: '/themself' },
+  { nsid: 'is.dame.page', title: 'page', blurb: 'The title and intro text for each page of this site. I edit the record to change the page.' },
+  { nsid: 'is.dame.creating.work', title: 'creating', blurb: 'Things I’ve made: art, software, writing. Each record gets its own page.', route: '/creating' },
+  { nsid: 'is.dame.resume', title: 'resume', blurb: 'My work history and education, as records instead of a PDF.', route: '/available' },
+  { nsid: 'is.dame.mothing', title: 'mothing', blurb: 'Moths I’ve logged on iNaturalist, mirrored here. No location is stored.', route: '/mothing' },
+  { nsid: 'is.dame.observing', title: 'observing', blurb: 'Everything I’ve logged on iNaturalist that isn’t a moth: birds, plants, fungi.' },
+  { nsid: 'is.dame.guestbook', title: 'guestbook', blurb: 'A guestbook you sign from your own repository. Your entry stays in your repo and links back to mine.', route: '/guestbook' },
+  { nsid: 'is.dame.arena.channel', title: 'arena channel', blurb: 'The are.na channels I curate, mirrored from are.na into my repo.', route: '/curating' },
+  { nsid: 'is.dame.annotating', title: 'annotating', blurb: 'Margin notes attached to another record by its AT URI.' },
 ];
 
 const OWNER = ME_HANDLE;
@@ -51,7 +50,7 @@ const OWNER = ME_HANDLE;
  * absent from the repo.
  */
 function browsableCollection(baseNsid, collections) {
-  if (!collections) return baseNsid; // describeRepo failed — best-effort link
+  if (!collections) return baseNsid; // describeRepo failed; best-effort link
   if (collections.includes(baseNsid)) return baseNsid;
   const sub = collections
     .filter((c) => c.startsWith(`${baseNsid}.`))
@@ -63,10 +62,10 @@ export default function ExploringHome({ identity }) {
   const { did, handle, pds } = identity;
   const isPlc = did.startsWith('did:plc:');
 
-  // Core facts — collections, account age + operation count, last-active —
-  // all come from fast, cached endpoints and load together. Constellation
-  // backlinks load separately (below) so a slow or offline index never holds
-  // up the rest of the page.
+  // Core facts (collections, account age and operation count, last-active) all
+  // come from fast, cached endpoints and load together. Constellation backlinks
+  // load separately (below) so a slow or offline index never holds up the rest
+  // of the page.
   const [core, setCore] = useState({ loading: true });
   const [inbound, setInbound] = useState(undefined); // undefined=loading · null=unavailable · number
 
@@ -138,15 +137,15 @@ export default function ExploringHome({ identity }) {
   return (
     <div className="exploring-home">
       <p className="exploring-home-lead dropcap">
-        A repository is a signed, public collection of records — kept on a personal data
-        server out in the atmosphere, and readable by anyone. This whole website is only a
-        view onto mine. Here’s what’s inside it: the shape of the thing, the record types I
-        invented, and every collection, open for you to wander through.
+        A repository is a collection of records stored on a personal data server, or PDS,
+        and signed by my account’s key. This site reads from mine and renders it as pages.
+        Below are its stats, the record types I wrote, and every collection, each one
+        linking into a browser you can open yourself.
       </p>
 
-      {/* Repo at a glance ------------------------------------------------ */}
+      {/* Stats ----------------------------------------------------------- */}
       <section className="exploring-home-section">
-        <h2 className="exploring-home-section-title small-caps">Repo at a glance</h2>
+        <h2 className="exploring-home-section-title small-caps">Stats</h2>
         <dl className="exploring-home-stats">
           <Stat label="Collections" value={collections ? collections.length : dash} />
           <Stat
@@ -178,8 +177,8 @@ export default function ExploringHome({ identity }) {
       <section className="exploring-home-section">
         <h2 className="exploring-home-section-title small-caps">Record types I made</h2>
         <p className="exploring-home-section-note">
-          Most of what’s here rides on custom <code>is.dame.*</code> lexicons — little
-          schemas I designed for the way I live online.
+          Most of these use custom <code>is.dame.*</code> lexicons, schemas I wrote for
+          records the standard lexicons don’t define.
         </p>
         <ul className="exploring-home-lexicons">
           {lexicons.map((lex) => (
@@ -220,7 +219,7 @@ export default function ExploringHome({ identity }) {
               identity document →
             </Link>
             <Link to={`/exploring/${OWNER}?tab=audit`} className="exploring-home-textlink">
-              full audit history →
+              audit log →
             </Link>
           </div>
         )}
@@ -235,7 +234,7 @@ export default function ExploringHome({ identity }) {
           </Link>
         </div>
         {collections === null && !loading && (
-          <p className="exploring-muted">Couldn’t load the collection list right now.</p>
+          <p className="exploring-muted">Couldn’t load the collections.</p>
         )}
         {loading && <p className="placeholder-card">Loading collections…</p>}
         {collections && (
@@ -297,7 +296,7 @@ function CopyButton({ text, label }) {
         if (mounted.current) setCopied(false);
       }, 1200);
     } catch {
-      // Clipboard blocked (insecure context / permissions) — no-op.
+      // Clipboard blocked (insecure context / permissions); no-op.
     }
   }
 

--- a/src/pages/Exploring.jsx
+++ b/src/pages/Exploring.jsx
@@ -36,8 +36,8 @@ export default function Exploring() {
   const repoInput = params.repo || ME_HANDLE;
   const { collection, rkey } = params;
   // The bare `/exploring` (no repo in the path) is dame's own repository,
-  // rendered as a personal landing (ExploringHome). Any explicit repo —
-  // including `/exploring/dame.is` — keeps the generic multi-repo browser.
+  // rendered as a personal landing (ExploringHome). Any explicit repo,
+  // including `/exploring/dame.is`, keeps the generic multi-repo browser.
   const isOwnerHome = !params.repo;
 
   const [identity, setIdentity] = useState(null); // { did, handle, pds }
@@ -70,7 +70,7 @@ export default function Exploring() {
       title="Exploring"
       intro={
         isOwnerHome
-          ? 'Everything on this site is a record in my public repository on the atproto network — and it’s open for anyone to read.'
+          ? 'Everything on this site is a record in my atproto repository. The repository is public, so anyone can read it.'
           : undefined
       }
       headTitle={isOwnerHome ? 'Exploring — dame.is' : `${title} — Exploring — dame.is`}


### PR DESCRIPTION
Follow-up to #260. Applies the project's no-AI-slop writing rules to the copy on the `/exploring` personal repository landing.

## What changed
- **No em dashes** in the visible prose (intro, lead paragraph, section note, every lexicon blurb).
- **Cut copywriter phrasing**: "out in the atmosphere", "the shape of the thing", "wander through", "greet you", "the way I live online", and the "right now" filler in the empty state.
- **Heading names its content**: "Repo at a glance" is now "Stats".
- **Each blurb ends on a concrete fact.** A few examples:
  - profile: "My Bluesky description holds the short version; this record holds the rest."
  - observing: "Everything I've logged on iNaturalist that isn't a moth: birds, plants, fungi."
  - guestbook: "Your entry stays in your repo and links back to mine."
- Removed em dashes from my own code comments in the two files.

Left untouched: the `'—'` no-value glyphs, the site-wide `<page> — dame.is` document title, and the pre-existing generic-browser strings.

## Verification
- `vite build` passes.
- Re-rendered `/exploring` headless with mock atproto data: every section shows the new copy, no JS errors, layout unchanged.

Only two files change: `src/components/ExploringHome.jsx` and `src/pages/Exploring.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yJK4Et6SAMuq1wTGezbFB

---
_Generated by [Claude Code](https://claude.ai/code/session_015yJK4Et6SAMuq1wTGezbFB)_