### PR TITLE
State dashboard on /logging + vitals-bar mobile polish

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -375,6 +375,14 @@
   }
 }
 
+/* Day of life lives at the right edge of the vitals bar on desktop (see
+   VitalsPanel). The copy rendered here in the secondary row exists only for the
+   mobile stack, where it becomes the third line under LISTENING TO / FOLLOWED
+   BY — hidden here at desktop widths, shown in the mobile block below. */
+.chrome-signals-secondary .chrome-signal-day {
+  display: none;
+}
+
 .chrome-signal {
   display: inline-flex;
   align-items: baseline;
@@ -685,8 +693,10 @@
   .chrome-signals-secondary {
     flex-direction: column;
     align-items: stretch;
-    row-gap: var(--space-2);
-    gap: var(--space-2);
+    /* Tight 3-line stack (LISTENING TO / FOLLOWED BY / DAY OF LIFE) — the lines
+       sit on their own line-height with no extra gap between them. */
+    row-gap: 0;
+    gap: 0;
   }
   /* In a column flex layout each child sizes to its intrinsic content
      unless explicitly constrained, which lets long now-playing strings
@@ -696,6 +706,11 @@
     width: 100%;
     max-width: 100%;
     min-width: 0;
+  }
+  /* On mobile the day of life joins this stack as the third line (it's hidden
+     from the vitals bar); reveal the secondary-row copy here. */
+  .chrome-signals-secondary .chrome-signal-day {
+    display: inline-flex;
   }
 }
 

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -18,6 +18,7 @@ import NowStatus from './NowStatus.jsx';
 import NowPlaying from './NowPlaying.jsx';
 import ProfileStats from './ProfileStats.jsx';
 import VitalsPanel from './VitalsPanel.jsx';
+import DayOfLifeTicker from './DayOfLifeTicker.jsx';
 import LayoutToggle from './LayoutToggle.jsx';
 import PaperToggle from './PaperToggle.jsx';
 import { PAPER_ENABLED } from '../hooks/usePaper.jsx';
@@ -263,6 +264,11 @@ export default function ChromeBar() {
                 >
                   <NowPlaying />
                   <ProfileStats />
+                  {/* Day of life joins the LISTENING TO / FOLLOWED BY stack —
+                      but only on mobile. On desktop it lives at the right edge
+                      of the vitals bar below instead; this copy is hidden there
+                      via CSS (and the vitals-bar copy is hidden on mobile). */}
+                  <DayOfLifeTicker />
                 </motion.div>
               </div>
               {/* Second expanded tier: the iPhone state / vitals bar. It lives

--- a/src/components/StateStats.css
+++ b/src/components/StateStats.css
@@ -1,0 +1,320 @@
+/* State dashboard — the rich header on /logging, sibling to ListeningStats on
+   /listening. Flat, ruled, serif titles, mono small-caps labels; single-hue
+   (the mossy accent) marks on the earthy palette. Square corners (--radius: 0). */
+
+.state-stats {
+  margin-bottom: var(--space-7);
+  padding-bottom: var(--space-5);
+  border-bottom: 1px solid var(--rule);
+}
+
+.state-stats-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-5);
+}
+
+.state-stats-title {
+  font-family: var(--serif);
+  font-size: var(--text-xl);
+  margin: 0;
+  color: var(--ink);
+}
+
+/* Segmented 24h / 7d toggle. */
+.state-stats-toggle {
+  display: inline-flex;
+  border: 1px solid var(--rule);
+}
+
+.state-stats-tab {
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.1em;
+  font-size: var(--text-xs);
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  border: 0;
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.state-stats-tab + .state-stats-tab {
+  border-left: 1px solid var(--rule);
+}
+
+.state-stats-tab:hover {
+  color: var(--ink);
+}
+
+.state-stats-tab.is-active {
+  background: var(--accent);
+  color: var(--page);
+}
+
+.state-stats-empty {
+  color: var(--ink-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ---- Headline tiles ---------------------------------------------- */
+
+.state-stats-tiles {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  margin-bottom: var(--space-6);
+}
+
+.state-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: var(--space-4) var(--space-2);
+  background: var(--page);
+  text-align: center;
+  min-width: 0;
+}
+
+.state-tile-value {
+  font-family: var(--serif);
+  font-size: var(--text-2xl);
+  line-height: 1;
+  font-weight: 600;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.state-tile-unit {
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.1em;
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+}
+
+/* ---- Panels (chart + activity) ----------------------------------- */
+
+.state-stats-panels {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: var(--space-6);
+}
+
+.state-panel {
+  min-width: 0;
+}
+
+.state-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.45em;
+  font-family: var(--mono-ui);
+  font-variant: all-small-caps;
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.state-panel-glyph {
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+/* ---- Heart-rate area chart --------------------------------------- */
+
+.state-chart {
+  overflow: visible;
+}
+
+.state-chart-plot {
+  position: relative;
+  width: 100%;
+}
+
+.state-chart-svg {
+  display: block;
+  touch-action: pan-y;
+}
+
+.state-chart-grid {
+  stroke: var(--rule-soft);
+  stroke-width: 1;
+}
+
+.state-chart-ylabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  fill: var(--ink-faint);
+}
+
+.state-chart-area {
+  fill: var(--accent);
+  fill-opacity: 0.13;
+  stroke: none;
+}
+
+.state-chart-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.state-chart-dot {
+  fill: var(--accent);
+}
+
+.state-chart-dot-last {
+  fill: var(--accent);
+  stroke: var(--page);
+  stroke-width: 1.5;
+}
+
+.state-chart-cross {
+  stroke: var(--ink-faint);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+
+.state-chart-marker {
+  fill: var(--accent);
+  stroke: var(--page);
+  stroke-width: 2;
+}
+
+.state-chart-tip {
+  position: absolute;
+  transform: translate(-50%, calc(-100% - 10px));
+  background: var(--surface-raised);
+  border: 1px solid var(--rule);
+  padding: 0.2rem 0.45rem;
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 2;
+  display: flex;
+  align-items: baseline;
+  gap: 0.3em;
+}
+
+.state-chart-tip strong {
+  font-family: var(--serif);
+  font-size: var(--text-sm);
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.state-chart-tip-time {
+  color: var(--ink-faint);
+}
+
+.state-chart-xaxis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-1);
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+}
+
+.state-chart-empty {
+  color: var(--ink-faint);
+  font-style: italic;
+  margin: var(--space-3) 0;
+}
+
+/* ---- Activity ranked bars ---------------------------------------- */
+
+.state-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.state-bar-row {
+  display: grid;
+  grid-template-columns: minmax(5rem, auto) 1fr 2.4rem;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.state-bar-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--serif);
+  font-size: var(--text-base);
+  color: var(--ink-soft);
+  text-transform: lowercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.state-bar-glyph {
+  color: var(--ink-faint);
+  flex: 0 0 auto;
+}
+
+.state-bar-track {
+  height: 0.5rem;
+  background: var(--rule-soft);
+  min-width: 0;
+}
+
+.state-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 500ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.state-bar-pct {
+  font-family: var(--mono);
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* ---- Responsive -------------------------------------------------- */
+
+@media (max-width: 760px) {
+  .state-stats-panels {
+    grid-template-columns: 1fr;
+    gap: var(--space-6);
+  }
+}
+
+@media (max-width: 560px) {
+  /* Tiles reflow to a tidy 2-across (last one spans the row) so the big
+     numbers stay legible on phones. */
+  .state-stats-tiles {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .state-tile:last-child {
+    grid-column: 1 / -1;
+  }
+  .state-tile-value {
+    font-size: var(--text-xl);
+  }
+}

--- a/src/components/StateStats.jsx
+++ b/src/components/StateStats.jsx
@@ -1,0 +1,354 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useReducedMotion } from 'motion/react';
+import { Heart, Flame, Volume2, Activity, Footprints, Bike, Car, Armchair } from 'lucide-react';
+import './StateStats.css';
+
+/**
+ * Rich state dashboard — the header on /logging, mirroring ListeningStats on
+ * /listening. Derives everything client-side from the is.dame.state history
+ * (heart rate, activity, ambient sound, calories) over a selectable window:
+ * headline tiles, a heart-rate area chart over time, and a ranked breakdown of
+ * time-in-activity. Single-hue (the site accent) throughout — no chart library.
+ */
+
+const WINDOWS = [
+  { hours: 24, label: '24h' },
+  { hours: 24 * 7, label: '7 days' },
+];
+
+const ACTIVITY_ICON = {
+  stationary: Armchair,
+  walking: Footprints,
+  running: Footprints,
+  cycling: Bike,
+  automotive: Car,
+};
+
+export default function StateStats({ samples }) {
+  const [hours, setHours] = useState(24);
+  const stats = useMemo(() => computeStats(samples, hours), [samples, hours]);
+
+  // Nothing yet — let the feed's own skeleton carry the wait.
+  if (!samples || samples.length === 0) return null;
+
+  return (
+    <section className="state-stats" aria-label="State statistics">
+      <div className="state-stats-head">
+        <h2 className="state-stats-title">Recent state</h2>
+        <div className="state-stats-toggle" role="tablist" aria-label="Time window">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.hours}
+              type="button"
+              role="tab"
+              aria-selected={hours === w.hours}
+              className={`state-stats-tab ${hours === w.hours ? 'is-active' : ''}`}
+              onClick={() => setHours(w.hours)}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {stats.count === 0 ? (
+        <p className="state-stats-empty">No readings in the last {hours === 24 ? '24 hours' : '7 days'}.</p>
+      ) : (
+        <>
+          <div className="state-stats-tiles">
+            <Tile value={stats.avgHr} unit="avg bpm" />
+            <Tile value={stats.peakHr} unit="peak bpm" />
+            <Tile value={stats.calLatest} unit="cal today" />
+            <Tile value={stats.avgDb} unit="avg dB" />
+            <Tile value={stats.count} unit={stats.count === 1 ? 'reading' : 'readings'} />
+          </div>
+
+          <div className="state-stats-panels">
+            <div className="state-panel state-panel-chart">
+              <h3 className="state-panel-title">
+                <Heart className="state-panel-glyph" size={13} strokeWidth={1.9} aria-hidden="true" />
+                Heart rate
+              </h3>
+              <HeartRateChart series={stats.hrSeries} t0={stats.t0} t1={stats.t1} />
+            </div>
+
+            <div className="state-panel state-panel-activity">
+              <h3 className="state-panel-title">
+                <Activity className="state-panel-glyph" size={13} strokeWidth={1.9} aria-hidden="true" />
+                Activity
+              </h3>
+              <ActivityBars rows={stats.activity} />
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Tiles                                                               */
+/* ------------------------------------------------------------------ */
+
+function Tile({ value, unit }) {
+  const has = value != null && Number.isFinite(value);
+  const n = useCountUp(has ? value : 0);
+  return (
+    <div className="state-tile">
+      <span className="state-tile-value">{has ? n.toLocaleString() : '—'}</span>
+      <span className="state-tile-unit">{unit}</span>
+    </div>
+  );
+}
+
+/** Short eased count-up when the target changes; snaps under reduced-motion. */
+function useCountUp(target, ms = 600) {
+  const reduce = useReducedMotion();
+  const [n, setN] = useState(typeof target === 'number' ? target : 0);
+  const fromRef = useRef(0);
+  const startRef = useRef(0);
+  const rafRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof target !== 'number') return undefined;
+    if (reduce) {
+      setN(target);
+      return undefined;
+    }
+    cancelAnimationFrame(rafRef.current);
+    fromRef.current = n;
+    startRef.current = performance.now();
+    function tick(t) {
+      const p = Math.min(1, (t - startRef.current) / ms);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setN(Math.round(fromRef.current + (target - fromRef.current) * eased));
+      if (p < 1) rafRef.current = requestAnimationFrame(tick);
+    }
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target, ms, reduce]);
+
+  return reduce && typeof target === 'number' ? target : n;
+}
+
+/* ------------------------------------------------------------------ */
+/* Heart-rate area chart (single series, accent, hover crosshair)      */
+/* ------------------------------------------------------------------ */
+
+const CHART_H = 168;
+const PAD = { l: 8, r: 10, t: 16, b: 8 };
+
+function HeartRateChart({ series, t0, t1 }) {
+  const plotRef = useRef(null);
+  const [w, setW] = useState(0);
+  const [hover, setHover] = useState(null); // index into series
+
+  // Draw in real pixels (measured width, fixed height) so uniform scaling
+  // keeps dots circular — a stretched viewBox would deform them.
+  useLayoutEffect(() => {
+    const el = plotRef.current;
+    if (!el) return undefined;
+    const measure = () => setW(el.clientWidth || 0);
+    measure();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    if (ro) ro.observe(el);
+    return () => {
+      if (ro) ro.disconnect();
+    };
+  }, []);
+
+  if (!series || series.length === 0) {
+    return <p className="state-chart-empty">No heart-rate readings in this window.</p>;
+  }
+
+  const values = series.map((p) => p.v);
+  const dataMin = Math.min(...values);
+  const dataMax = Math.max(...values);
+  // Nice, padded y-range clamped to a plausible band.
+  const yMin = Math.max(30, Math.floor((dataMin - 6) / 10) * 10);
+  const yMax = Math.min(210, Math.ceil((dataMax + 6) / 10) * 10);
+  const ySpan = Math.max(1, yMax - yMin);
+  const tSpan = Math.max(1, t1 - t0);
+  const avg = Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+  const H = CHART_H;
+  const ready = w > 0;
+
+  const x = (t) => PAD.l + ((t - t0) / tSpan) * Math.max(1, w - PAD.l - PAD.r);
+  const y = (v) => H - PAD.b - ((v - yMin) / ySpan) * (H - PAD.t - PAD.b);
+  const baseY = H - PAD.b;
+
+  const pts = ready ? series.map((p) => ({ ...p, cx: x(p.t), cy: y(p.v) })) : [];
+  const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.cx.toFixed(1)},${p.cy.toFixed(1)}`).join(' ');
+  const area = pts.length
+    ? `M${pts[0].cx.toFixed(1)},${baseY} ${pts
+        .map((p) => `L${p.cx.toFixed(1)},${p.cy.toFixed(1)}`)
+        .join(' ')} L${pts[pts.length - 1].cx.toFixed(1)},${baseY} Z`
+    : '';
+  const ticks = [yMax, avg, yMin].filter((v, i, arr) => arr.indexOf(v) === i);
+  const single = pts.length === 1;
+
+  function onMove(e) {
+    if (!ready || !plotRef.current) return;
+    const rect = plotRef.current.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    let best = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < pts.length; i++) {
+      const d = Math.abs(pts[i].cx - px);
+      if (d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    setHover(best);
+  }
+
+  const hp = hover != null && pts[hover] ? pts[hover] : null;
+
+  return (
+    <div className="state-chart">
+      <div className="state-chart-plot" ref={plotRef} style={{ height: H }}>
+        {ready && (
+          <svg
+            className="state-chart-svg"
+            width={w}
+            height={H}
+            viewBox={`0 0 ${w} ${H}`}
+            role="img"
+            aria-label={`Heart rate over time: ${series.length} readings, low ${dataMin}, average ${avg}, high ${dataMax} bpm`}
+            onPointerMove={onMove}
+            onPointerLeave={() => setHover(null)}
+          >
+            {ticks.map((v) => (
+              <g key={v}>
+                <line className="state-chart-grid" x1={PAD.l} x2={w - PAD.r} y1={y(v)} y2={y(v)} />
+                <text className="state-chart-ylabel" x={PAD.l + 1} y={y(v) - 3}>
+                  {v}
+                </text>
+              </g>
+            ))}
+
+            {!single && <path className="state-chart-area" d={area} />}
+            {!single && <path className="state-chart-line" d={line} />}
+
+            {(single || pts.length <= 14) &&
+              pts.map((p, i) => <circle key={i} className="state-chart-dot" cx={p.cx} cy={p.cy} r="3" />)}
+            {!single && pts.length > 14 && (
+              <circle
+                className="state-chart-dot state-chart-dot-last"
+                cx={pts[pts.length - 1].cx}
+                cy={pts[pts.length - 1].cy}
+                r="3.4"
+              />
+            )}
+
+            {hp && (
+              <g>
+                <line className="state-chart-cross" x1={hp.cx} x2={hp.cx} y1={PAD.t - 6} y2={baseY} />
+                <circle className="state-chart-marker" cx={hp.cx} cy={hp.cy} r="4" />
+              </g>
+            )}
+          </svg>
+        )}
+
+        {hp && (
+          <div className="state-chart-tip" style={{ left: hp.cx, top: hp.cy }}>
+            <strong>{hp.v}</strong> bpm
+            <span className="state-chart-tip-time">{clockLabel(hp.t)}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="state-chart-xaxis" aria-hidden="true">
+        <span>{t0Label(t1 - t0)}</span>
+        <span>now</span>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Activity ranked bars (single hue, direct % labels)                  */
+/* ------------------------------------------------------------------ */
+
+function ActivityBars({ rows }) {
+  if (!rows || rows.length === 0) {
+    return <p className="state-chart-empty">No activity readings in this window.</p>;
+  }
+  const max = Math.max(...rows.map((r) => r.pct));
+  return (
+    <ul className="state-bars">
+      {rows.map((r) => {
+        const Icon = ACTIVITY_ICON[r.activity] || Activity;
+        return (
+          <li key={r.activity} className="state-bar-row">
+            <span className="state-bar-label">
+              <Icon className="state-bar-glyph" size={13} strokeWidth={1.75} aria-hidden="true" />
+              {r.activity}
+            </span>
+            <span className="state-bar-track" aria-hidden="true">
+              <span className="state-bar-fill" style={{ width: `${max > 0 ? (r.pct / max) * 100 : 0}%` }} />
+            </span>
+            <span className="state-bar-pct">{Math.round(r.pct * 100)}%</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Aggregation                                                         */
+/* ------------------------------------------------------------------ */
+
+function computeStats(samples, hours) {
+  const t1 = Date.now();
+  const t0 = t1 - hours * 3600 * 1000;
+  const win = (samples || []).filter((s) => s.t >= t0 && s.t <= t1);
+
+  const hr = win.map((s) => s.heartRate).filter((n) => n != null);
+  const db = win.map((s) => s.soundLevel).filter((n) => n != null);
+  const avgHr = hr.length ? Math.round(hr.reduce((a, b) => a + b, 0) / hr.length) : null;
+  const peakHr = hr.length ? Math.max(...hr) : null;
+  const avgDb = db.length ? Math.round(db.reduce((a, b) => a + b, 0) / db.length) : null;
+
+  // Calories reset daily; the latest reading is "today so far".
+  let calLatest = null;
+  for (let i = win.length - 1; i >= 0; i--) {
+    if (win[i].caloriesBurned != null) {
+      calLatest = win[i].caloriesBurned;
+      break;
+    }
+  }
+
+  // Activity distribution (share of samples in each state).
+  const actMap = new Map();
+  for (const s of win) if (s.activity) actMap.set(s.activity, (actMap.get(s.activity) || 0) + 1);
+  const actTotal = Array.from(actMap.values()).reduce((a, b) => a + b, 0);
+  const activity = Array.from(actMap.entries())
+    .map(([activity, count]) => ({ activity, count, pct: actTotal ? count / actTotal : 0 }))
+    .sort((a, b) => b.count - a.count);
+
+  const hrSeries = win.filter((s) => s.heartRate != null).map((s) => ({ t: s.t, v: s.heartRate }));
+
+  return { count: win.length, avgHr, peakHr, avgDb, calLatest, activity, hrSeries, t0, t1 };
+}
+
+function t0Label(spanMs) {
+  const h = Math.round(spanMs / 3600000);
+  if (h <= 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+function clockLabel(t) {
+  try {
+    return new Date(t).toLocaleString(undefined, {
+      weekday: 'short',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}

--- a/src/components/VitalsPanel.css
+++ b/src/components/VitalsPanel.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2) var(--space-5);
+  gap: var(--space-2) var(--space-4);
   width: 100%;
   font-family: var(--sans);
   font-size: var(--text-xs);
@@ -88,10 +88,11 @@
 
 @media (max-width: 700px) {
   .vitals {
-    gap: var(--space-2) var(--space-4);
+    gap: var(--space-2) var(--space-3);
   }
+  /* Day of life moves up into the LISTENING TO / FOLLOWED BY stack on mobile
+     (rendered in the secondary bar — see ChromeBar.css); hide the copy here. */
   .vitals .chrome-signal-day {
-    margin-left: 0;
-    flex-basis: 100%;
+    display: none;
   }
 }

--- a/src/hooks/useStateHistory.js
+++ b/src/hooks/useStateHistory.js
@@ -1,0 +1,38 @@
+import { useLiveFeed } from './useLiveFeed.js';
+import { resolvePds, listRecords } from '../lib/atproto.js';
+import { normalizeVitals } from '../lib/vitals.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
+
+/**
+ * The is.dame.state append log as a time-ordered array of normalized samples
+ * (oldest → newest), for the /logging dashboard. Snapshot-first (the build
+ * writes the newest ~200 to state.json) then live via listRecords. Each sample
+ * is `{ ...vitals, t }` where `t` is the capture time in ms; readings that came
+ * back empty/0 (see normalizeVitals) are simply absent on that sample.
+ */
+export function useStateHistory({ max = 500 } = {}) {
+  const { items, status } = useLiveFeed({
+    name: 'state',
+    strategy: 'snapshot-first',
+    fetchLive: async () => {
+      const pds = await resolvePds(ME_DID);
+      return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.state, max });
+    },
+    mapItems: toSamples,
+  });
+  return { samples: items || [], status };
+}
+
+function toSamples(records) {
+  if (!Array.isArray(records)) return [];
+  return records
+    .map((r) => {
+      const v = normalizeVitals(r?.value);
+      if (!v || !v.sampledAt) return null;
+      const t = Date.parse(v.sampledAt);
+      if (!Number.isFinite(t)) return null;
+      return { ...v, t };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.t - b.t);
+}

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -3,9 +3,11 @@ import { useSearchParams } from 'react-router-dom';
 import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
+import StateStats from '../components/StateStats.jsx';
 import { matchesQuery } from '../components/FeedSearch.jsx';
 import { FeedSkeleton } from '../components/Skeleton.jsx';
 import { useLiveFeed } from '../hooks/useLiveFeed.js';
+import { useStateHistory } from '../hooks/useStateHistory.js';
 import { usePageContent } from '../hooks/usePageContent.js';
 import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
@@ -29,6 +31,10 @@ export default function Logging() {
     },
     mapItems: toLoggingItems,
   });
+
+  // The state dashboard paints from its own snapshot-first history, independent
+  // of the status feed's loading state, so it can show the instant it lands.
+  const { samples: stateSamples } = useStateHistory();
 
   const { active: editActive } = useEditMode();
   const { layout } = useFeedLayout();
@@ -56,6 +62,7 @@ export default function Logging() {
       headTitle="dame.is logging"
       selectable
     >
+      {stateSamples.length > 0 && <StateStats samples={stateSamples} />}
       {loading ? (
         <FeedSkeleton rows={5} label="Loading status updates" />
       ) : status === 'error' ? (


### PR DESCRIPTION
Two changes, both extending the `is.dame.state` feature.

## State dashboard on `/logging`
A rich header sibling to `ListeningStats` on `/listening`, built entirely from the `is.dame.state` history — no chart library, no extra data plumbing (snapshot-first + live `listRecords`).

- **`useStateHistory`** — the append log as a time-ordered array of normalized samples.
- **`StateStats`** — headline tiles (avg/peak bpm, calories today, avg dB, readings) with count-up; a **heart-rate area chart** over a 24h / 7d window with recessive gridlines and a **hover crosshair + tooltip**; and a **ranked activity breakdown**. Single-hue (the mossy accent) throughout — following the dataviz method — so it stays on-brand and colorblind-safe; the chart draws in measured pixels so dots stay circular; both themes via tokens.
- **`Logging`** — mounts `<StateStats>` at the top, painting from its own snapshot independent of the feed's loading state.

## Vitals-bar mobile polish (carried from earlier)
- Tighter horizontal gap between the vital stats.
- On mobile, day of life becomes the third line of the LISTENING TO / FOLLOWED BY stack (desktop keeps it at the vitals-bar right edge); the stack's inter-line gap is removed.

Verified headless: `/logging` dashboard at 24h + 7d, hover tooltip, responsive mobile stack; combined tree builds on top of latest `main` (resolved a clean auto-merge with the x-ray→inspect ChromeBar changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_