### PR TITLE
Inspect: show the Atmosphere Record panel directly on document pages

### DIFF
--- a/src/components/Xray.css
+++ b/src/components/Xray.css
@@ -282,39 +282,17 @@
   from { opacity: 0; transform: translateY(-0.35rem); }
   to   { opacity: 1; transform: none; }
 }
-.doc-inspect-note {
-  display: block;
-  width: 100%;
-  text-align: left;
-  font: inherit;
-  color: inherit;
-  background: var(--xr-field);
-  border: 0;
-  border-left: 2px solid var(--xr-frame);
-  padding: var(--space-2) var(--space-3);
-  cursor: pointer;
-}
-.doc-inspect-note .nsid { color: var(--xr-ink); display: block; font-size: 0.7rem; }
-.doc-inspect-note .uri { color: var(--ink-muted); display: block; font-size: 0.66rem; word-break: break-all; margin-top: 1px; }
-.doc-inspect-note .note { color: var(--ink-faint); display: block; font-size: 0.64rem; margin-top: 3px; }
-.doc-inspect-note .cta { color: var(--accent); display: block; font-size: 0.64rem; margin-top: var(--space-2); }
-.doc-inspect-note:hover .nsid { text-decoration: underline; }
 .doc-inspect-margin .xray-substrate { margin-top: 0; }
 
-/* Wide: float the note into the outer right margin as a true margin gloss. */
+/* Wide: float the record panel into the outer right margin as a true margin
+   gloss, clear of the reading column. */
 @media (min-width: 1080px) {
   .doc-inspect-margin {
     position: absolute;
     top: 0;
     left: 100%;
-    width: 16rem;
+    width: 18rem;
     margin: 0 0 0 var(--space-5);
-  }
-  .doc-inspect-margin.is-xray-focus { width: 18rem; }
-  .doc-inspect-note {
-    background: transparent;
-    border-left: 1px dashed var(--xr-frame);
-    padding: 0 0 0 var(--space-4);
   }
 }
 

--- a/src/components/XraySubstrate.jsx
+++ b/src/components/XraySubstrate.jsx
@@ -33,41 +33,29 @@ export function XrayTag({ atUri, onOpen }) {
 
 /**
  * Marginalia for a reading document (a blog post, a work) — the page is one
- * record, so this floats a single margin note beside the prose naming that
- * record, like a gloss in a book. Tapping it inspects: the note gives way to
- * the full you-are-here substrate panel, still in the margin. On narrow
- * screens (no room for a true margin) it stacks at the top of the document.
- * The document text itself is never dimmed — the note is additive marginalia.
+ * record, so this floats that record's atmosphere panel beside the prose like
+ * a gloss in a book. The whole document IS the one record, so there's nothing
+ * to disambiguate: under inspect it shows the full Atmosphere Record locus
+ * (pds → repo → collection → record → cid) directly, with no intermediate
+ * "tap to inspect" step. On narrow screens (no true margin) it stacks at the
+ * top of the document; the document text itself is never dimmed.
  */
-export function InspectMargin({ atUri, cid, note }) {
+export function InspectMargin({ atUri, cid }) {
   const xray = useXray();
   const parts = atUriParts(atUri);
   if (!parts) return null;
-  const focused = xray.active && xray.focusUri === atUri;
   const nsid = parts.nsid || nsidFromAtUri(atUri);
   return (
     <aside
-      className={`doc-inspect-margin${focused ? ' is-xray-focus' : ''}`}
+      className="doc-inspect-margin"
       data-atproto=""
       data-at-uri={atUri}
       data-nsid={nsid || undefined}
       aria-label="record"
     >
-      {focused ? (
-        <XraySubstratePanel atUri={atUri} cid={cid} />
-      ) : (
-        <button
-          type="button"
-          className="doc-inspect-note"
-          onClick={() => xray.focus(atUri)}
-          tabIndex={xray.active ? 0 : -1}
-        >
-          <span className="nsid">{nsid}</span>
-          <span className="uri">…/{parts.nsid}{parts.rkey}</span>
-          {note && <span className="note">{note}</span>}
-          <span className="cta">tap to inspect →</span>
-        </button>
-      )}
+      {/* The panel resolves the PDS, so only mount it once inspect is armed
+          (the aside is display:none until then). */}
+      {xray.active && <XraySubstratePanel atUri={atUri} cid={cid} />}
     </aside>
   );
 }

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -154,7 +154,7 @@ function StandardPostBody({ record, id, commentsUri, replies, repliesStatus }) {
       headTitle={`${title} — dame.is`}
     >
       <article className="blog-article reveal">
-        <InspectMargin atUri={record?.uri} cid={record?.cid} note="the whole post is one record" />
+        <InspectMargin atUri={record?.uri} cid={record?.cid} />
         <DocumentMeta date={created} />
         {/* The `description` field is intentionally not rendered here — it's the
             open-graph / feed-summary blurb, and on the post itself it just

--- a/src/pages/CreatingWork.jsx
+++ b/src/pages/CreatingWork.jsx
@@ -95,7 +95,7 @@ export default function CreatingWork() {
       headTitle={v?.title ? `${v.title} — dame.is` : `${slug} — dame.is`}
     >
       <article className="creating-work-page reveal">
-        <InspectMargin atUri={record?.uri} cid={record?.cid} note="the whole work is one record" />
+        <InspectMargin atUri={record?.uri} cid={record?.cid} />
         <DocumentMeta date={v?.createdAt} />
         {/* The summary is metadata — the feed-card / open-graph blurb, not page
             copy. For standard/leaflet docs it's auto-derived from the body's


### PR DESCRIPTION
On blog posts and works, the document margin under **inspect** had a two-step reveal: a collapsed "the whole post is one record / tap to inspect →" note that expanded to the full **Atmosphere Record** panel on tap. But the whole document *is* the one record — there's nothing to disambiguate — so the intermediate note was pure friction.

## Change
- The document margin now shows the Atmosphere Record panel (pds → repo → collection → record → cid, with the explorer / full-record links) **directly** under inspect, no "tap to inspect" step.
- The panel resolves the PDS, so it's still only mounted once inspect is armed (the aside is `display: none` until then — no eager network call on every document load).
- Drops the `note` prop from the `BlogPost` / `CreatingWork` call sites and the now-dead `.doc-inspect-note` styles; the wide-screen margin is always the panel width (18rem) now.

## Verification
Headless renders under inspect:
- **Mobile:** panel stacks in flow between the title and dateline.
- **Desktop:** panel floats into the right margin as marginalia, with the `blocks.text` labels in the left margin.
- Confirmed the note element is gone (`hasNote: false`) and the panel renders (`hasPanel: true`, heading "Atmosphere Record") at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzVxacnncEzLRLjEfJkHEP)_