### PR TITLE
Rename x-ray → inspect; resume paints instantly + per-job inspect

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -610,7 +610,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                 >
                   <Info className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>
-                {/* Atmosphere x-ray — the marquee "turn the page inside out"
+                {/* Atmosphere inspect — the marquee "turn the page inside out"
                     mode. Toggling it reveals the AT Protocol records beneath
                     the page; entering it folds away any open panel and the
                     owner's edit mode (they compete for the same surface). */}
@@ -623,8 +623,8 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
                     toggleXray();
                   }}
                   aria-pressed={xrayActive}
-                  aria-label={xrayActive ? 'Exit x-ray' : 'X-ray this page'}
-                  title="Atmosphere x-ray — reveal the records under the page"
+                  aria-label={xrayActive ? 'Stop inspecting' : 'Inspect this page'}
+                  title="Inspect — reveal the records under the page"
                 >
                   <Microscope className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
                 </button>

--- a/src/components/Xray.css
+++ b/src/components/Xray.css
@@ -206,8 +206,9 @@
 .resume-xray-tag .nsid { color: var(--xr-ink); display: block; font-size: 0.68rem; }
 .resume-xray-tag .uri { color: var(--ink-muted); font-size: 0.66rem; word-break: break-all; }
 .resume-xray-tag .note { color: var(--ink-faint); display: block; font-size: 0.63rem; margin-top: 2px; }
+.resume-xray-tag-cta { display: block; margin-top: var(--space-2); font-size: 0.62rem; color: var(--accent); }
 :root[data-xray="on"] .resume-xray-tag {
-  max-height: 7rem;
+  max-height: 8rem;
   opacity: 1;
   margin-top: var(--space-2);
   padding-left: var(--space-3);
@@ -228,6 +229,15 @@
     margin-top: 0;
     padding-left: var(--space-4);
   }
+}
+
+/* Focused role: the ambient gutter tag gives way to the full substrate panel,
+   which spans the whole width below the (now fully-legible) entry. Dropping the
+   desktop gutter grid lets the panel run full-width instead of squeezing into
+   the 15rem column. */
+:root[data-xray-focus="on"] .resume-xray.is-xray-focus .resume-xray-content { opacity: 1; }
+@media (min-width: 860px) {
+  :root[data-xray="on"] .resume-xray.is-xray-focus { display: block; }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/components/XrayLayer.jsx
+++ b/src/components/XrayLayer.jsx
@@ -49,7 +49,7 @@ function XrayHud() {
   const atUri = derived.atUri || fallback?.atUri || null;
   const explorerPath = atUri ? explorerPathFromAtUri(atUri) : null;
 
-  function inspect() {
+  function openDetails() {
     setView('debug');
     openDock();
   }
@@ -72,7 +72,7 @@ function XrayHud() {
         aria-live="polite"
       >
         <span className="xray-hud-mark">
-          <Microscope aria-hidden="true" strokeWidth={1.75} /> x-ray
+          <Microscope aria-hidden="true" strokeWidth={1.75} /> inspect
         </span>
         {atUri ? (
           explorerPath ? (
@@ -86,8 +86,8 @@ function XrayHud() {
           <span className="xray-hud-aggregate">a live view over many records</span>
         )}
         <span className="xray-hud-spacer" />
-        <button type="button" className="xray-hud-inspect" onClick={inspect}>
-          inspect ↗
+        <button type="button" className="xray-hud-inspect" onClick={openDetails}>
+          details ↗
         </button>
       </div>
     </motion.div>

--- a/src/hooks/useXray.jsx
+++ b/src/hooks/useXray.jsx
@@ -75,17 +75,17 @@ export function XrayProvider({ children }) {
     setFocusUri(null);
   }, [location.pathname]);
 
-  // `x` toggles the mode from anywhere (ignoring keystrokes inside inputs).
-  // Esc pops a focused element back to the full-page x-ray (a no-op when
-  // nothing is focused, and it never preventDefaults, so the dock/modal Esc
-  // handlers still work).
+  // `i` (for inspect) toggles the mode from anywhere (ignoring keystrokes
+  // inside inputs). Esc pops a focused element back to the full-page view (a
+  // no-op when nothing is focused, and it never preventDefaults, so the
+  // dock/modal Esc handlers still work).
   useEffect(() => {
     function onKey(e) {
       if (e.key === 'Escape') {
         setFocusUri((f) => (f ? null : f));
         return;
       }
-      if (e.key !== 'x' && e.key !== 'X') return;
+      if (e.key !== 'i' && e.key !== 'I') return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       const tag = e.target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable) return;

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
+import { XraySubstratePanel } from '../components/XraySubstrate.jsx';
+import { useXray } from '../hooks/useXray.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
@@ -34,6 +36,44 @@ function ResumeXrayTag({ nsid, atUri, note }) {
       <span className="nsid">{nsid}</span>
       {parts && <span className="uri">…/{parts.nsid}{parts.rkey}</span>}
       {note && <span className="note">{note}</span>}
+      <span className="resume-xray-tag-cta">tap to inspect →</span>
+    </div>
+  );
+}
+
+/**
+ * A resume role / education entry wrapped for x-ray: while the mode is armed it
+ * recedes its prose and slides a record tag into the right margin (the ambient
+ * "this is its own is.dame.resume.job record" cue). Tapping it focuses that
+ * record — the tag gives way to the full you-are-here substrate panel and the
+ * other entries recede — mirroring how the feed rows inspect. Outside x-ray it
+ * renders as a plain `.resume-role`.
+ */
+function ResumeXrayRole({ atUri, nsid, note, children }) {
+  const xray = useXray();
+  const inspectable = xray.active && !!atUri;
+  const focused = inspectable && xray.focusUri === atUri;
+  return (
+    <div
+      className={`resume-role resume-xray${focused ? ' is-xray-focus' : ''}`}
+      data-atproto={atUri ? '' : undefined}
+      data-at-uri={atUri || undefined}
+      onClickCapture={
+        inspectable
+          ? (e) => {
+              // Let real links (org / institution / portfolio work) and the
+              // open panel's own links through; anything else inspects.
+              if (e.target.closest('a, button, .xray-substrate')) return;
+              e.preventDefault();
+              e.stopPropagation();
+              xray.toggleFocus(atUri);
+            }
+          : undefined
+      }
+    >
+      <div className="resume-xray-content">{children}</div>
+      {inspectable && !focused && <ResumeXrayTag nsid={nsid} atUri={atUri} note={note} />}
+      {focused && <XraySubstratePanel atUri={atUri} />}
     </div>
   );
 }
@@ -135,7 +175,11 @@ export default function Resume() {
 
   const { items, status } = useLiveFeed({
     name: 'resume',
-    strategy: 'live-first',
+    // Paint the prebuilt /data/resume.json snapshot instantly, then confirm
+    // with a live re-fetch — the resume rarely changes, so a skeleton on every
+    // cold load (which 'live-first' forced, using the snapshot only on error)
+    // was needless. This is what the snapshot was written for.
+    strategy: 'snapshot-first',
     deps: [slug || ''],
     fetchLive: fetchResumeBundle,
     mapItems: (data) => (data && Array.isArray(data.resumes) ? data : null),
@@ -242,45 +286,38 @@ export default function Resume() {
                     </h3>
                   </div>
                   {org.roles.map((role) => (
-                    <div
-                      className="resume-role resume-xray"
+                    <ResumeXrayRole
                       key={role.uri}
-                      data-atproto={role.uri ? '' : undefined}
-                      data-at-uri={role.uri || undefined}
+                      atUri={role.uri}
+                      nsid="is.dame.resume.job"
+                      note="canonical role — the bullets live here, shared across resume versions"
                     >
-                      <div className="resume-xray-content">
-                        <div className="resume-role-head">
-                          <h4 className="resume-role-title">{role.title}</h4>
-                          <span className="resume-role-dates gutter">{role.dateRange}</span>
-                        </div>
-                        <div className="resume-role-meta">
-                          {[role.employmentType, role.locationType, role.location]
-                            .filter(Boolean)
-                            .join(' · ')}
-                        </div>
-                        {role.summary && <p className="resume-role-summary">{role.summary}</p>}
-                        {role.highlights.length > 0 && (
-                          <ul className="resume-highlights">
-                            {role.highlights.map((h) => (
-                              <li
-                                key={h.refId || h.id}
-                                className={`resume-highlight ${h.featured ? 'is-featured' : ''} ${
-                                  h.metric ? 'is-metric' : ''
-                                }`}
-                              >
-                                {h.text}
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                        <RoleWork links={role.links} />
+                      <div className="resume-role-head">
+                        <h4 className="resume-role-title">{role.title}</h4>
+                        <span className="resume-role-dates gutter">{role.dateRange}</span>
                       </div>
-                      <ResumeXrayTag
-                        nsid="is.dame.resume.job"
-                        atUri={role.uri}
-                        note="canonical role — the bullets live here, shared across resume versions"
-                      />
-                    </div>
+                      <div className="resume-role-meta">
+                        {[role.employmentType, role.locationType, role.location]
+                          .filter(Boolean)
+                          .join(' · ')}
+                      </div>
+                      {role.summary && <p className="resume-role-summary">{role.summary}</p>}
+                      {role.highlights.length > 0 && (
+                        <ul className="resume-highlights">
+                          {role.highlights.map((h) => (
+                            <li
+                              key={h.refId || h.id}
+                              className={`resume-highlight ${h.featured ? 'is-featured' : ''} ${
+                                h.metric ? 'is-metric' : ''
+                              }`}
+                            >
+                              {h.text}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      <RoleWork links={role.links} />
+                    </ResumeXrayRole>
                   ))}
                 </div>
               ))}
@@ -293,46 +330,39 @@ export default function Resume() {
             <h2 className="resume-section-title small-caps">Education</h2>
             <div className="resume-orgs">
               {resolved.education.map((e) => (
-                <div
-                  className="resume-role resume-xray"
+                <ResumeXrayRole
                   key={e.uri}
-                  data-atproto={e.uri ? '' : undefined}
-                  data-at-uri={e.uri || undefined}
+                  atUri={e.uri}
+                  nsid="is.dame.resume.education"
+                  note="canonical education record"
                 >
-                  <div className="resume-xray-content">
-                    <div className="resume-role-head">
-                      <h4 className="resume-role-title">
-                        {e.value.institutionUrl ? (
-                          <a href={e.value.institutionUrl} target="_blank" rel="noreferrer noopener">
-                            {e.value.institution}
-                          </a>
-                        ) : (
-                          e.value.institution
-                        )}
-                      </h4>
-                      {e.dateRange && <span className="resume-role-dates gutter">{e.dateRange}</span>}
-                    </div>
-                    {(e.value.studyType || e.value.area) && (
-                      <p className="resume-role-summary">
-                        {[e.value.studyType, e.value.area].filter(Boolean).join(', ')}
-                      </p>
-                    )}
-                    {e.highlights.length > 0 && (
-                      <ul className="resume-highlights">
-                        {e.highlights.map((h) => (
-                          <li key={h.refId || h.id} className="resume-highlight">
-                            {h.text}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                  <div className="resume-role-head">
+                    <h4 className="resume-role-title">
+                      {e.value.institutionUrl ? (
+                        <a href={e.value.institutionUrl} target="_blank" rel="noreferrer noopener">
+                          {e.value.institution}
+                        </a>
+                      ) : (
+                        e.value.institution
+                      )}
+                    </h4>
+                    {e.dateRange && <span className="resume-role-dates gutter">{e.dateRange}</span>}
                   </div>
-                  <ResumeXrayTag
-                    nsid="is.dame.resume.education"
-                    atUri={e.uri}
-                    note="canonical education record"
-                  />
-                </div>
+                  {(e.value.studyType || e.value.area) && (
+                    <p className="resume-role-summary">
+                      {[e.value.studyType, e.value.area].filter(Boolean).join(', ')}
+                    </p>
+                  )}
+                  {e.highlights.length > 0 && (
+                    <ul className="resume-highlights">
+                      {e.highlights.map((h) => (
+                        <li key={h.refId || h.id} className="resume-highlight">
+                          {h.text}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </ResumeXrayRole>
               ))}
             </div>
           </section>


### PR DESCRIPTION
Three related changes.

- **Rename the framing "x-ray" → "inspect"** — the icon is a microscope now, so the label should match. The toggle button, the page HUD mark, and the keyboard shortcut (now **`i`**) all read "inspect"; the HUD's deeper-record button is labelled "details" to stay distinct from the mode name. Internal identifiers (`useXray`, `data-xray`, `.xray-*` classes, filenames) are deliberately left as-is — implementation detail, not worth the churn/risk.
- **`/available` paints instantly.** It fetched live with a skeleton on every cold load, touching the prebuilt `resume.json` snapshot only on error — even though that snapshot was written expressly so the page "paints instantly." Flipped it to `snapshot-first` (what blogging/creating already do), so the snapshot shows immediately and the live fetch just confirms it. (This also fixes the skeleton that had been blocking verification.)
- **Per-job inspect on the resume.** Each role / education entry is now individually inspectable: a `ResumeXrayRole` wrapper keeps the ambient right-margin record tag AND makes the entry tap-to-focus — the tag gives way to the full "you are here in the repo" substrate panel for that `is.dame.resume.job` / `.education` record, the entry returns to full clarity, and the others recede. Mirrors how the feed rows inspect.

## Verification

Builds clean against current `main`. With the snapshot-first fix the resume now renders from `resume.json` in the sandbox, so I could finally drive it: confirmed it paints without a skeleton, each role shows its `is.dame.resume.job` gutter tag under inspect, and tapping a role opens its repo-locus panel (`pds → repo → collection is.dame.resume.job → record … ← you are here`) while the others recede. Verified on desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_