### PR TITLE
Reword day-of-life chrome line as "on day N of their life"

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -713,10 +713,14 @@
     display: inline-flex;
   }
   /* Faint dashed divider between the three stacked lines (LISTENING TO /
-     FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers. */
+     FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers. The gap
+     around each divider is tighter than the stack's outer padding: the block's
+     top padding (above the first line) and bottom padding (below the last)
+     stay at --space-2 via the container, while only these in-between gaps
+     shrink to --space-1 so the lines sit closer together. */
   .chrome-signals-secondary > .chrome-signal + .chrome-signal {
-    margin-top: var(--space-2);
-    padding-top: var(--space-2);
+    margin-top: var(--space-1);
+    padding-top: var(--space-1);
     border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 55%, transparent);
   }
 }

--- a/src/components/DayOfLifeTicker.jsx
+++ b/src/components/DayOfLifeTicker.jsx
@@ -6,9 +6,12 @@ export default function DayOfLifeTicker() {
   const tooltip = `Day ${day} · ${dayOfYear} of 365 · Year ${year}`;
   return (
     <span className="chrome-signal chrome-signal-day">
-      <span className="chrome-signal-label">day of life</span>
+      {/* Reads as one small-caps phrase — "on day 12,124 of their life" — with
+          only the number carrying the bold value ink. */}
       <TickerText className="chrome-signal-value" title={tooltip}>
-        <strong>{day.toLocaleString()}</strong>
+        <span className="chrome-signal-label">on day</span>{' '}
+        <strong>{day.toLocaleString()}</strong>{' '}
+        <span className="chrome-signal-label">of their life</span>
       </TickerText>
     </span>
   );


### PR DESCRIPTION
Recasts the expanded-chrome day-of-life signal and tightens the mobile atmosphere stack.

## Changes

**Day-of-life line reworded** — `src/components/DayOfLifeTicker.jsx`
- Was the `DAY OF LIFE  12,124` label/value pair; now reads as a single small-caps phrase, **"on day 12,124 of their life"**, with only the number carrying the bold value ink.
- Reuses the existing `chrome-signal-label` / `chrome-signal-value` classes, so the hover-scroll ticker and tooltip behave exactly as before. Shared component, so it updates both the mobile stack and the desktop vitals bar.

**Tighter mobile inter-line spacing** — `src/components/ChromeBar.css`
- On mobile the LISTENING TO / FOLLOWED BY / day-of-life lines now sit closer together: the in-between dashed-divider gaps drop from `--space-2` to `--space-1`.
- The block's outer top padding (above the first line) and bottom padding (below the last line) stay at `--space-2`, so only the gaps between lines shrink. The divider stays centered in each tightened gap.

## Verification

Ran the app in Chromium and drove the expanded chrome at mobile (402px) and desktop widths. Confirmed the reworded line renders as `on day 12,123 of their life` (live value for the test date), and measured the mobile stack: top/bottom padding unchanged at 8px, inter-line gaps reduced from 16px to 8px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011oDbhGTpow4Soz7WvW5EdL)_