### PR TITLE
Auto-scroll the chrome status as a repeating ticker tape

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -689,6 +689,65 @@
   will-change: transform;
 }
 
+/* Marquee mode (opt-in via the `marquee` prop — used by the status). When the
+   value overflows it auto-scrolls as a seamless, repeating ticker tape: two
+   copies chase each other on an infinite loop, so as the first slides off the
+   left the second is already following from the right. Hover/focus pauses it
+   in place for reading; a fitting value (no `data-playing`) just sits still. */
+.ticker-track {
+  display: inline-block;
+  white-space: nowrap;
+  will-change: transform;
+}
+
+.ticker-auto[data-playing='true'] .ticker-track {
+  /* The track holds two identical copies (each carrying the trailing gap), so
+     translating it by exactly -50% lands the second copy where the first
+     started — a jump-free wrap. Duration is set per-instance from the text
+     width so every status scrolls at the same pace. */
+  animation: ticker-scroll var(--ticker-duration, 8s) linear infinite;
+}
+
+/* Pause, so it can be read — hover with a pointer, or keyboard focus within
+   the (linked) status. Freezes in place rather than resetting. */
+.ticker-auto[data-playing='true']:hover .ticker-track,
+.ticker-auto[data-playing='true']:focus-within .ticker-track {
+  animation-play-state: paused;
+}
+
+.ticker-seg {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+/* The seamless-loop gap: baked into each copy as trailing padding so it's part
+   of the -50% travel (a plain flex/margin gap would throw the wrap point off).
+   Only present while looping. Must match MARQUEE_GAP in TickerText.jsx. */
+.ticker-auto[data-playing='true'] .ticker-seg {
+  padding-right: var(--ticker-gap, 44px);
+}
+
+.ticker-measure {
+  display: inline-block;
+}
+
+@keyframes ticker-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Continuous motion is opt-out under reduced-motion: the tail still fades, and
+   the value stays put (the title tooltip carries the full text). */
+@media (prefers-reduced-motion: reduce) {
+  .ticker-auto .ticker-track {
+    animation: none;
+  }
+}
+
 @media (max-width: 700px) {
   .chrome-signals-secondary {
     flex-direction: column;

--- a/src/components/NowStatus.jsx
+++ b/src/components/NowStatus.jsx
@@ -29,7 +29,7 @@ export default function NowStatus() {
   );
   return (
     <span className="chrome-signal chrome-signal-status">
-      <TickerText className="chrome-signal-value" title={tooltip || undefined}>
+      <TickerText className="chrome-signal-value" title={tooltip || undefined} marquee>
         {href ? (
           <Link to={href} className="chrome-signal-link">{inner}</Link>
         ) : (

--- a/src/components/TickerText.jsx
+++ b/src/components/TickerText.jsx
@@ -2,23 +2,40 @@ import { useEffect, useRef, useState } from 'react';
 import { motion, useReducedMotion } from 'motion/react';
 
 /**
- * Hover-reveal for truncated chrome-bar values. Renders a single copy of
- * the text inside a clipped container; when hovered/focused (and only then),
- * animates it left by exactly the overflow amount on a slow oscillation so
- * the trailing characters scroll into view, then back. No duplicate DOM, no
- * idle flicker.
+ * Truncation-aware scroller for chrome-bar values. Two modes:
  *
- *   <TickerText className="chrome-signal-value">
- *     {text}
- *   </TickerText>
+ * 1. Default (hover-reveal). Renders a single copy clipped by the container;
+ *    on hover/focus it eases left by exactly the overflow amount and back, so
+ *    the hidden tail comes into view on demand. Fully still when idle.
  *
- * Speed is proportional to overflow distance: ~40 px / second, capped 4–10s.
- * Respects `prefers-reduced-motion`: just shows ellipsis with no motion.
+ * 2. Marquee (`marquee` prop). When the text overflows, it auto-scrolls as a
+ *    seamless, repeating ticker tape — two copies chase each other on an
+ *    infinite CSS loop (translateX 0 → -50%). Hover/focus pauses it in place
+ *    so it can be read, and it collapses to a still, ellipsized copy when the
+ *    text fits or when reduced motion is requested.
+ *
+ *   <TickerText className="chrome-signal-value" marquee>{text}</TickerText>
+ *
+ * Both modes clip to the container, respect `prefers-reduced-motion`, and
+ * scroll at the same steady pace so the chrome reads as one system.
  */
-export default function TickerText({ children, className = '', title }) {
+
+// Scroll pace shared by both modes, in px/second — slow enough to read.
+const SPEED = 40;
+// Breathing room (px) between the tail of one marquee copy and the head of
+// the next. It's baked into each copy as padding, so translating the track by
+// exactly -50% lands the second copy precisely where the first began — the
+// seamless-loop invariant. The CSS `--ticker-gap` must match this value.
+const MARQUEE_GAP = 44;
+// Floor on a full loop so a barely-overflowing status still drifts gently
+// rather than snapping past in a fraction of a second.
+const MARQUEE_MIN_DURATION = 6;
+
+export default function TickerText({ children, className = '', title, marquee = false }) {
   const wrapRef = useRef(null);
   const innerRef = useRef(null);
   const [overflow, setOverflow] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
   const [hovered, setHovered] = useState(false);
   const reduce = useReducedMotion();
 
@@ -28,8 +45,11 @@ export default function TickerText({ children, className = '', title }) {
     if (!wrap || !inner) return undefined;
 
     function measure() {
-      const next = Math.max(0, inner.scrollWidth - wrap.clientWidth);
-      setOverflow(next);
+      // innerRef points at the (unpadded) content span in both modes, so this
+      // is the text's natural width regardless of any marquee gap padding.
+      const width = inner.scrollWidth;
+      setContentWidth(width);
+      setOverflow(Math.max(0, width - wrap.clientWidth));
     }
 
     measure();
@@ -40,6 +60,55 @@ export default function TickerText({ children, className = '', title }) {
   }, [children]);
 
   const truncated = overflow > 0;
+
+  // --- Marquee (auto-scrolling ticker tape) --------------------------------
+  if (marquee) {
+    // Only loop when the text actually overflows and motion is allowed. Both
+    // the second copy and the gap padding are gated on this, so a fitting or
+    // reduced-motion value renders as a single still copy (with the same fade
+    // as the hover mode's idle state).
+    const playing = truncated && !reduce;
+    // The track travels one copy-plus-gap per cycle; keep the pace constant so
+    // longer statuses take proportionally longer to loop.
+    const duration = playing
+      ? Math.max(MARQUEE_MIN_DURATION, (contentWidth + MARQUEE_GAP) / SPEED)
+      : 0;
+    return (
+      <span
+        ref={wrapRef}
+        className={`ticker ticker-auto ${className}`}
+        data-truncated={truncated ? 'true' : undefined}
+        data-playing={playing ? 'true' : undefined}
+        title={title}
+      >
+        <span
+          className="ticker-track"
+          style={
+            playing
+              ? { '--ticker-duration': `${duration}s`, '--ticker-gap': `${MARQUEE_GAP}px` }
+              : undefined
+          }
+        >
+          <span className="ticker-seg">
+            <span ref={innerRef} className="ticker-measure">
+              {children}
+            </span>
+          </span>
+          {/* Trailing copy that chases the first so the loop never shows a gap
+              at the wrap point. Purely decorative: `aria-hidden` keeps it out
+              of the accessibility tree and `inert` out of the tab order, so a
+              linked status isn't announced — or focusable — twice. */}
+          {playing && (
+            <span className="ticker-seg" aria-hidden="true" inert="">
+              <span className="ticker-measure">{children}</span>
+            </span>
+          )}
+        </span>
+      </span>
+    );
+  }
+
+  // --- Hover-reveal (default) ---------------------------------------------
   const playing = hovered && truncated && !reduce;
 
   return (
@@ -61,7 +130,7 @@ export default function TickerText({ children, className = '', title }) {
         transition={
           playing
             ? {
-                duration: Math.min(10, Math.max(4, overflow / 40)),
+                duration: Math.min(10, Math.max(4, overflow / SPEED)),
                 ease: 'linear',
                 repeat: Infinity,
                 repeatType: 'reverse',


### PR DESCRIPTION
When the top-chrome status is longer than the space it has, it now auto-animates as a seamless, repeating ticker tape that scrolls horizontally — instead of just sitting truncated behind a fade.

## What changed

- **`TickerText.jsx`** — added an opt-in `marquee` mode (the component was previously hover-reveal only). When the text overflows it renders two copies that chase each other on an infinite CSS loop (`translateX(0 → -50%)`, with the loop gap baked into each copy as padding so the wrap is jump-free). Pace is a steady ~40px/s regardless of length.
- **`NowStatus.jsx`** — one line: passes `marquee` so only the status auto-scrolls. The other chrome signals (listening-to, followed-by, day-of-life) keep their existing hover-reveal behavior.
- **`ChromeBar.css`** — the `ticker-scroll` keyframes plus the marquee rules.

## Behavior (verified in a browser)

| Case | Result |
|------|--------|
| Long / truncated status | Scrolls left continuously and loops seamlessly |
| Hover / keyboard focus | Pauses in place so it can be read |
| Short status | Stays completely still, single copy |
| `prefers-reduced-motion` | No animation; the tail just fades as before |
| Linked status | Duplicate copy is `aria-hidden` + `inert`, so screen readers and Tab only reach it once |

Pausing on hover/focus also keeps the moving content friendly to WCAG 2.2.2. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DYxKkhzuHQHBkVu4uTGp4

---
_Generated by [Claude Code](https://claude.ai/code/session_012DYxKkhzuHQHBkVu4uTGp4)_