### PR TITLE
Vitals: reorder to heart/cal/sound/activity/battery; smaller on mobile

### DIFF
--- a/src/components/VitalsPanel.css
+++ b/src/components/VitalsPanel.css
@@ -87,8 +87,14 @@
 }
 
 @media (max-width: 700px) {
+  /* A touch smaller on phones: tighter gap, slightly smaller text + glyphs. */
   .vitals {
-    gap: var(--space-2) var(--space-3);
+    gap: var(--space-1) var(--space-2);
+    font-size: 0.7rem;
+  }
+  .vitals .vital-glyph {
+    width: 13px;
+    height: 13px;
   }
   /* Day of life moves up into the LISTENING TO / FOLLOWED BY stack on mobile
      (rendered in the secondary bar — see ChromeBar.css); hide the copy here. */

--- a/src/components/VitalsPanel.jsx
+++ b/src/components/VitalsPanel.jsx
@@ -62,6 +62,22 @@ export default function VitalsPanel() {
         </span>
       )}
 
+      {vitals.caloriesBurned != null && (
+        <span className="vital vital-cal" aria-label={`${vitals.caloriesBurned} calories burned today`}>
+          <Flame className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
+          <span className="vital-value">{vitals.caloriesBurned}</span>
+          <span className="vital-unit">cal</span>
+        </span>
+      )}
+
+      {vitals.soundLevel != null && (
+        <span className="vital vital-sound" aria-label={`Ambient sound ${vitals.soundLevel} decibels`}>
+          <Volume2 className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
+          <span className="vital-value">{vitals.soundLevel}</span>
+          <span className="vital-unit">dB</span>
+        </span>
+      )}
+
       {vitals.activity && (
         <span className="vital vital-activity" aria-label={`Currently ${vitals.activity}`}>
           <ActivityIcon className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
@@ -78,22 +94,6 @@ export default function VitalsPanel() {
         >
           <BatteryIcon className="vital-glyph" size={16} strokeWidth={1.75} aria-hidden="true" />
           <span className="vital-value">{vitals.batteryLevel}%</span>
-        </span>
-      )}
-
-      {vitals.caloriesBurned != null && (
-        <span className="vital vital-cal" aria-label={`${vitals.caloriesBurned} calories burned today`}>
-          <Flame className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
-          <span className="vital-value">{vitals.caloriesBurned}</span>
-          <span className="vital-unit">cal</span>
-        </span>
-      )}
-
-      {vitals.soundLevel != null && (
-        <span className="vital vital-sound" aria-label={`Ambient sound ${vitals.soundLevel} decibels`}>
-          <Volume2 className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
-          <span className="vital-value">{vitals.soundLevel}</span>
-          <span className="vital-unit">dB</span>
         </span>
       )}
 


### PR DESCRIPTION
Two small tweaks to the atmosphere-bar vitals.

- **Reorder** to heart rate → calories → ambient sound → activity → battery (was heart, activity, battery, calories, sound).
- **Smaller on mobile** — tighter gap, slightly smaller text, and glyphs downsized to 13px, so the row sits more compactly on a phone. Desktop sizing is unchanged (scoped to ≤700px).

Verified headless on both desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_