### PR TITLE
Home feed ledger: show the quoted post inside a repost

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1998,25 +1998,36 @@ a.ledger-time:focus-visible {
 }
 
 /* Reposts render as a quote-style box (FeedLedgerRow's RepostQuote).
-   The original post IS the row's content, so unlike a quote nested
-   inside a post its text stays unclamped and its own media renders —
-   still height-capped by the rules above. Quotes nested inside the
-   reposted post stay dropped. */
+   The reposted post IS the row's content, so — unlike a quote nested
+   inside a normal post — its text stays unclamped and its own media
+   renders, height-capped by the rules above. The media/quote re-enables
+   below are scoped to the reposted post's *direct* children (`>` from
+   .ledger-repost) so they lift only its own embeds, never anything one
+   level deeper. */
 .ledger-repost .post-embed-quote-text {
   display: block;
   overflow: visible;
 }
 
-.ledger-repost .post-embed-quote > .post-embed-images {
+.ledger-repost > .post-embed-quote > .post-embed-images {
   display: grid;
 }
 
-.ledger-repost .post-embed-quote > .post-embed-video {
+.ledger-repost > .post-embed-quote > .post-embed-video {
   display: block;
 }
 
-.ledger-repost .post-embed-quote > .post-embed-link-card {
+.ledger-repost > .post-embed-quote > .post-embed-link-card {
   display: grid;
+}
+
+/* A repost of a quote-post: show the quoted post as a compact card so
+   the repost keeps the subject it was quoting (this was dropped before).
+   Its author + full text ride along; its own media stays dropped (the
+   rules above only lift the reposted post's direct embeds), keeping the
+   nested card from ballooning the row — the record page has the rest. */
+.ledger-repost > .post-embed-quote > .post-embed-quote {
+  display: flex;
 }
 
 /* Text-less posts: the embed is the row's only content. Baseline row


### PR DESCRIPTION
## What

Reposts on the default (ledger) home feed dropped the post they were quoting. This makes a repost of a quote-post carry that quote through to the feed, so you can see what was actually reposted.

## Why it was broken

The data was always there — a repost hydrates to `payload.embed = app.bsky.embed.record#view` and `repostToFullPostItem` passes it through. The gap was purely CSS, and only in the **ledger layout**, which is the *default* home feed (`useFeedLayout.jsx` → `DEFAULT = 'ledger'`).

`FeedLedgerRow`'s `RepostQuote` wraps the reposted post in a `.post-embed-quote` box, and the ledger hides every embed nested inside a quote box (`Feed.css`) to keep quote teasers to author + text. The repost-specific rules re-enabled the reposted post's own images / video / link-cards — but never its nested quote. The old comment literally said *"Quotes nested inside the reposted post stay dropped."* So a repost of a quote-post showed only the reposter's line and lost the subject entirely.

The **cards layout** and the **record page** were never affected (no such hiding rule), which is why the quote rendered there but not in the feed.

## The change (`src/components/Feed.css`)

- Un-hide the quoted post inside a repost so it renders as a compact card (author + full text, so punchlines survive).
- Scope the media / quote re-enables to the reposted post's **direct** children (`>` from `.ledger-repost`) so they lift only *its* embeds — the quoted post's own media stays dropped one level down, keeping the nested card from ballooning the row. The record page keeps the full media.

## Verification

Rendered the exact DOM `RepostQuote` produces against the real CSS in headless Chromium and checked computed styles:

| Element | Before | After |
|---|---|---|
| Reposted post's own media | shows | shows (unchanged) |
| Quoted post (the missing piece) | `display:none` | **shows** |
| Quoted post's full text | hidden | **shows** |
| Quoted post's own nested media | hidden | hidden (kept condensed) |

CSS-only; no behavior change to the cards layout or the record page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQSvYGcE9DPFdX59QBNnGj)_