### PR TITLE
Move physical activity to the end of the vitals row

### DIFF
--- a/src/components/VitalsPanel.jsx
+++ b/src/components/VitalsPanel.jsx
@@ -79,13 +79,6 @@ export default function VitalsPanel() {
         </span>
       )}
 
-      {vitals.activity && (
-        <span className="vital vital-activity" aria-label={`Currently ${activityLabel(vitals.activity)}`}>
-          <ActivityIcon className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
-          <span className="vital-word">{activityLabel(vitals.activity)}</span>
-        </span>
-      )}
-
       {BatteryIcon && (
         <span
           className={`vital vital-battery ${vitals.charging ? 'is-charging' : ''} ${
@@ -95,6 +88,15 @@ export default function VitalsPanel() {
         >
           <BatteryIcon className="vital-glyph" size={16} strokeWidth={1.75} aria-hidden="true" />
           <span className="vital-value">{vitals.batteryLevel}%</span>
+        </span>
+      )}
+
+      {/* Activity sits last — it's a word rather than a number, so it reads
+          cleanly at the end of the numeric run. */}
+      {vitals.activity && (
+        <span className="vital vital-activity" aria-label={`Currently ${activityLabel(vitals.activity)}`}>
+          <ActivityIcon className="vital-glyph" size={14} strokeWidth={1.75} aria-hidden="true" />
+          <span className="vital-word">{activityLabel(vitals.activity)}</span>
         </span>
       )}
 


### PR DESCRIPTION
## What

Reorder the atmosphere-bar vitals so **physical activity is the last item**.

Activity is a word rather than a number, so it now reads after the numeric run (heart / cal / dB / battery) instead of mid-row — keeping the figures grouped and the word as a natural tail. Day-of-life stays pinned to the right edge.

Order is now: **heart → cal → sound → battery → activity**.

## Verification

- `npm run build:offline` passes.
- Playwright against the built app with a mock record: the atmosphere bar renders `88 BPM · 430 CAL · 61 DB · 72% · in vehicle`, confirming activity now sits last, before the right-edge day-of-life ticker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_017PJieFnxGVg733zYqgRNGd)_