### PR TITLE
Inspect: rename substrate panel heading to "Atmosphere Record"

### DIFF
--- a/src/components/XraySubstrate.jsx
+++ b/src/components/XraySubstrate.jsx
@@ -121,7 +121,7 @@ export function XraySubstratePanel({ atUri, cid }) {
 
   return (
     <div className="xray-substrate" role="group" aria-label="record location">
-      <p className="xray-substrate-h">you are here in the repo</p>
+      <p className="xray-substrate-h">Atmosphere Record</p>
       <div className="xray-locus">
         <span className="locus-lvl" style={{ '--d': 0 }}>
           <span className="k">pds</span>


### PR DESCRIPTION
The focused-record panel (the "you are here" locus tree shown when you inspect an element) had the heading **"you are here in the repo"**. Rename it to **"Atmosphere Record"**.

Still uppercased by the existing `.xray-substrate-h` accent-label style, so it renders as "ATMOSPHERE RECORD". One-line copy change in `src/components/XraySubstrate.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_