### PR TITLE
Refine exploring + inspect UI: search icon, copy JSON, site-font chrome

### DIFF
--- a/src/components/Xray.css
+++ b/src/components/Xray.css
@@ -113,7 +113,7 @@
   gap: var(--space-2);
   align-items: baseline;
   flex-wrap: wrap;
-  font-family: var(--code);
+  font-family: var(--serif);
   font-size: calc(var(--text-xs) * 0.95);
   color: var(--ink-muted);
   max-height: 0;
@@ -158,7 +158,9 @@
   margin-top: var(--space-3);
   display: grid;
   gap: var(--space-3);
-  font-family: var(--code);
+  /* The chrome reads in the site's voice; only the protocol identifiers
+     (NSIDs, DIDs, rkeys, CIDs — the at-uri's parts) drop to --code below. */
+  font-family: var(--serif);
 }
 .xray-substrate-h {
   font-size: 0.64rem;
@@ -178,11 +180,13 @@
 }
 .locus-lvl .lead { color: var(--xr-frame); margin-left: -1em; }
 .locus-lvl .k { color: var(--ink-faint); }
+/* pds host + handle read as words (serif, inherited); the identifier values
+   below stay monospace so their exact characters read cleanly. */
 .locus-lvl .v { color: var(--ink-soft); word-break: break-all; }
-.locus-lvl .v.accent { color: var(--xr-ink); }
-.locus-lvl .vdim { color: var(--ink-faint); }
+.locus-lvl .v.accent { color: var(--xr-ink); font-family: var(--code); }
+.locus-lvl .vdim { color: var(--ink-faint); font-family: var(--code); }
 .locus-lvl.is-here { padding-top: 1px; padding-bottom: 1px; box-shadow: inset 2px 0 0 var(--accent); }
-.locus-lvl.is-here .v { color: var(--xr-ink); }
+.locus-lvl.is-here .v { color: var(--xr-ink); font-family: var(--code); }
 .locus-lvl .here-mark { color: var(--accent); }
 .locus-cid .kdim { color: var(--ink-faint); }
 .locus-cid .vdim { color: var(--ink-muted); }
@@ -190,7 +194,7 @@
 
 .xray-actions { display: flex; gap: var(--space-2); flex-wrap: wrap; margin-top: var(--space-1); }
 .xray-actions a, .xray-actions button {
-  font-family: var(--code); font-size: 0.68rem; letter-spacing: 0.04em;
+  font-family: var(--serif); font-size: var(--text-xs); letter-spacing: 0.02em;
   color: var(--ink-soft); background: var(--page); border: 1px solid var(--rule);
   padding: 3px var(--space-2); text-decoration: none; cursor: pointer;
 }
@@ -364,7 +368,8 @@
   gap: var(--space-2) var(--space-3);
   flex-wrap: wrap;
   padding: var(--space-3) var(--chrome-pad-x);
-  font-family: var(--code);
+  /* Site voice for the label + affordance; the at-uri keeps --code (.bp-uri). */
+  font-family: var(--serif);
   font-size: var(--text-xs);
   color: var(--ink-muted);
 }
@@ -377,10 +382,31 @@
 .xray-hud-spacer { flex: 1 1 auto; }
 .xray-hud-inspect {
   flex: none;
-  font-family: var(--code); font-size: 0.66rem; letter-spacing: 0.06em; text-transform: uppercase;
+  display: inline-flex; align-items: center; gap: var(--space-1);
+  font-family: var(--serif); font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase;
   color: var(--ink-soft); background: transparent; border: 1px solid var(--rule); padding: 3px var(--space-2); cursor: pointer;
 }
+.xray-hud-inspect svg { width: 13px; height: 13px; }
 .xray-hud-inspect:hover { color: var(--accent); border-color: var(--accent-soft); }
+
+/* Phones: the HUD rode three stacked lines (label / uri / button) and ate too
+   much of the screen above the chrome bar. Collapse it to one line — just the
+   truncated at-uri and a single icon affordance — by dropping the "inspecting"
+   label, the button text, and the pushing spacer, and letting the uri fill. */
+@media (max-width: 600px) {
+  .xray-hud {
+    flex-wrap: nowrap;
+    gap: var(--space-2);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+  }
+  .xray-hud-mark { display: none; }
+  .xray-hud-spacer { display: none; }
+  .xray-hud-inspect-label { display: none; }
+  .xray-hud-inspect { padding: var(--space-1) var(--space-2); }
+  .xray-hud-uri-link { flex: 1 1 auto; }
+  .xray-hud .bp-uri { max-width: 100%; }
+}
 
 /* Toggle button (chrome) active pulse when armed. */
 .chrome-xray.is-open .chrome-nav-glyph { animation: xray-pulse 2.4s ease-in-out infinite; }

--- a/src/components/XrayLayer.jsx
+++ b/src/components/XrayLayer.jsx
@@ -1,7 +1,7 @@
 import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
-import { Microscope } from 'lucide-react';
+import { ArrowUpRight, Microscope } from 'lucide-react';
 import { useXray } from '../hooks/useXray.jsx';
 import { useAtUri } from '../hooks/useAtUri.js';
 import { useActionDock } from '../hooks/useActionDock.jsx';
@@ -87,8 +87,14 @@ function XrayHud() {
           <span className="xray-hud-aggregate">the protocol data</span>
         )}
         <span className="xray-hud-spacer" />
-        <button type="button" className="xray-hud-inspect" onClick={openDetails}>
-          details ↗
+        <button
+          type="button"
+          className="xray-hud-inspect"
+          onClick={openDetails}
+          aria-label="Open atmosphere details"
+        >
+          <span className="xray-hud-inspect-label">details</span>
+          <ArrowUpRight aria-hidden strokeWidth={1.75} />
         </button>
       </div>
     </motion.div>

--- a/src/components/XraySubstrate.jsx
+++ b/src/components/XraySubstrate.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ME_DID, ME_HANDLE } from '../config.js';
 import { resolvePds, explorerPathFromAtUri } from '../lib/atproto.js';
-import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { useXray } from '../hooks/useXray.jsx';
 import { nsidFromAtUri } from '../lib/verbRegistry.js';
 import { atUriParts, parseAtUri, shortenCid, shortenDid } from '../lib/xray.js';
@@ -105,7 +104,6 @@ export function XraySubstratePanel({ atUri, cid }) {
   const pdsHost = pds ? String(pds).replace(/^https?:\/\//, '') : isMe ? 'resolving…' : 'unknown host';
   const repoLabel = isMe ? `@${ME_HANDLE}` : shortenDid(did) || did;
   const explorerPath = explorerPathFromAtUri(atUri);
-  const recordPath = recordPathFromAtUri(atUri);
 
   return (
     <div className="xray-substrate" role="group" aria-label="record location">
@@ -143,7 +141,6 @@ export function XraySubstratePanel({ atUri, cid }) {
 
       <div className="xray-actions">
         {explorerPath && <Link to={explorerPath}>open in explorer</Link>}
-        {recordPath && <Link to={recordPath}>view full record</Link>}
       </div>
     </div>
   );

--- a/src/pages/Exploring.css
+++ b/src/pages/Exploring.css
@@ -24,6 +24,16 @@
   font-family: var(--mono-ui, var(--mono));
 }
 
+/* The submit is an icon square that stretches to the input's height so the
+   two read as one control (no more short, misaligned text button). */
+.exploring-search-button {
+  align-self: stretch;
+  flex: none;
+  padding-block: 0;
+  padding-inline: var(--space-4);
+}
+.exploring-search-button svg { display: block; }
+
 /* Error hint */
 .exploring-error { display: flex; flex-direction: column; gap: var(--space-2); }
 .exploring-hint { color: var(--ink-soft); font-size: var(--text-sm); }
@@ -444,6 +454,12 @@
   font-size: var(--text-sm);
 }
 .exploring-record-site-link { color: var(--accent); }
+.exploring-record-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+.exploring-record-copy svg { display: block; }
 
 .exploring-editor { margin-top: var(--space-2); }
 

--- a/src/pages/Exploring.jsx
+++ b/src/pages/Exploring.jsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Check, Copy, Search } from 'lucide-react';
 import PageShell from '../components/PageShell.jsx';
 import ExploringHome from '../components/ExploringHome.jsx';
 import RecordEditor, { rkeyFromUri } from '../components/RecordEditor.jsx';
@@ -159,8 +160,13 @@ function SearchBox({ initial }) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
       />
-      <button type="submit" className="admin-gate-button admin-gate-button-tight">
-        Look up
+      <button
+        type="submit"
+        className="admin-gate-button exploring-search-button"
+        aria-label="Look up repo"
+        title="Look up"
+      >
+        <Search size={16} strokeWidth={1.75} aria-hidden />
       </button>
     </form>
   );
@@ -899,6 +905,7 @@ function RecordView({ identity, collection, rkey }) {
             Close editor
           </button>
         )}
+        {record && !editing && <CopyJsonButton record={record} />}
         {!session && (
           <SignInToEditButton
             signIn={signIn}
@@ -977,6 +984,40 @@ function SignInToEditButton({ signIn, target }) {
       }}
     >
       {busy ? 'Redirecting…' : 'Sign in to edit'}
+    </button>
+  );
+}
+
+/**
+ * Copy the focused record's JSON to the clipboard. Sits in the record's action
+ * row (above the raw JSON dump) and flips to a check for a beat on success.
+ */
+function CopyJsonButton({ record }) {
+  const [copied, setCopied] = useState(false);
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
+
+  async function onClick() {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(record, null, 2));
+      setCopied(true);
+      setTimeout(() => {
+        if (mounted.current) setCopied(false);
+      }, 1200);
+    } catch {
+      // Clipboard blocked (insecure context / permissions); no-op.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className="admin-link-subtle exploring-record-copy"
+      onClick={onClick}
+      title={copied ? 'Copied' : 'Copy JSON'}
+    >
+      {copied ? <Check size={14} aria-hidden /> : <Copy size={14} aria-hidden />}
+      <span>{copied ? 'Copied' : 'Copy JSON'}</span>
     </button>
   );
 }


### PR DESCRIPTION
Small UI refinements to the exploring pages and the inspect (x-ray) chrome.

## Changes

- **Search button → icon.** The exploring "Look up" text button is now a search-icon square that stretches to the input's height, so the two read as one control.
- **Copy JSON.** The record view gets a "Copy JSON" button inline with the record actions (above the raw JSON) that copies the record to the clipboard and flips to a ✓ on success.
- **Site font in inspect chrome.** The x-ray HUD status line ("the protocol data") and the **Atmosphere Record** substrate panel now read in the site's serif voice. Only the protocol identifiers stay monospace — NSIDs, DIDs, rkeys, CIDs, at-uris, and JSON — so their exact characters read cleanly.
- **Drop "view full record."** Removed from the substrate actions (a no-op for many records); "open in explorer" remains.
- **Compact mobile inspect HUD.** On phones the HUD collapses from three stacked lines to one — the truncated at-uri plus a single icon affordance — by hiding the "inspecting" label and the button text and letting the uri fill.

## Verification

Built (`vite build` clean) and driven in the running app with Playwright: confirmed the search button height match, the copy button placement, the serif/mono split in the Atmosphere Record panel (light + dark), the removed action, and the single-line mobile HUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lp3mNTdAqAp9gej151kZ8v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp3mNTdAqAp9gej151kZ8v)_