### PR TITLE
Use PersonStanding as the physical-activity fallback icon

### DIFF
--- a/src/components/StateStats.jsx
+++ b/src/components/StateStats.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useReducedMotion } from 'motion/react';
-import { Heart, Flame, Volume2, Activity, Footprints, Bike, Car, Armchair } from 'lucide-react';
+import { Heart, Flame, Volume2, Activity, PersonStanding, Footprints, Bike, Car, Armchair } from 'lucide-react';
 import { activityLabel } from '../lib/activity.js';
 import './StateStats.css';
 
@@ -281,7 +281,7 @@ function ActivityBars({ rows }) {
   return (
     <ul className="state-bars">
       {rows.map((r) => {
-        const Icon = ACTIVITY_ICON[r.activity] || Activity;
+        const Icon = ACTIVITY_ICON[r.activity] || PersonStanding;
         return (
           <li key={r.activity} className="state-bar-row">
             <span className="state-bar-label">

--- a/src/components/VitalsChip.jsx
+++ b/src/components/VitalsChip.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Heart, Flame, Footprints, Bike, Car, Armchair, Activity } from 'lucide-react';
+import { Heart, Flame, Footprints, Bike, Car, Armchair, PersonStanding } from 'lucide-react';
 import { resolveVitalsFromRef } from '../lib/vitals.js';
 import { activityLabel } from '../lib/activity.js';
 import './VitalsChip.css';
@@ -48,7 +48,7 @@ export default function VitalsChip({ stateRef, vitals: provided }) {
     vitals.heartRate != null || vitals.activity || vitals.caloriesBurned != null;
   if (!hasBody) return null;
 
-  const ActivityIcon = (vitals.activity && ACTIVITY_ICON[vitals.activity]) || Activity;
+  const ActivityIcon = (vitals.activity && ACTIVITY_ICON[vitals.activity]) || PersonStanding;
 
   return (
     <p className="vitals-chip" aria-label="Body-state captured with this status">

--- a/src/components/VitalsPanel.jsx
+++ b/src/components/VitalsPanel.jsx
@@ -1,5 +1,5 @@
 import {
-  Heart, Flame, Footprints, Bike, Car, Armchair, Activity, Volume2,
+  Heart, Flame, Footprints, Bike, Car, Armchair, PersonStanding, Volume2,
   BatteryLow, BatteryMedium, BatteryFull, BatteryCharging,
 } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
@@ -49,7 +49,7 @@ export default function VitalsPanel() {
   }
 
   const ActivityIcon =
-    (vitals.activity && ACTIVITY_ICON[vitals.activity]) || Activity;
+    (vitals.activity && ACTIVITY_ICON[vitals.activity]) || PersonStanding;
   const BatteryIcon =
     vitals.batteryLevel != null ? batteryIcon(vitals.batteryLevel, vitals.charging) : null;
 


### PR DESCRIPTION
## What

An unrecognized-but-present activity string (one that doesn't map to a canonical key) previously fell back to the generic lucide `Activity` pulse glyph, which reads as telemetry rather than a body state.

## Change

Swap the fallback icon to lucide **`PersonStanding`** across all three state surfaces — `VitalsPanel`, `VitalsChip`, and the `/logging` dashboard (`StateStats`) — so an unmapped activity still looks like an activity. `StateStats` keeps `Activity` imported for its panel-header glyph; only the per-item fallback changed.

The mapped icons are unchanged: stationary → `Armchair`, walking/running → `Footprints`, cycling → `Bike`, automotive → `Car`.

## Verification

- `npm run build:offline` passes.
- Playwright against the built app with a mock record whose activity is `"hiking"` (unrecognized → passes through raw → no specific icon): the atmosphere bar and the dashboard bar both render the `PersonStanding` figure instead of the old pulse glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_