### PR TITLE
Normalize iOS activity strings for icons + short labels

### DIFF
--- a/src/components/StateStats.jsx
+++ b/src/components/StateStats.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useReducedMotion } from 'motion/react';
 import { Heart, Flame, Volume2, Activity, Footprints, Bike, Car, Armchair } from 'lucide-react';
+import { activityLabel } from '../lib/activity.js';
 import './StateStats.css';
 
 /**
@@ -285,7 +286,7 @@ function ActivityBars({ rows }) {
           <li key={r.activity} className="state-bar-row">
             <span className="state-bar-label">
               <Icon className="state-bar-glyph" size={13} strokeWidth={1.75} aria-hidden="true" />
-              {r.activity}
+              {activityLabel(r.activity)}
             </span>
             <span className="state-bar-track" aria-hidden="true">
               <span className="state-bar-fill" style={{ width: `${max > 0 ? (r.pct / max) * 100 : 0}%` }} />

--- a/src/components/VitalsChip.jsx
+++ b/src/components/VitalsChip.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Heart, Flame, Footprints, Bike, Car, Armchair, Activity } from 'lucide-react';
 import { resolveVitalsFromRef } from '../lib/vitals.js';
+import { activityLabel } from '../lib/activity.js';
 import './VitalsChip.css';
 
 // A compact readout for the body-state a status carried — the "effort" signals
@@ -61,7 +62,7 @@ export default function VitalsChip({ stateRef, vitals: provided }) {
       {vitals.activity && (
         <span className="vitals-chip-item">
           <ActivityIcon className="vitals-chip-glyph" size={12} strokeWidth={1.75} aria-hidden="true" />
-          <span className="vitals-chip-word">{vitals.activity}</span>
+          <span className="vitals-chip-word">{activityLabel(vitals.activity)}</span>
         </span>
       )}
       {vitals.caloriesBurned != null && (

--- a/src/components/VitalsPanel.jsx
+++ b/src/components/VitalsPanel.jsx
@@ -4,6 +4,7 @@ import {
 } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { useDameState } from '../hooks/useDameState.js';
+import { activityLabel } from '../lib/activity.js';
 import DayOfLifeTicker from './DayOfLifeTicker.jsx';
 import './VitalsPanel.css';
 
@@ -79,9 +80,9 @@ export default function VitalsPanel() {
       )}
 
       {vitals.activity && (
-        <span className="vital vital-activity" aria-label={`Currently ${vitals.activity}`}>
+        <span className="vital vital-activity" aria-label={`Currently ${activityLabel(vitals.activity)}`}>
           <ActivityIcon className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
-          <span className="vital-word">{vitals.activity}</span>
+          <span className="vital-word">{activityLabel(vitals.activity)}</span>
         </span>
       )}
 

--- a/src/lib/activity.js
+++ b/src/lib/activity.js
@@ -1,0 +1,54 @@
+// Physical-activity string handling, shared by the state surfaces. The iPhone
+// reports activity as free-ish, inconsistently-worded strings ("Stationary",
+// "In a moving vehicle", …). Normalize them to a small set of canonical keys so
+// the icons resolve and the same state groups together, and give the wordier
+// ones a short display label.
+
+const ALIASES = {
+  stationary: 'stationary',
+  still: 'stationary',
+  idle: 'stationary',
+  walking: 'walking',
+  walk: 'walking',
+  'on foot': 'walking',
+  running: 'running',
+  run: 'running',
+  cycling: 'cycling',
+  biking: 'cycling',
+  bicycling: 'cycling',
+  'on a bicycle': 'cycling',
+  automotive: 'automotive',
+  driving: 'automotive',
+  'in a vehicle': 'automotive',
+  'in vehicle': 'automotive',
+  'in a moving vehicle': 'automotive',
+};
+
+/**
+ * Map a raw activity string to a canonical key (stationary | walking | running
+ * | cycling | automotive), or null for empty / "unknown". Falls back to loose
+ * keyword matching for phrasings we didn't enumerate, then to the raw lowercased
+ * string so an unrecognized-but-present activity still shows (generic icon).
+ */
+export function normalizeActivity(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim().toLowerCase().replace(/\s+/g, ' ');
+  if (!s || s === 'unknown') return null;
+  if (ALIASES[s]) return ALIASES[s];
+  if (/vehicle|driving|automotive/.test(s)) return 'automotive';
+  if (/cycl|bike|bicycl/.test(s)) return 'cycling';
+  if (/runn/.test(s)) return 'running';
+  if (/walk|on foot/.test(s)) return 'walking';
+  if (/stationary|not moving|standing still|\bstill\b|idle/.test(s)) return 'stationary';
+  return s;
+}
+
+const LABELS = {
+  automotive: 'in vehicle',
+};
+
+/** Short display label for a canonical activity key (defaults to the key). */
+export function activityLabel(key) {
+  if (!key) return '';
+  return LABELS[key] || key;
+}

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -5,6 +5,7 @@
 
 import { fetchSnapshot } from './snapshot.js';
 import { resolvePds, getRecord } from './atproto.js';
+import { normalizeActivity } from './activity.js';
 
 export function toInt(v) {
   if (v === null || v === undefined || v === '') return null;
@@ -34,15 +35,12 @@ export function clampPct(n) {
  */
 export function normalizeVitals(value) {
   if (!value) return null;
-  // Accept the raw iOS key (`physicalActivity`, e.g. "Stationary") as well as
-  // the normalized `activity`, the same way charging/sound accept their raw
-  // keys below — the Shortcut posts whichever it has.
-  const rawActivity = value.activity ?? value.physicalActivity;
-  const activity = rawActivity ? String(rawActivity).trim().toLowerCase() : null;
   return {
     heartRate: nonZero(toInt(value.heartRate)),
-    // `unknown` is the lexicon's "no reading" sentinel — treat it as absent too.
-    activity: activity && activity !== 'unknown' ? activity : null,
+    // The iOS activity string (raw `physicalActivity` or the normalized
+    // `activity`) → a canonical key, so icons resolve and states group even
+    // though the phone's wording varies. See lib/activity.js.
+    activity: normalizeActivity(value.activity ?? value.physicalActivity),
     batteryLevel: nonZero(clampPct(toInt(value.batteryLevel))),
     charging: toBool(value.charging ?? value.isCharging),
     soundLevel: nonZero(toInt(value.soundLevel ?? value.environmentSound)),


### PR DESCRIPTION
## What

The iPhone reports physical activity as inconsistently-worded strings — `"Stationary"`, `"In a moving vehicle"`, etc. The state surfaces keyed their icon lookups on exact lowercase names (`automotive`, `stationary`, …), so any phrasing that didn't match fell through to the generic icon and never changed — and long phrases like "in a moving vehicle" read awkwardly.

## Changes

- **New `src/lib/activity.js`**
  - `normalizeActivity(raw)` — maps varied phrasings to a small set of canonical keys (`stationary | walking | running | cycling | automotive`) via an alias table plus a loose keyword fallback; returns `null` for empty/`"unknown"`, and passes an unrecognized-but-present string through so it still shows (generic icon).
  - `activityLabel(key)` — short display label; `automotive` → **"in vehicle"**.
- **`src/lib/vitals.js`** — `normalizeVitals()` now delegates activity handling to `normalizeActivity()`, so every state surface receives a canonical key.
- **`VitalsPanel.jsx`, `VitalsChip.jsx`, `StateStats.jsx`** — render `activityLabel()` for the display text (and aria-label). Because the dashboard now aggregates on the canonical key, differently-worded readings for the same state group into one bar.

## Verification

- `npm run build:offline` passes.
- Logic check: `"in a moving vehicle"` → `automotive` → **"in vehicle"** (Car icon); canonical strings and keyword fallbacks map correctly; `"unknown"`/empty → absent.
- Playwright against the built app with a mock record: the atmosphere bar shows the Car icon + "in vehicle"; the `/logging` dashboard groups `"in a moving vehicle"` under a single **in vehicle** bar alongside stationary/walking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_