### PR TITLE
Refine day-of-life chrome line: number spacing + divider color

### DIFF
--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -412,6 +412,16 @@
   font-weight: 600;
 }
 
+/* "on day N of their life" — lay the three pieces out with the same 0.45em
+   gap that .chrome-signal puts between a label and its value on every other
+   row, so the number gets equal, comfortable breathing room on both sides
+   instead of a tight word-space. */
+.chrome-signal-day-phrase {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45em;
+}
+
 .chrome-signal-status .chrome-signal-value {
   color: var(--ink-muted);
 }

--- a/src/components/ChromeBar.css
+++ b/src/components/ChromeBar.css
@@ -782,15 +782,16 @@
     display: inline-flex;
   }
   /* Faint dashed divider between the three stacked lines (LISTENING TO /
-     FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers. The gap
-     around each divider is tighter than the stack's outer padding: the block's
-     top padding (above the first line) and bottom padding (below the last)
-     stay at --space-2 via the container, while only these in-between gaps
-     shrink to --space-1 so the lines sit closer together. */
+     FOLLOWED BY / DAY OF LIFE), echoing the feed's thread dividers — same
+     dashed color-mix (--rule-soft at 60%) they use between thread posts. The
+     gap around each divider is tighter than the stack's outer padding: the
+     block's top padding (above the first line) and bottom padding (below the
+     last) stay at --space-2 via the container, while only these in-between
+     gaps shrink to --space-1 so the lines sit closer together. */
   .chrome-signals-secondary > .chrome-signal + .chrome-signal {
     margin-top: var(--space-1);
     padding-top: var(--space-1);
-    border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 55%, transparent);
+    border-top: 1px dashed color-mix(in srgb, var(--rule-soft) 60%, transparent);
   }
 }
 

--- a/src/components/DayOfLifeTicker.jsx
+++ b/src/components/DayOfLifeTicker.jsx
@@ -7,11 +7,16 @@ export default function DayOfLifeTicker() {
   return (
     <span className="chrome-signal chrome-signal-day">
       {/* Reads as one small-caps phrase — "on day 12,124 of their life" — with
-          only the number carrying the bold value ink. */}
+          only the number carrying the bold value ink. The inline-flex gap gives
+          the number the same breathing room on both sides as the label↔value
+          gap on every other chrome row (.chrome-signal's 0.45em), rather than a
+          tighter plain word-space. */}
       <TickerText className="chrome-signal-value" title={tooltip}>
-        <span className="chrome-signal-label">on day</span>{' '}
-        <strong>{day.toLocaleString()}</strong>{' '}
-        <span className="chrome-signal-label">of their life</span>
+        <span className="chrome-signal-day-phrase">
+          <span className="chrome-signal-label">on day</span>
+          <strong>{day.toLocaleString()}</strong>
+          <span className="chrome-signal-label">of their life</span>
+        </span>
       </TickerText>
     </span>
   );


### PR DESCRIPTION
Two small follow-ups to the "on day N of their life" chrome line (the wording change landed in #281).

## Changes

**Equal breathing room around the number** — `src/components/DayOfLifeTicker.jsx`, `src/components/ChromeBar.css`
- The phrase's three pieces were separated by plain word-spaces, so the number sat noticeably tighter than numbers on the other atmosphere rows.
- Wrap the phrase in an inline-flex using the chrome's standard `gap: 0.45em` — the same gap `.chrome-signal` puts between a label and its value on every other row — so the number gets equal, comfortable spacing on both sides. Verified in-browser: 0.449em on each side, symmetric.

**Match the stack divider to the feed's thread-post dividers** — `src/components/ChromeBar.css`
- The dashed dividers between the stacked chrome lines were mixed at `--rule-soft` 55%, a touch fainter than the dashed dividers used between thread posts in the feed (`--rule-soft` 60%, per `.feed-item-ledger` and the `DocumentMeta` dateline).
- Bumped to 60% so it renders with the same color/opacity. Verified: the divider's computed color now resolves to exactly `--rule-soft @ 60%`, identical to the thread-post divider expression.

## Verification

Drove the expanded chrome in Chromium at mobile width (402px): measured the number's side gaps (0.449em each, symmetric) and confirmed the divider's computed border color matches the thread-post divider expression exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011oDbhGTpow4Soz7WvW5EdL)_