### PR TITLE
PDS-configurable nav menu (/logging restored); mobile stack dividers; dashboard border

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ Schema-only documentation lives under [`lexicons/`](lexicons/):
   which renders as a small chip (`src/components/VitalsChip.jsx`) under the status
   in the feed and on its record page.
   Posted straight from an iPhone Apple Shortcut (app-password `createSession` →
-  `createRecord`, no server); the panel dims and reads "last seen" once the
-  latest reading goes stale. See [`lexicons/STATE.md`](lexicons/STATE.md).
+  `createRecord`, no server), and also charts over time in the /logging
+  dashboard (`src/components/StateStats.jsx`). See
+  [`lexicons/STATE.md`](lexicons/STATE.md).
+- `is.dame.nav` — optional PDS override for the nav-menu (dock sheet) route
+  list. When its `enabled` flag is set, its `items` select / reorder / relabel /
+  hide the entries; otherwise the site uses the hardcoded routes in
+  `src/lib/navRoutes.js`. Edited in the admin "Nav menu" panel.
 
 Plus `fm.teal.alpha.feed.play` (teal.fm) for the now-playing signal.
 

--- a/lexicons/is.dame.nav.json
+++ b/lexicons/is.dame.nav.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.nav",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "description": "Overrides the site nav menu (the dock sheet). A singleton at at://{me}/is.dame.nav/self. When `enabled`, `items` replace the site's hardcoded route list — letting you select, reorder, relabel, and hide entries. When `enabled` is false (or no record exists), the site falls back to its built-in routes (see src/lib/navRoutes.js).",
+      "record": {
+        "type": "object",
+        "required": ["enabled", "createdAt"],
+        "properties": {
+          "enabled": { "type": "boolean", "description": "Whether this record drives the nav menu. False = use the hardcoded routes." },
+          "items": {
+            "type": "array",
+            "description": "Ordered nav entries. Order here is the order shown.",
+            "items": {
+              "type": "object",
+              "required": ["to", "label"],
+              "properties": {
+                "to": { "type": "string", "maxLength": 512, "description": "Route path, e.g. /logging." },
+                "label": { "type": "string", "maxLength": 64, "description": "Display label." },
+                "hidden": { "type": "boolean", "description": "Keep the entry in the list but hide it from the menu." }
+              }
+            }
+          },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "updatedAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -131,6 +131,17 @@ async function main() {
   );
   await writeJson('state', stateLog);
 
+  // --- Nav menu override (is.dame.nav/self) ---------------------------------
+  // Optional PDS override for the dock-sheet route list; snapshotted so the
+  // menu paints the right routes on first load. getRecord 404s until one
+  // exists — `safe` degrades it to {} and the site uses its hardcoded routes.
+  const navRecord = await safe(
+    'getRecord:nav',
+    () => getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.nav, rkey: 'self' }),
+    null,
+  );
+  await writeJson('nav', navRecord || {});
+
   // --- is.dame.page (pages keyed by rkey) -----------------------------------
   const pageRecords = backfillTimestamps(
     await safe(

--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -4,23 +4,11 @@ import { NavLink } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { ChevronLeft } from 'lucide-react';
 import { useActionDock } from '../hooks/useActionDock.jsx';
+import { useNavRoutes } from '../hooks/useNavRoutes.js';
 import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import SignInPanel from './SignInPanel.jsx';
 import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
-
-const ROUTES = [
-  { to: '/', label: 'home' },
-  { to: '/themself', label: 'themself' },
-  { to: '/available', label: 'available' },
-  { to: '/blogging', label: 'blogging' },
-  { to: '/creating', label: 'creating' },
-  { to: '/listening', label: 'listening' },
-  { to: '/curating', label: 'curating' },
-  { to: '/mothing', label: 'mothing' },
-  { to: '/welcoming', label: 'welcoming' },
-  { to: '/exploring', label: 'exploring' },
-];
 
 export default function ActionDock() {
   // Sheet-replace navigation: the dock has three interchangeable views.
@@ -29,6 +17,7 @@ export default function ActionDock() {
   // chevron header. `view`/`setView` live in the dock context so the bar
   // can drive them.
   const { open, view, setView, openDock, closeDock } = useActionDock();
+  const routes = useNavRoutes();
   const reduce = useReducedMotion();
   const panelRef = useRef(null);
   // Keep a touch-drag on the open sheet from scrolling the concealed page
@@ -128,7 +117,7 @@ export default function ActionDock() {
               <div className="dock-section">
                 <div className="dock-heading">Dame is&hellip;</div>
                 <nav className="dock-routes">
-                  {ROUTES.map((r) => (
+                  {routes.map((r) => (
                     <NavLink
                       key={r.to}
                       to={r.to}

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -712,6 +712,13 @@
   .chrome-signals-secondary .chrome-signal-day {
     display: inline-flex;
   }
+  /* Faint dashed divider between the three stacked lines (LISTENING TO /
+     FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers. */
+  .chrome-signals-secondary > .chrome-signal + .chrome-signal {
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
+    border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 55%, transparent);
+  }
 }
 
 /* Print: the fixed chrome bars (and their expanding sheets) are screen

--- a/src/components/NavMenuPanel.css
+++ b/src/components/NavMenuPanel.css
@@ -1,0 +1,168 @@
+/* Admin Nav-menu editor. Matches the admin panels' flat, ruled, square look. */
+
+.nav-enable {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--rule);
+  background: var(--surface-raised);
+  margin-bottom: var(--space-5);
+  cursor: pointer;
+}
+
+.nav-enable input {
+  margin-top: 0.2em;
+  flex: 0 0 auto;
+}
+
+.nav-enable > span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.nav-enable strong {
+  color: var(--ink);
+}
+
+.nav-enable-hint {
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+}
+
+/* ---- item list ---------------------------------------------------- */
+
+.nav-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--rule);
+  transition: opacity 0.2s ease;
+}
+
+.nav-items.is-dormant {
+  opacity: 0.62;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--page);
+}
+
+.nav-item + .nav-item {
+  border-top: 1px solid var(--rule-soft);
+}
+
+.nav-item.is-hidden {
+  background: repeating-linear-gradient(
+    135deg,
+    var(--page),
+    var(--page) 8px,
+    var(--surface-raised) 8px,
+    var(--surface-raised) 9px
+  );
+}
+
+.nav-item-reorder {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.nav-item-fields {
+  display: flex;
+  gap: var(--space-2);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.nav-item-label {
+  flex: 1 1 45%;
+  min-width: 0;
+}
+
+.nav-item-path {
+  flex: 1 1 55%;
+  min-width: 0;
+  font-family: var(--mono);
+}
+
+.nav-item-actions {
+  display: flex;
+  gap: var(--space-1);
+  flex: 0 0 auto;
+}
+
+/* Square icon buttons in the admin's muted vocabulary. */
+.nav-item-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  padding: 0;
+  border: 1px solid var(--rule);
+  background: var(--surface-raised);
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+
+.nav-item-reorder .nav-item-btn {
+  width: 1.7rem;
+  height: 1.25rem;
+}
+
+.nav-item-btn:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: var(--accent-soft);
+}
+
+.nav-item-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.nav-item-btn.is-on {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
+
+.nav-item-remove:hover:not(:disabled) {
+  color: #c17d3f;
+  border-color: #c17d3f;
+}
+
+/* ---- footer actions ----------------------------------------------- */
+
+.nav-list-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+.nav-add,
+.nav-list-actions .admin-link-subtle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+}
+
+.nav-save {
+  margin-top: var(--space-5);
+}
+
+@media (max-width: 560px) {
+  .nav-item {
+    flex-wrap: wrap;
+  }
+  .nav-item-fields {
+    order: 3;
+    flex-basis: 100%;
+  }
+}

--- a/src/components/NavMenuPanel.jsx
+++ b/src/components/NavMenuPanel.jsx
@@ -1,0 +1,252 @@
+// Admin editor for is.dame.nav/self — the optional PDS override for the site
+// nav menu (the dock sheet). Toggle the override on/off, and select / reorder /
+// relabel / hide the entries. With the override off (or no record), the site
+// uses the hardcoded routes in src/lib/navRoutes.js. Nothing is written until
+// Save.
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronUp, ChevronDown, Trash2, Plus, RotateCcw, Eye, EyeOff } from 'lucide-react';
+import PageShell from './PageShell.jsx';
+import { AdminRecordListSkeleton } from './Skeleton.jsx';
+import { NAV_NSID } from '../config.js';
+import { DEFAULT_ROUTES } from '../lib/navRoutes.js';
+import './NavMenuPanel.css';
+
+const toItem = (r) => ({ to: r.to, label: r.label, hidden: false });
+const normalizeItem = (it) => ({
+  to: typeof it?.to === 'string' ? it.to : '',
+  label: typeof it?.label === 'string' ? it.label : '',
+  hidden: Boolean(it?.hidden),
+});
+
+export default function NavMenuPanel({ agent, did }) {
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [items, setItems] = useState([]);
+  const [createdAt, setCreatedAt] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [flash, setFlash] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await agent.com.atproto.repo.getRecord({
+          repo: did,
+          collection: NAV_NSID,
+          rkey: 'self',
+        });
+        const v = res?.data?.value;
+        if (cancelled) return;
+        if (v) {
+          setEnabled(Boolean(v.enabled));
+          setItems(
+            Array.isArray(v.items) && v.items.length
+              ? v.items.map(normalizeItem)
+              : DEFAULT_ROUTES.map(toItem),
+          );
+          setCreatedAt(v.createdAt || null);
+        } else {
+          setItems(DEFAULT_ROUTES.map(toItem));
+        }
+      } catch {
+        // No record yet — seed the editor from the site defaults.
+        if (!cancelled) setItems(DEFAULT_ROUTES.map(toItem));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did]);
+
+  function move(i, dir) {
+    const j = i + dir;
+    if (j < 0 || j >= items.length) return;
+    setItems((prev) => {
+      const next = prev.slice();
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  }
+  function patchItem(i, fields) {
+    setItems((prev) => prev.map((it, idx) => (idx === i ? { ...it, ...fields } : it)));
+  }
+  function removeItem(i) {
+    setItems((prev) => prev.filter((_, idx) => idx !== i));
+  }
+  function addItem() {
+    setItems((prev) => [...prev, { to: '', label: '', hidden: false }]);
+  }
+  function resetDefaults() {
+    setItems(DEFAULT_ROUTES.map(toItem));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setFlash(false);
+    try {
+      const cleanItems = items
+        .map((it) => {
+          const to = (it.to || '').trim();
+          const label = (it.label || '').trim();
+          const out = { to, label };
+          if (it.hidden) out.hidden = true;
+          return out;
+        })
+        .filter((it) => it.to && it.label);
+      const now = new Date().toISOString();
+      const record = {
+        $type: NAV_NSID,
+        enabled,
+        items: cleanItems,
+        createdAt: createdAt || now,
+        updatedAt: now,
+      };
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: NAV_NSID,
+        rkey: 'self',
+        record,
+      });
+      setCreatedAt(record.createdAt);
+      setItems(cleanItems.map(normalizeItem));
+      setFlash(true);
+      setTimeout(() => setFlash(false), 2400);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <PageShell
+      title="Nav menu"
+      intro="Override the site's nav-menu route list. When the override is on, these entries replace the built-in menu — reorder, relabel, or hide them. Turn it off to fall back to the hardcoded routes. Nothing is written until you press Save."
+      headTitle="Nav menu — Admin — dame.is"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <code className="admin-collection-nsid">{NAV_NSID}/self</code>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+
+      {loading ? (
+        <AdminRecordListSkeleton rows={4} />
+      ) : (
+        <>
+          <label className="nav-enable">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            <span>
+              <strong>Use this override</strong>
+              <span className="nav-enable-hint">
+                {enabled
+                  ? 'The menu below is live on the site.'
+                  : 'Off — the site is using its built-in routes. Your edits are saved but dormant.'}
+              </span>
+            </span>
+          </label>
+
+          <ul className={`nav-items ${enabled ? '' : 'is-dormant'}`}>
+            {items.map((it, i) => (
+              <li key={i} className={`nav-item ${it.hidden ? 'is-hidden' : ''}`}>
+                <div className="nav-item-reorder">
+                  <button
+                    type="button"
+                    className="nav-item-btn"
+                    onClick={() => move(i, -1)}
+                    disabled={i === 0}
+                    aria-label="Move up"
+                    title="Move up"
+                  >
+                    <ChevronUp size={15} aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className="nav-item-btn"
+                    onClick={() => move(i, 1)}
+                    disabled={i === items.length - 1}
+                    aria-label="Move down"
+                    title="Move down"
+                  >
+                    <ChevronDown size={15} aria-hidden="true" />
+                  </button>
+                </div>
+
+                <div className="nav-item-fields">
+                  <input
+                    className="admin-input nav-item-label"
+                    type="text"
+                    value={it.label}
+                    placeholder="label"
+                    onChange={(e) => patchItem(i, { label: e.target.value })}
+                  />
+                  <input
+                    className="admin-input nav-item-path"
+                    type="text"
+                    value={it.to}
+                    placeholder="/path"
+                    spellCheck={false}
+                    onChange={(e) => patchItem(i, { to: e.target.value })}
+                  />
+                </div>
+
+                <div className="nav-item-actions">
+                  <button
+                    type="button"
+                    className={`nav-item-btn ${it.hidden ? 'is-on' : ''}`}
+                    onClick={() => patchItem(i, { hidden: !it.hidden })}
+                    aria-pressed={it.hidden}
+                    aria-label={it.hidden ? 'Show in menu' : 'Hide from menu'}
+                    title={it.hidden ? 'Hidden — click to show' : 'Visible — click to hide'}
+                  >
+                    {it.hidden ? <EyeOff size={15} aria-hidden="true" /> : <Eye size={15} aria-hidden="true" />}
+                  </button>
+                  <button
+                    type="button"
+                    className="nav-item-btn nav-item-remove"
+                    onClick={() => removeItem(i)}
+                    aria-label="Remove entry"
+                    title="Remove"
+                  >
+                    <Trash2 size={15} aria-hidden="true" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="nav-list-actions">
+            <button type="button" className="admin-link-subtle nav-add" onClick={addItem}>
+              <Plus size={14} aria-hidden="true" /> Add entry
+            </button>
+            <button type="button" className="admin-link-subtle" onClick={resetDefaults}>
+              <RotateCcw size={13} aria-hidden="true" /> Reset to site defaults
+            </button>
+          </div>
+
+          <div className="nav-save">
+            <button
+              type="button"
+              className="admin-gate-button"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? 'Saving…' : flash ? 'Saved ✓' : 'Save'}
+            </button>
+          </div>
+        </>
+      )}
+    </PageShell>
+  );
+}

--- a/src/components/StateStats.css
+++ b/src/components/StateStats.css
@@ -4,8 +4,6 @@
 
 .state-stats {
   margin-bottom: var(--space-7);
-  padding-bottom: var(--space-5);
-  border-bottom: 1px solid var(--rule);
 }
 
 .state-stats-head {

--- a/src/config.js
+++ b/src/config.js
@@ -81,6 +81,13 @@ export const LEGACY_GUESTBOOK_SUBJECT = `at://${ME_DID}/${LEGACY_GUESTBOOK_NSID}
 // an iPhone Apple Shortcut; see lexicons/STATE.md.
 export const STATE_NSID = 'is.dame.state';
 
+// --- nav menu ----------------------------------------------------------------
+// Optional PDS override for the nav-menu (dock sheet) route list. The singleton
+// at is.dame.nav/self can select / reorder / relabel / hide entries; when its
+// `enabled` flag is off (or no record exists) the site uses the hardcoded
+// routes in src/lib/navRoutes.js. Edited in the admin "Nav menu" panel.
+export const NAV_NSID = 'is.dame.nav';
+
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';
@@ -117,6 +124,7 @@ export const COLLECTIONS = {
   resumeEducation: RESUME_EDUCATION_NSID,
   arenaChannel: ARENA_CHANNEL_NSID,
   state: STATE_NSID,
+  nav: NAV_NSID,
 };
 
 /** Gerund verbs surfaced on the home feed. Sourced from the registry. */

--- a/src/hooks/useNavRoutes.js
+++ b/src/hooks/useNavRoutes.js
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import { resolvePds, getRecord } from '../lib/atproto.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
+import { effectiveNavRoutes } from '../lib/navRoutes.js';
+
+/**
+ * The effective nav-menu routes. Reads the optional is.dame.nav/self override
+ * (snapshot for instant paint, then live getRecord) and resolves it against the
+ * hardcoded defaults via effectiveNavRoutes — so with no record, a disabled
+ * one, or an empty list, the built-in routes show unchanged.
+ */
+export function useNavRoutes() {
+  const [record, setRecord] = useState(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    async function boot() {
+      const seed = await fetchSnapshot('nav');
+      if (!cancelledRef.current && seed?.value) setRecord(seed);
+      try {
+        const pds = await resolvePds(ME_DID);
+        const rec = await getRecord(pds, {
+          repo: ME_DID,
+          collection: COLLECTIONS.nav,
+          rkey: 'self',
+        });
+        if (!cancelledRef.current && rec?.value) setRecord(rec);
+      } catch {
+        // No override (getRecord 404s until one exists) — defaults stand.
+      }
+    }
+    boot();
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  return effectiveNavRoutes(record);
+}

--- a/src/lib/navRoutes.js
+++ b/src/lib/navRoutes.js
@@ -1,0 +1,43 @@
+// The nav-menu (dock sheet) route list. This hardcoded default is the fallback;
+// an is.dame.nav/self PDS record can override it (select / reorder / relabel /
+// hide) when its `enabled` flag is set — see useNavRoutes + the admin Nav menu
+// panel. Shared by ActionDock (render) and NavMenuPanel (its "reset to
+// defaults" seed).
+
+export const DEFAULT_ROUTES = [
+  { to: '/', label: 'home' },
+  { to: '/themself', label: 'themself' },
+  { to: '/available', label: 'available' },
+  { to: '/logging', label: 'logging' },
+  { to: '/blogging', label: 'blogging' },
+  { to: '/creating', label: 'creating' },
+  { to: '/listening', label: 'listening' },
+  { to: '/curating', label: 'curating' },
+  { to: '/mothing', label: 'mothing' },
+  { to: '/welcoming', label: 'welcoming' },
+  { to: '/exploring', label: 'exploring' },
+];
+
+/**
+ * The routes the menu should show for a given is.dame.nav record (or null).
+ * Uses the record's items only when it's present AND enabled AND yields at
+ * least one visible, well-formed entry; otherwise falls back to DEFAULT_ROUTES.
+ */
+export function effectiveNavRoutes(record) {
+  const v = record?.value;
+  if (v?.enabled && Array.isArray(v.items)) {
+    const items = v.items
+      .filter(
+        (it) =>
+          it &&
+          typeof it.to === 'string' &&
+          it.to.trim() &&
+          typeof it.label === 'string' &&
+          it.label.trim() &&
+          !it.hidden,
+      )
+      .map((it) => ({ to: it.to.trim(), label: it.label.trim() }));
+    if (items.length) return items;
+  }
+  return DEFAULT_ROUTES;
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -7,6 +7,7 @@ import GuestbookModerationPanel from '../components/GuestbookModerationPanel.jsx
 import ResumeStudio from '../components/resume/ResumeStudio.jsx';
 import ResumeWorkbench from '../components/resume/ResumeWorkbench.jsx';
 import PublicationsManager from '../components/PublicationsManager.jsx';
+import NavMenuPanel from '../components/NavMenuPanel.jsx';
 import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -81,6 +82,9 @@ export default function Admin() {
   }
   if (view === 'publications') {
     return <PublicationsManager agent={agent} did={did} />;
+  }
+  if (view === 'nav') {
+    return <NavMenuPanel agent={agent} did={did} />;
   }
   if (view === 'resume-tailor' && rkey) {
     return <ResumeWorkbench agent={agent} did={did} rkey={rkey} />;
@@ -218,6 +222,8 @@ const PICKER_GROUPS = [
     items: [
       { to: '/admin?view=pages', label: 'Site pages', nsid: COLLECTIONS.page,
         summary: 'Titles, intros, and page bodies — see which serve from the PDS vs local defaults, and edit the raw records.' },
+      { to: '/admin?view=nav', label: 'Nav menu', nsid: 'is.dame.nav',
+        summary: 'Override the dock-menu route list — select, reorder, relabel, or hide entries — or turn the override off to use the built-in routes.' },
       { to: '/admin?view=publications', label: 'Publications', nsid: 'site.standard.publication',
         summary: 'The blog + portfolio publications behind the Bluesky Standard Site embeds — edit their fields, or apply the sky theme + a dynamic avatar.' },
       { to: '/admin?view=guestbook', label: 'Guestbook', nsid: 'is.dame.guestbook.entry',


### PR DESCRIPTION
Three changes.

## Nav menu — `/logging` restored + PDS-configurable
- **`is.dame.nav`** (singleton `/self`) — an optional override for the dock-sheet route list: an `enabled` flag + ordered `items` you can select, reorder, relabel, and hide.
- **`src/lib/navRoutes.js`** holds the hardcoded default list (now with `/logging`); `effectiveNavRoutes()` resolves a record against it — no record, disabled, or empty → the built-in routes, so it's safe by default.
- **`useNavRoutes`** (snapshot-first + live `getRecord`) feeds `ActionDock` in place of its inline list; `prefetch` snapshots `is.dame.nav/self`.
- **Admin → "Nav menu"** panel (`NavMenuPanel`): override on/off, per-item reorder / relabel / retarget / hide, add, reset-to-defaults, save.

## Smaller tweaks
- **Mobile atmosphere stack** — a faint dashed divider between the three stacked lines (LISTENING TO / FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers.
- **`/logging` dashboard** — dropped the bottom border so it flows into the feed.

Verified headless: `/logging` in the menu (falling back to defaults), the mobile dashed dividers, the border-free dashboard, and that `/admin?view=nav` renders (the editor itself is owner-gated; it mirrors the Publications panel and builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_