### PR TITLE
Inspect: HUD copy + marginalia on the reading documents

### DIFF
--- a/src/components/Xray.css
+++ b/src/components/Xray.css
@@ -252,6 +252,69 @@
 :root[data-xray-focus="on"] .resume-xray.is-xray-focus .resume-xray-content { opacity: 1; }
 
 /* ----------------------------------------------------------------------
+   Document marginalia (blog post / work) — see InspectMargin. The page is one
+   record; a single margin note names it beside the prose like a book gloss,
+   and the document text is never dimmed (the note is additive). The reading
+   column is --measure, centred in the 72rem main, so on wide screens there's a
+   right margin to float into; narrower screens stack the note atop the doc.
+   ---------------------------------------------------------------------- */
+.blog-article, .creating-work-page { position: relative; }
+
+.doc-inspect-margin {
+  font-family: var(--code);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  margin: 0;
+  transition: opacity 0.28s var(--xr-ease), max-height 0.3s var(--xr-ease), margin 0.3s var(--xr-ease);
+}
+:root[data-xray="on"] .doc-inspect-margin {
+  max-height: 42rem;
+  opacity: 1;
+  pointer-events: auto;
+  margin: 0 0 var(--space-5);
+}
+.doc-inspect-note {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  background: var(--xr-field);
+  border: 0;
+  border-left: 2px solid var(--xr-frame);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+.doc-inspect-note .nsid { color: var(--xr-ink); display: block; font-size: 0.7rem; }
+.doc-inspect-note .uri { color: var(--ink-muted); display: block; font-size: 0.66rem; word-break: break-all; margin-top: 1px; }
+.doc-inspect-note .note { color: var(--ink-faint); display: block; font-size: 0.64rem; margin-top: 3px; }
+.doc-inspect-note .cta { color: var(--accent); display: block; font-size: 0.64rem; margin-top: var(--space-2); }
+.doc-inspect-note:hover .nsid { text-decoration: underline; }
+.doc-inspect-margin .xray-substrate { margin-top: 0; }
+
+/* Wide: float the note into the outer right margin as a true margin gloss. */
+@media (min-width: 1080px) {
+  .doc-inspect-margin {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    width: 16rem;
+    max-height: none;
+    overflow: visible;
+    margin: 0 0 0 var(--space-5);
+  }
+  :root[data-xray="on"] .doc-inspect-margin { max-height: none; margin: 0 0 0 var(--space-5); }
+  .doc-inspect-margin.is-xray-focus { width: 18rem; }
+  .doc-inspect-note {
+    background: transparent;
+    border-left: 1px dashed var(--xr-frame);
+    padding: 0 0 0 var(--space-4);
+  }
+}
+
+/* ----------------------------------------------------------------------
    Page HUD — a slim status strip naming the record behind the page. It
    rides the shared BottomSheet chrome (.bottom-sheet-wrap/-panel) so it
    expands up out of the bottom bar like the search/filter/info panels;

--- a/src/components/XrayLayer.jsx
+++ b/src/components/XrayLayer.jsx
@@ -72,7 +72,7 @@ function XrayHud() {
         aria-live="polite"
       >
         <span className="xray-hud-mark">
-          <Microscope aria-hidden="true" strokeWidth={1.75} /> inspect
+          <Microscope aria-hidden="true" strokeWidth={1.75} /> inspecting
         </span>
         {atUri ? (
           explorerPath ? (
@@ -83,7 +83,7 @@ function XrayHud() {
             <AtUriMono atUri={atUri} />
           )
         ) : (
-          <span className="xray-hud-aggregate">a live view over many records</span>
+          <span className="xray-hud-aggregate">the protocol data</span>
         )}
         <span className="xray-hud-spacer" />
         <button type="button" className="xray-hud-inspect" onClick={openDetails}>

--- a/src/components/XraySubstrate.jsx
+++ b/src/components/XraySubstrate.jsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { ME_DID, ME_HANDLE } from '../config.js';
 import { resolvePds, explorerPathFromAtUri } from '../lib/atproto.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
+import { useXray } from '../hooks/useXray.jsx';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { atUriParts, parseAtUri, shortenCid, shortenDid } from '../lib/xray.js';
 
 /**
@@ -26,6 +28,47 @@ export function XrayTag({ atUri, onOpen }) {
         </button>
       )}
     </div>
+  );
+}
+
+/**
+ * Marginalia for a reading document (a blog post, a work) — the page is one
+ * record, so this floats a single margin note beside the prose naming that
+ * record, like a gloss in a book. Tapping it inspects: the note gives way to
+ * the full you-are-here substrate panel, still in the margin. On narrow
+ * screens (no room for a true margin) it stacks at the top of the document.
+ * The document text itself is never dimmed — the note is additive marginalia.
+ */
+export function InspectMargin({ atUri, cid, note }) {
+  const xray = useXray();
+  const parts = atUriParts(atUri);
+  if (!parts) return null;
+  const focused = xray.active && xray.focusUri === atUri;
+  const nsid = parts.nsid || nsidFromAtUri(atUri);
+  return (
+    <aside
+      className={`doc-inspect-margin${focused ? ' is-xray-focus' : ''}`}
+      data-atproto=""
+      data-at-uri={atUri}
+      data-nsid={nsid || undefined}
+      aria-label="record"
+    >
+      {focused ? (
+        <XraySubstratePanel atUri={atUri} cid={cid} />
+      ) : (
+        <button
+          type="button"
+          className="doc-inspect-note"
+          onClick={() => xray.focus(atUri)}
+          tabIndex={xray.active ? 0 : -1}
+        >
+          <span className="nsid">{nsid}</span>
+          <span className="uri">…/{parts.nsid}{parts.rkey}</span>
+          {note && <span className="note">{note}</span>}
+          <span className="cta">tap to inspect →</span>
+        </button>
+      )}
+    </aside>
   );
 }
 

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import LeafletDocument from '../components/LeafletDocument.jsx';
 import Comments from '../components/Comments.jsx';
 import DocumentMeta from '../components/DocumentMeta.jsx';
+import { InspectMargin } from '../components/XraySubstrate.jsx';
 import { BlogPostSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { resolvePds, listRecords } from '../lib/atproto.js';
@@ -153,6 +154,7 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
       headTitle={`${title} — dame.is`}
     >
       <article className="blog-article reveal">
+        <InspectMargin atUri={record?.uri} cid={record?.cid} note="the whole post is one record" />
         <DocumentMeta date={created} />
         {/* The `description` field is intentionally not rendered here — it's the
             open-graph / feed-summary blurb, and on the post itself it just

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -4,6 +4,7 @@ import PageShell from '../components/PageShell.jsx';
 import { CreatingWorkSkeleton } from '../components/Skeleton.jsx';
 import LeafletDocument from '../components/LeafletDocument.jsx';
 import DocumentMeta from '../components/DocumentMeta.jsx';
+import { InspectMargin } from '../components/XraySubstrate.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
 import { fetchSnapshot } from '../lib/snapshot.js';
 import { resolvePds, listRecords, rkeyFromAtUri } from '../lib/atproto.js';
@@ -94,6 +95,7 @@ export default function CreatingWork() {
       headTitle={v?.title ? `${v.title} — dame.is` : `${slug} — dame.is`}
     >
       <article className="creating-work-page reveal">
+        <InspectMargin atUri={record?.uri} cid={record?.cid} note="the whole work is one record" />
         <DocumentMeta date={v?.createdAt} />
         {/* The summary is metadata — the feed-card / open-graph blurb, not page
             copy. For standard/leaflet docs it's auto-derived from the body's


### PR DESCRIPTION
Two changes.

- **HUD copy.** The bottom bar read "inspect · a live view over many records". Now it says what it is: the mode reads **"inspecting"**, and the aggregate fallback (pages with no single backing record, like the home feed) reads **"the protocol data"** — so it lands as "inspecting the protocol data". Record pages still show the at-uri after "inspecting".
- **Marginalia on the reading documents.** The blog post (`/blogging/:slug`) and work (`/creating/:slug`) pages are single prose documents — one `site.standard.document` record each — so inspect gives them a **book-style margin gloss** rather than the ledger/collapse treatment. A new `InspectMargin` floats one note into the outer right margin naming the record; tapping it opens the full "you are here in the repo" panel, still in the margin. The document text is **never dimmed** — the note is additive marginalia. The reading column is `--measure`, centred in the 72rem main, so on wide screens (≥1080px) there's a right margin to float into; narrower screens stack the note atop the document.

## Verification

Builds clean against current `main`. Drove the dev build on a real blog post (`/blogging/why-i-started-posting-like-its-the-2000s-again`, from the `blogs.json` snapshot): confirmed the ambient margin note sits in the outer right margin (note left-edge past the article's right edge), the post text stays fully readable, tapping the note opens the repo-locus panel in the margin, and the HUD reads "INSPECTING at://…/site.standard.document/…". Same `InspectMargin` is wired into the work pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_