### PR TITLE
Render record-page metadata as one flowing phrase, not bulleted atoms

### DIFF
--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -237,15 +237,6 @@
   color: var(--ink-faint);
 }
 
-.record-page-meta-nsid {
-  font-family: var(--mono);
-  /* No explicit base size (inherits from .record-page-meta); scale the
-     inherited size so serif-only mode compensates like the other --mono
-     elements. calc(1em * 1) is a no-op in the default mono voice. */
-  font-size: calc(1em * var(--mono-scale));
-  letter-spacing: 0;
-}
-
 .record-page-aturi {
   margin-top: var(--space-7);
   padding-top: var(--space-4);

--- a/src/pages/Record.jsx
+++ b/src/pages/Record.jsx
@@ -16,7 +16,7 @@ import AturiActions from '../components/AturiActions.jsx';
 import { RecordSkeleton } from '../components/Skeleton.jsx';
 import { resolvePds, getRecord, getPostThread, explorerPathFromAtUri } from '../lib/atproto.js';
 import { ME_DID } from '../config.js';
-import { formatDateLong, formatTime, relativeTime } from '../lib/time.js';
+import { formatDateFull, formatTime, relativeDay, relativeTime } from '../lib/time.js';
 import { dayOfLife } from '../lib/dayOfLife.js';
 import { VERB_TO_COLLECTION, VERB_LABELS, recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { verbConfig, primaryNsid } from '../lib/verbRegistry.js';
@@ -217,7 +217,7 @@ export default function Record({ verb, nsid, source }) {
           </div>
         )}
 
-        {item && <RecordMeta collection={collection} createdAt={createdAt} />}
+        {item && <RecordMeta createdAt={createdAt} />}
 
         {item && <AturiActions atUri={atUri} />}
 
@@ -623,16 +623,26 @@ function condensePostView(view) {
   };
 }
 
-function RecordMeta({ collection, createdAt }) {
+/**
+ * The single-record publication stamp, rendered as one flowing phrase:
+ *
+ *   5 days ago at 10:18 PM on July 10, 2026 (Day 12,118)
+ *
+ * A single <span> deliberately — the `.blog-article-meta` container adds a
+ * bullet before every span after the first, so splitting the atoms into
+ * separate spans (as this once did) produced a doubled "•·" separator on top
+ * of hardcoded middots. One span, connective words, no bullets. Mirrors the
+ * blog/creating <DocumentMeta> phrasing so every record page reads the same.
+ */
+function RecordMeta({ createdAt }) {
   if (!createdAt) return null;
   const dayNum = dayOfLife(createdAt);
   return (
     <div className="blog-article-meta record-page-meta">
-      {collection && <span className="record-page-meta-nsid">{collection}</span>}
-      <span>· {relativeTime(createdAt)}</span>
-      <span>· {formatTime(createdAt)}</span>
-      <span>· {formatDateLong(createdAt)}</span>
-      {dayNum && <span>· Day {dayNum.toLocaleString()}</span>}
+      <span>
+        {relativeDay(createdAt)} at {formatTime(createdAt)} on {formatDateFull(createdAt)}
+        {dayNum ? ` (Day ${dayNum.toLocaleString()})` : ''}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## What & why

On individual record pages (e.g. `/logging/3mqb3hdakb52d`) the metadata row showed doubled bullet separators and a redundant nsid label:

```
is.dame.now •· 5d ago •· 10:18 PM •· 10 July 2026 •· Day 12,118
```

The atoms were rendered as separate `<span>`s inside `.blog-article-meta`, whose `span + span::before` rule adds a `•` before every span after the first — **and** each span also carried a hardcoded `· ` middot, producing the doubled `•·` between every atom.

## Change

Collapse the row into a single `<span>` that reads as one sentence:

```
5 days ago at 10:18 PM on July 10, 2026 (Day 12,118)
```

With one span the CSS bullet rule never fires, so no separators are needed — connective words (`at`, `on`, parenthesised day) carry the flow. Switches `relativeTime`→`relativeDay` and `formatDateLong`→`formatDateFull` to match the existing blog/creating `DocumentMeta` phrasing, so every record page reads consistently. Drops the now-dead `.record-page-meta-nsid` CSS and the nsid label (the AT URI + "Inspect Data" below already expose the collection).

## Verification

- `npm run build:offline` compiles cleanly.
- Exercised the real `time.js` + `dayOfLife.js` helpers against a representative `is.dame.now` timestamp — output is an exact match for the target string, Day 12,118 included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abekq1VeTQ4eeJnk5aT6EV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abekq1VeTQ4eeJnk5aT6EV)_