### PR TITLE
Re-enable the are.na mirror cron after the backfill

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,8 @@
   "trailingSlash": false,
   "crons": [
     { "path": "/api/rebuild", "schedule": "0 */6 * * *" },
-    { "path": "/api/mirror-mothing", "schedule": "50 5,11,17,23 * * *" }
+    { "path": "/api/mirror-mothing", "schedule": "50 5,11,17,23 * * *" },
+    { "path": "/api/mirror-arena", "schedule": "20 6 * * *" }
   ],
   "rewrites": [
     { "source": "/.well-known/site.standard.publication", "destination": "/api/well-known" },


### PR DESCRIPTION
The initial backfill is complete, so restore the daily `/api/mirror-arena` cron (6:20 UTC) for incremental upkeep. It was temporarily removed so the multi-day backfill could use the full write-points budget without contention. One-line change to `vercel.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BidDoP8mkC779zWzA95f8q)_