### PR TITLE
Document dateline rules + move atmosphere debug into its own sheet

### DIFF
--- a/src/components/ActionDock.jsx
+++ b/src/components/ActionDock.jsx
@@ -7,16 +7,16 @@ import { useActionDock } from '../hooks/useActionDock.jsx';
 import { useNavRoutes } from '../hooks/useNavRoutes.js';
 import { usePreventScrollChain } from '../hooks/usePreventScrollChain.js';
 import SignInPanel from './SignInPanel.jsx';
-import DebugPane from './DebugPane.jsx';
 import './ActionDock.css';
 
 export default function ActionDock() {
-  // Sheet-replace navigation: the dock has three interchangeable views.
-  // 'menu' is the root; the tool buttons (now relocated into the bottom
-  // chrome bar) push to 'account' and 'debug'. Each sub-view has a back
-  // chevron header. `view`/`setView` live in the dock context so the bar
-  // can drive them.
-  const { open, view, setView, openDock, closeDock } = useActionDock();
+  // Sheet-replace navigation: the dock has two interchangeable views. 'menu'
+  // is the root; the account tool button (relocated into the bottom chrome
+  // bar) pushes to 'account', which has a back chevron header. `view`/`setView`
+  // live in the dock context so the bar can drive them. (The atmosphere-debug
+  // readout used to be a third view here; it's now its own sheet — see
+  // DebugSheet — reached from the inspect HUD.)
+  const { open, view, setView, closeDock } = useActionDock();
   const routes = useNavRoutes();
   const reduce = useReducedMotion();
   const panelRef = useRef(null);
@@ -38,28 +38,6 @@ export default function ActionDock() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [open, view, closeDock]);
-
-  // `?` toggles the atmosphere debug view from anywhere in the app
-  // (ignoring keystrokes inside text inputs). Opens the dock if needed
-  // and jumps straight to the debug sub-view; pressing again from
-  // within debug closes the whole dock.
-  useEffect(() => {
-    function onKey(e) {
-      if (e.key !== '?') return;
-      const tag = e.target?.tagName;
-      const editing = tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable;
-      if (editing) return;
-      e.preventDefault();
-      if (open && view === 'debug') {
-        closeDock();
-      } else {
-        setView('debug');
-        if (!open) openDock();
-      }
-    }
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, view, openDock, closeDock]);
 
   if (typeof document === 'undefined') return null;
 
@@ -156,32 +134,6 @@ export default function ActionDock() {
                   <div className="dock-heading">Account</div>
                 </div>
                 <SignInPanel onAction={closeDock} />
-              </div>
-            </motion.div>
-          )}
-
-          {view === 'debug' && (
-            <motion.div
-              key="debug"
-              initial={{ x: 16, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              exit={{ x: 16, opacity: 0 }}
-              transition={{ duration: reduce ? 0 : 0.18, ease: [0.22, 0.61, 0.36, 1] }}
-            >
-              <div className="dock-section">
-                <div className="dock-subhead">
-                  <button
-                    type="button"
-                    className="dock-tool-icon dock-back"
-                    onClick={() => setView('menu')}
-                    aria-label="Back to menu"
-                    title="Back"
-                  >
-                    <ChevronLeft aria-hidden="true" strokeWidth={1.75} />
-                  </button>
-                  <div className="dock-heading">atmosphere · this page</div>
-                </div>
-                <DebugPane onClose={closeDock} />
               </div>
             </motion.div>
           )}

--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
-import { ArrowDown, ArrowLeft, ArrowUp, Bug, Compass, Home, Info, ListFilterPlus, Microscope, Pencil, Printer, Search, Type, User, X } from 'lucide-react';
+import { ArrowDown, ArrowLeft, ArrowUp, Compass, Home, Info, ListFilterPlus, Microscope, Pencil, Printer, Search, Type, User, X } from 'lucide-react';
 import { useChromeBar } from '../hooks/useChromeBar.jsx';
 import { nsidFromAtUri, primaryNsid } from '../lib/verbRegistry.js';
 import { skyAvatarUrl } from '../lib/skyAvatars.js';
@@ -25,6 +25,7 @@ import { PAPER_ENABLED } from '../hooks/usePaper.jsx';
 import SearchSheet from './SearchSheet.jsx';
 import InfoSheet from './InfoSheet.jsx';
 import GuestbookSheet from './GuestbookSheet.jsx';
+import DebugSheet from './DebugSheet.jsx';
 import Footer from './Footer.jsx';
 import './ChromeBar.css';
 
@@ -506,10 +507,11 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
     <div className="chrome-bar chrome-bar-bottom" role="toolbar" aria-label="Global actions">
       <div className="chrome-bottom-row">
         {/* Left cluster. While the nav dock is open, the page-level controls
-            (theme / filter / search / info) hand off to the dock's tools
-            (layout / debug / account) — they animate in and temporarily
-            take the same spot, then swap back when the dock closes. The
-            debug/account tools drive the open sheet's sub-view. */}
+            (theme / filter / search / info / inspect) hand off to the dock's
+            density tools (layout) — they cross-fade in and temporarily take the
+            same spot, then swap back when the dock closes. (Account lives in the
+            right cluster now; the atmosphere-debug readout is its own sheet,
+            reached from the inspect HUD.) */}
         <div className="chrome-bottom-left">
           <AnimatePresence mode="wait" initial={false}>
             {dockOpen ? (
@@ -523,26 +525,6 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
               >
                 <LayoutToggle />
                 {PAPER_ENABLED && <PaperToggle />}
-                <button
-                  type="button"
-                  className={`chrome-nav chrome-tool-debug ${view === 'debug' ? 'is-open' : ''}`}
-                  onClick={() => setView(view === 'debug' ? 'menu' : 'debug')}
-                  aria-pressed={view === 'debug'}
-                  aria-label="Atmosphere debug"
-                  title="Atmosphere debug"
-                >
-                  <Bug className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-                </button>
-                <button
-                  type="button"
-                  className={`chrome-nav chrome-tool-account ${view === 'account' ? 'is-open' : ''}`}
-                  onClick={() => setView(view === 'account' ? 'menu' : 'account')}
-                  aria-pressed={view === 'account'}
-                  aria-label="Account"
-                  title="Account"
-                >
-                  <User className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
-                </button>
               </motion.div>
             ) : (
               <motion.div
@@ -764,6 +746,27 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
             </MotionLink>
           )}
         </AnimatePresence>
+        {/* Account tool. It rides the RIGHT cluster (beside the menu button it
+            belongs with) rather than the left tool group, fading in only while
+            the nav dock is open and swapping the open sheet between its menu
+            and account views. */}
+        <AnimatePresence mode="popLayout" initial={false}>
+          {dockOpen && (
+            <motion.button
+              key="account"
+              layout={layoutProp}
+              type="button"
+              className={`chrome-nav chrome-tool-account ${view === 'account' ? 'is-open' : ''}`}
+              onClick={() => setView(view === 'account' ? 'menu' : 'account')}
+              aria-pressed={view === 'account'}
+              aria-label="Account"
+              title="Account"
+              {...controlFade}
+            >
+              <User className="chrome-nav-glyph" aria-hidden="true" strokeWidth={1.75} />
+            </motion.button>
+          )}
+        </AnimatePresence>
         <motion.button
           layout={layoutProp}
           type="button"
@@ -803,6 +806,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
       <SearchSheet />
       <InfoSheet />
       <GuestbookSheet />
+      <DebugSheet />
     </div>
   );
 }

--- a/src/components/DebugPane.jsx
+++ b/src/components/DebugPane.jsx
@@ -9,10 +9,10 @@ import { BUILD_ID } from '../lib/appVersion.js';
 import './DebugOverlay.css';
 
 /**
- * Atmosphere debug content for the current route. Lives inside the
- * ActionDock as the 'debug' sub-view — the dock owns the surrounding
- * Modal, the back chevron, and the heading, so this component renders
- * only the readouts, actions, and (optionally) the inline record editor.
+ * Atmosphere debug content for the current route. Rendered inside the
+ * DebugSheet — that sheet owns the surrounding BottomSheet, the header, and
+ * the close button, so this component renders only the readouts, actions, and
+ * (optionally) the inline record editor.
  */
 export default function DebugPane({ onClose }) {
   const { atUri, cid, lexicon, pds, record, route, rkey, slug, recordStatus } = useAtUri();

--- a/src/components/DebugSheet.css
+++ b/src/components/DebugSheet.css
@@ -1,0 +1,46 @@
+/* Interior of the atmosphere-debug bottom sheet. BottomSheet owns positioning,
+   the surface, and the expand animation; this file lays out the header + the
+   DebugPane below it. Mirrors the info sheet so the two read as one family. */
+.debug-sheet-panel {
+  /* Horizontal inset tracks the chrome bars' shared column (--chrome-pad-x) so
+     the readout lines up with the nav dock, the breadcrumb, and the bottom-bar
+     buttons at every breakpoint. */
+  padding: var(--space-4) var(--chrome-pad-x);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.debug-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.16em;
+  color: var(--ink-faint);
+}
+
+.debug-sheet-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+  background: var(--page);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.debug-sheet-close:hover,
+.debug-sheet-close:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 14%, var(--page));
+  outline: none;
+}

--- a/src/components/DebugSheet.jsx
+++ b/src/components/DebugSheet.jsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import BottomSheet from './BottomSheet.jsx';
+import DebugPane from './DebugPane.jsx';
+import { useChromePanel } from '../hooks/useChromePanel.jsx';
+import './DebugSheet.css';
+
+/**
+ * The atmosphere readout for the current route — at-uri, cid, lexicon, pds,
+ * the raw record, and (for the owner) an inline editor. Once a sub-view of the
+ * nav dock, it's now its own sheet: the marquee way in is the inspect HUD's
+ * "details" affordance, so the data view belongs to the inspect experience,
+ * not the site menu. Expands up out of the bottom chrome on the shared
+ * BottomSheet, coordinated with the other panels + the dock by useChromePanel.
+ *
+ * Owns the `?` shortcut, which toggles this sheet from anywhere in the app
+ * (ignoring keystrokes inside text inputs).
+ */
+export default function DebugSheet() {
+  const { panel, togglePanel, closePanel } = useChromePanel();
+  const open = panel === 'debug';
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key !== '?') return;
+      const tag = e.target?.tagName;
+      const editing = tag === 'INPUT' || tag === 'TEXTAREA' || e.target?.isContentEditable;
+      if (editing) return;
+      e.preventDefault();
+      togglePanel('debug');
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [togglePanel]);
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={closePanel}
+      label="atmosphere · this page"
+      id="chrome-debug-sheet"
+      size="fill"
+      className="debug-sheet-panel"
+    >
+      <div className="debug-sheet-header">
+        <span className="small-caps">atmosphere · this page</span>
+        <button
+          type="button"
+          className="debug-sheet-close"
+          onClick={closePanel}
+          aria-label="Close"
+        >
+          <X size={16} aria-hidden="true" />
+        </button>
+      </div>
+      <DebugPane onClose={closePanel} />
+    </BottomSheet>
+  );
+}

--- a/src/components/DocumentMeta.jsx
+++ b/src/components/DocumentMeta.jsx
@@ -20,7 +20,7 @@ export default function DocumentMeta({ date }) {
   if (!date) return null;
   const day = dayOfLife(date);
   return (
-    <div className="blog-article-meta">
+    <div className="blog-article-meta document-meta">
       <span>
         Published {relativeDay(date)} on {formatDateFull(date)}
         {day ? ` (Day ${day.toLocaleString()})` : ''}

--- a/src/components/XrayLayer.jsx
+++ b/src/components/XrayLayer.jsx
@@ -40,7 +40,7 @@ function XrayHud() {
   const reduce = useReducedMotion();
   const derived = useAtUri();
   const { pageRecord } = useEditMode();
-  const { openDock, setView } = useActionDock();
+  const { openPanel } = useChromePanel();
 
   // Prefer the route-derived record; else fall back to whatever backing record
   // the current page registered through PageShell (e.g. the resume version at
@@ -49,9 +49,10 @@ function XrayHud() {
   const atUri = derived.atUri || fallback?.atUri || null;
   const explorerPath = atUri ? explorerPathFromAtUri(atUri) : null;
 
+  // The atmosphere readout is its own sheet now (DebugSheet, a chrome panel);
+  // opening it folds the dock away and suppresses this HUD until it closes.
   function openDetails() {
-    setView('debug');
-    openDock();
+    openPanel('debug');
   }
 
   // Expand up out of the bottom chrome on the shared BottomSheet mechanism

--- a/src/hooks/useActionDock.jsx
+++ b/src/hooks/useActionDock.jsx
@@ -9,10 +9,10 @@ export function ActionDockProvider({ children }) {
     const stored = localStorage.getItem(STORAGE_KEY);
     return stored === '1';
   });
-  // The dock's active sub-view ('menu' | 'account' | 'debug'). It lives here,
-  // not inside <ActionDock>, so the bottom chrome bar's relocated tool
-  // buttons can drive it too — tapping Account/Debug down in the bar swaps
-  // the open sheet's view.
+  // The dock's active sub-view ('menu' | 'account'). It lives here, not inside
+  // <ActionDock>, so the bottom chrome bar's relocated Account tool button can
+  // drive it too — tapping Account down in the bar swaps the open sheet's view.
+  // (Atmosphere debug used to be a third view; it's now its own DebugSheet.)
   const [view, setView] = useState('menu');
 
   useEffect(() => {

--- a/src/hooks/useChromePanel.jsx
+++ b/src/hooks/useChromePanel.jsx
@@ -19,8 +19,10 @@ import { useActionDock } from './useActionDock.jsx';
 const ChromePanelContext = createContext(null);
 
 // The known transient panels. Kept as a constant so callers and tests can
-// reason about the full set without magic strings scattered around.
-export const CHROME_PANELS = ['search', 'filter', 'info', 'guestbook'];
+// reason about the full set without magic strings scattered around. `debug`
+// (the atmosphere readout) is a panel too now, opened from the inspect HUD's
+// "details" affordance rather than living as a sub-view of the nav dock.
+export const CHROME_PANELS = ['search', 'filter', 'info', 'guestbook', 'debug'];
 
 export function ChromePanelProvider({ children }) {
   const { open: dockOpen, closeDock } = useActionDock();

--- a/src/pages/Blogging.css
+++ b/src/pages/Blogging.css
@@ -146,6 +146,26 @@
   color: var(--ink-faint);
 }
 
+/* Document dateline (blog post / work) — frame the single publication line in
+   faint dashed rules top and bottom, echoing the dashed dividers between
+   thread posts in the feed. Scoped to .document-meta (the shared DocumentMeta
+   component) so the record-page meta, which also wears .blog-article-meta,
+   keeps its own bare style. The padding gives the text room off the rules;
+   margin-top sets the band apart from the title above. */
+.document-meta {
+  margin-top: var(--space-4);
+  padding: var(--space-3) 0;
+  border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 60%, transparent);
+  border-bottom: 1px dashed color-mix(in srgb, var(--rule-soft) 60%, transparent);
+}
+/* The blog post is a plain block container with no gap to separate the band
+   from the body, so it gets an explicit bottom margin. The work page
+   (.creating-work-page) is a flex column whose `gap` already provides that
+   space — adding a margin there would double it. */
+.blog-article > .document-meta {
+  margin-bottom: var(--space-5);
+}
+
 .blog-prose {
   font-family: var(--serif);
   font-size: 1.05rem;


### PR DESCRIPTION
Two changes on the branch.

## 1. Faint dashed dateline on document pages
Frame the publication line on blog posts and works in a faint dashed rule top and bottom, echoing the dashed dividers between thread posts in the feed (same `1px dashed`, same `--rule-soft` 60% mix, full reading-column width). Scoped to a new `.document-meta` class on the shared `DocumentMeta` component so the record-page metadata — which also wears `.blog-article-meta` — keeps its bare style. Spacing lands at a consistent 40px above / 24px below on both page types (the block blog page gets an explicit bottom margin; the flex work page relies on its column `gap`).

## 2. Split atmosphere debug into its own sheet; move account to the right
Now that **inspect** owns "reveal the protocol data," the debug readout no longer belongs in the nav menu:

- **Removed** the debug (bug) tool button from the bottom chrome.
- **Separated** the debug view out of the nav dock into its own standalone sheet (`DebugSheet`). It was the dock's third sub-view; it's now a chrome panel (`debug` added to `CHROME_PANELS`) that expands up on the shared `BottomSheet`, coordinated with the dock and the other panels. The way in is the inspect HUD's **"details ↗"** affordance (`openPanel('debug')`), so the data view belongs to the inspect experience rather than the site menu. The `?` shortcut moved onto the sheet and toggles it from anywhere. `DebugPane` is unchanged, just re-homed.
- **Moved** the account tool button to the **right** cluster (beside the menu button), fading in only while the dock is open. It still swaps the sheet between its menu and account views.

The nav dock drops to two views (menu | account); its stale `?`/debug handling and `DebugPane` import go with it.

## Verification
Headless renders at mobile + desktop:
- Dateline band renders framed and balanced on both blog posts and works.
- With the dock open: account button sits on the right (just left of the menu), the debug button is gone, and the left cluster is just the density toggle.
- The debug sheet opens via both the inspect HUD "details" button (which suppresses the HUD) and the `?` shortcut, showing the full atmosphere readout.
- Account tap switches the dock to its account view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_