### PR TITLE
Vitals: uniform expanded-bar padding; day-of-life instead of the freshness stamp

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -110,10 +110,10 @@
 
 .chrome-bar-secondary > .chrome-signals {
   width: 100%;
-  /* --space-2 up top (matching the tertiary crumb strip's height), but only
-     --space-1 below so the state/vitals bar beneath sits close to this row
-     rather than a full row's gap away. */
-  padding: var(--space-2) 0 var(--space-1);
+  /* Same vertical padding as the tertiary strip's crumbs (--space-2) so
+     this row and the timestamp/NSID strip stand the same height when each
+     is a single row. */
+  padding: var(--space-2) 0;
 }
 
 /* State / vitals bar — a second expanded tier beneath the LISTENING TO /
@@ -129,8 +129,9 @@
 
 .chrome-bar-state > .chrome-signals {
   width: 100%;
-  /* Tight to the row above (--space-1 top), normal breathing room below. */
-  padding: var(--space-1) 0 var(--space-2);
+  /* Same padding as the LISTENING TO / FOLLOWED BY row above and every other
+     expanded bar. */
+  padding: var(--space-2) 0;
 }
 
 /* Tertiary chrome: the scroll-driven breadcrumb strip. It's absolutely

--- a/src/components/VitalsPanel.css
+++ b/src/components/VitalsPanel.css
@@ -2,7 +2,8 @@
    expanded chrome tier beneath the LISTENING TO / FOLLOWED BY row (see
    .chrome-bar-state in ChromeBar.css). Reuses the atmosphere voice: lucide
    glyphs, small-caps units, mono tabular numbers, ink/accent on the earthy
-   palette, square corners. */
+   palette, square corners. The day-of-life signal on the right shares the
+   FOLLOWED BY / LISTENING TO label voice (via .chrome-signal). */
 
 .vitals {
   display: flex;
@@ -14,13 +15,6 @@
   font-size: var(--text-xs);
   color: var(--ink-muted);
   min-width: 0;
-  transition: opacity 200ms ease;
-}
-
-/* Stale (no fresh push for a while): the whole strip recedes so it never
-   presents a hours-old reading as if it were live. */
-.vitals.is-stale {
-  opacity: 0.5;
 }
 
 .vitals-empty {
@@ -87,20 +81,16 @@
   color: #c17d3f;
 }
 
-/* --- update stamp -------------------------------------------------------- */
-.vital-stamp {
+/* Day-of-life signal, pinned to the strip's right edge like FOLLOWED BY. */
+.vitals .chrome-signal-day {
   margin-left: auto;
-  color: var(--ink-faint);
-  font-variant-numeric: tabular-nums;
-  font-size: 0.95em;
-  white-space: nowrap;
 }
 
 @media (max-width: 700px) {
   .vitals {
     gap: var(--space-2) var(--space-4);
   }
-  .vital-stamp {
+  .vitals .chrome-signal-day {
     margin-left: 0;
     flex-basis: 100%;
   }

--- a/src/components/VitalsPanel.jsx
+++ b/src/components/VitalsPanel.jsx
@@ -4,13 +4,8 @@ import {
 } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { useDameState } from '../hooks/useDameState.js';
-import { relativeTime } from '../lib/time.js';
+import DayOfLifeTicker from './DayOfLifeTicker.jsx';
 import './VitalsPanel.css';
-
-// Past this many minutes with no fresh push, the panel reads as "last seen"
-// rather than "now" and dims — a phone that's asleep or dead shouldn't present
-// yesterday's heart rate as if it were live.
-const STALE_MINUTES = 30;
 
 const ACTIVITY_ICON = {
   stationary: Armchair,
@@ -34,8 +29,7 @@ export default function VitalsPanel() {
 
   // Nothing worth showing — no data yet, or every reading came back empty/0
   // (see normalizeVitals). Render an empty-but-present row so the atmosphere
-  // bar doesn't pop a whole extra line a beat after it opens, and so a
-  // stripped record doesn't leave a lonely "updated" stamp with no vitals.
+  // bar doesn't pop a whole extra line a beat after it opens.
   const hasAny =
     vitals &&
     (vitals.heartRate != null ||
@@ -53,22 +47,16 @@ export default function VitalsPanel() {
     );
   }
 
-  const minutesOld = vitals.sampledAt
-    ? (Date.now() - new Date(vitals.sampledAt).getTime()) / 60000
-    : Infinity;
-  const stale = !Number.isFinite(minutesOld) || minutesOld > STALE_MINUTES;
-  const ago = vitals.sampledAt ? relativeTime(vitals.sampledAt) : '';
-
   const ActivityIcon =
     (vitals.activity && ACTIVITY_ICON[vitals.activity]) || Activity;
   const BatteryIcon =
     vitals.batteryLevel != null ? batteryIcon(vitals.batteryLevel, vitals.charging) : null;
 
   return (
-    <div className={`vitals ${stale ? 'is-stale' : ''}`} aria-label="Current state from Dame's phone">
+    <div className="vitals" aria-label="Current state from Dame's phone">
       {vitals.heartRate != null && (
         <span className="vital vital-heart" aria-label={`Heart rate ${vitals.heartRate} beats per minute`}>
-          <Heartbeat bpm={vitals.heartRate} animate={!reduce && !stale} />
+          <Heartbeat bpm={vitals.heartRate} animate={!reduce} />
           <span className="vital-value">{vitals.heartRate}</span>
           <span className="vital-unit">bpm</span>
         </span>
@@ -109,19 +97,15 @@ export default function VitalsPanel() {
         </span>
       )}
 
-      {ago && (
-        <span className="vital-stamp" title={vitals.sampledAt || undefined}>
-          {stale ? 'last seen ' : 'updated '}
-          {ago}
-        </span>
-      )}
+      {/* Right edge: day of life, in the same small-caps label voice as
+          LISTENING TO / FOLLOWED BY one bar up. */}
+      <DayOfLifeTicker />
     </div>
   );
 }
 
 /** A heart with a gentle beat at the actual BPM — a subtle pulse, not a throb.
- *  Falls back to a still glyph under reduced-motion or when the reading is
- *  stale. */
+ *  Falls back to a still glyph under reduced-motion. */
 function Heartbeat({ bpm, animate }) {
   const beat = bpm > 20 && bpm < 260 ? 60 / bpm : null;
   if (!animate || !beat) {


### PR DESCRIPTION
Two display tweaks to the `is.dame.state` vitals bar (follow-up to #263).

- **Uniform padding** — revert the #263 padding tweak: the LISTENING TO / FOLLOWED BY row and the state/vitals bar both use `--space-2` top+bottom again, matching every other expanded bar (the asymmetric boundary shouldn't have shipped).
- **Day of life instead of the freshness stamp** — drop the staleness state (no dimming, no "updated / last seen"). In its place the right edge shows the day of life in the same small-caps label voice as FOLLOWED BY / LISTENING TO (reuses `DayOfLifeTicker`). The heartbeat no longer freezes on stale readings.

Display-only. Verified in a render: `❤ 69 · 🪑 stationary · 🔋 83% · 🔥 92 cal · 🔊 52 dB … DAY OF LIFE 12,123`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_