### PR TITLE
Add lexicon-backed sky theme tuning studio

### DIFF
--- a/lexicons/is.dame.sky.json
+++ b/lexicons/is.dame.sky.json
@@ -1,0 +1,50 @@
+{
+  "lexicon": 1,
+  "id": "is.dame.sky",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "description": "Tuning for the hour-tracking 'sky' theme (src/lib/skyTheme.js). A singleton at at://{me}/is.dame.sky/self. When `enabled`, each entry in `hours` layers a parametric override onto that hour's built-in palette — warming the borders and faint/muted text toward the horizon color, deepening them for contrast, optionally replacing the background, and adding a soft glow to chosen elements. When `enabled` is false (or no record exists), the site uses its hardcoded hourly derivation unchanged. Only hours that carry an override need to be listed. Edited in the admin 'Sky theme studio'.",
+      "record": {
+        "type": "object",
+        "required": ["enabled", "createdAt"],
+        "properties": {
+          "enabled": { "type": "boolean", "description": "Whether this record drives the sky palette. False = use the built-in derivation." },
+          "hours": {
+            "type": "array",
+            "maxLength": 24,
+            "description": "Per-hour tuning overrides. Each entry keys off its `hour` (0 = 12am Eastern … 23 = 11pm, matching og/time.js). Unlisted hours use the built-in palette.",
+            "items": { "type": "ref", "ref": "#hourTuning" }
+          },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "updatedAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    },
+    "hourTuning": {
+      "type": "object",
+      "description": "A single hour's parametric override. All knobs are optional and default to a no-op, so an entry with only `hour` renders identically to the built-in palette.",
+      "required": ["hour"],
+      "properties": {
+        "hour": { "type": "integer", "minimum": 0, "maximum": 23, "description": "Eastern hour this override applies to (0 = 12am … 23 = 11pm)." },
+        "pop": { "type": "string", "maxLength": 7, "description": "Horizon 'pop' hex the borders / faint-muted text / inline highlight warm toward, e.g. #efa82b. Defaults to this hour's horizon band." },
+        "page": { "type": "string", "maxLength": 7, "description": "Absolute page (background) hex. When set, the whole neutral ramp — page, chrome surfaces, ink, rules — re-derives from it; the art-based link accent stays tied to the frame. Omit to keep the sun-tracked background." },
+        "surfaceSep": { "type": "number", "minimum": 0.2, "maximum": 2.5, "description": "Multiplier on how far the chrome surfaces sit from the page (1 = built-in separation)." },
+        "ruleWarmth": { "type": "number", "minimum": 0, "maximum": 1, "description": "How far the borders blend toward the pop color (0 = keep their own hue, 1 = full pop hue)." },
+        "ruleContrast": { "type": "number", "minimum": 0, "maximum": 0.6, "description": "How much the borders are pushed away from the page for contrast (darker by day, lighter by night)." },
+        "inkWarmth": { "type": "number", "minimum": 0, "maximum": 1, "description": "How far the faint / muted text blends toward the pop color." },
+        "inkContrast": { "type": "number", "minimum": 0, "maximum": 0.6, "description": "How much the faint / muted text is pushed away from the page for contrast." },
+        "glowColor": { "type": "string", "maxLength": 7, "description": "Glow / shine hex. Defaults to the pop color." },
+        "glowSize": { "type": "number", "minimum": 0, "maximum": 64, "description": "Glow blur radius in px. 0 = no glow." },
+        "glowStrength": { "type": "number", "minimum": 0, "maximum": 1, "description": "Glow opacity 0–1. 0 = no glow." },
+        "glowTargets": {
+          "type": "array",
+          "maxLength": 4,
+          "description": "Which element families receive the glow.",
+          "items": { "type": "string", "knownValues": ["buttons", "avatar", "accentText", "controls"] }
+        }
+      }
+    }
+  }
+}

--- a/scripts/prefetch.mjs
+++ b/scripts/prefetch.mjs
@@ -142,6 +142,17 @@ async function main() {
   );
   await writeJson('nav', navRecord || {});
 
+  // --- Sky theme override (is.dame.sky/self) --------------------------------
+  // Optional PDS override for the hour-tracking sky palette; snapshotted so the
+  // first paint picks up the tuning without waiting on the live record. getRecord
+  // 404s until one exists — `safe` degrades it to {} and the built-in palette stands.
+  const skyRecord = await safe(
+    'getRecord:sky',
+    () => getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.sky, rkey: 'self' }),
+    null,
+  );
+  await writeJson('sky', skyRecord || {});
+
   // --- is.dame.page (pages keyed by rkey) -----------------------------------
   const pageRecords = backfillTimestamps(
     await safe(

--- a/src/components/SkyThemeStudio.css
+++ b/src/components/SkyThemeStudio.css
@@ -1,0 +1,422 @@
+/* Sky theme studio. Reuses the shared admin-* field / button styles and
+   adds the studio-specific chrome: the hour arc, the live preview card, the
+   contrast readout, and the site-native control grid. Square corners,
+   hairline rules, mono ledger accents — in keeping with the rest of admin. */
+
+.sky-enable,
+.sky-live {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--rule);
+}
+.sky-enable input,
+.sky-live input {
+  margin-top: 0.2em;
+  accent-color: var(--accent);
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+}
+.sky-enable span:not(.sky-enable-hint) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+.sky-enable strong {
+  font-weight: 600;
+}
+.sky-enable-hint {
+  color: var(--ink-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
+}
+.sky-live {
+  border-bottom: 0;
+  align-items: center;
+  color: var(--ink-soft);
+  font-size: var(--text-sm);
+}
+
+/* ---- hour arc ---- */
+.sky-arc-wrap {
+  margin: var(--space-5) 0 var(--space-4);
+}
+.sky-arc-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-2);
+}
+.sky-arc-meta {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.sky-dot,
+.sky-arc-meta .sky-dot {
+  display: inline-block;
+  width: 0.7em;
+  height: 3px;
+  background: var(--accent);
+  vertical-align: middle;
+}
+.sky-arc {
+  display: grid;
+  grid-template-columns: repeat(24, 1fr);
+  gap: 2px;
+  border: 1px solid var(--rule);
+  padding: 2px;
+  background: var(--rule-soft);
+}
+.sky-arc-cell {
+  position: relative;
+  height: 38px;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+}
+.sky-arc-cell:hover {
+  filter: brightness(1.08);
+}
+.sky-arc-cell.is-ovr::before {
+  content: '';
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  top: 1px;
+  height: 3px;
+  background: var(--accent);
+}
+.sky-arc-cell.is-sel {
+  box-shadow: inset 0 0 0 2px var(--ink), inset 0 0 0 3px var(--page);
+  z-index: 1;
+}
+.sky-arc-cell:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--accent);
+  z-index: 2;
+}
+.sky-arc-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+.sky-step {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--rule);
+  background: var(--surface-raised);
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+.sky-step:hover {
+  color: var(--ink);
+  border-color: var(--accent-soft);
+}
+.sky-hour-name {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  min-width: 12ch;
+  text-align: center;
+}
+.sky-hour-tag {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ---- live preview card ---- */
+.sky-preview {
+  background: var(--page);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  overflow: hidden;
+  margin: var(--space-4) 0 var(--space-3);
+}
+.sky-pv-chrome {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--rule);
+}
+.sky-pv-avatar {
+  width: 26px;
+  height: 26px;
+  object-fit: cover;
+  flex: none;
+  box-shadow: var(--glow-avatar, none);
+}
+.sky-pv-avatar-empty {
+  background: var(--rule);
+}
+.sky-pv-id {
+  font-size: var(--text-sm);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.sky-pv-note {
+  color: var(--ink-muted);
+}
+.sky-pv-ago {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  flex: none;
+}
+.sky-pv-body {
+  padding: var(--space-3);
+}
+.sky-pv-hero {
+  font-size: var(--text-xl);
+  line-height: var(--leading-tight);
+  font-weight: 600;
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--rule-soft);
+}
+.sky-pv-faint {
+  color: var(--ink-faint);
+}
+.sky-pv-muted {
+  color: var(--ink-muted);
+}
+.sky-pv-accent {
+  color: var(--accent);
+  text-shadow: var(--glow-accent, none);
+}
+.sky-pv-nav {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+.sky-pv-cta {
+  font-size: var(--text-sm);
+  padding: 0.3em 0.7em;
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  box-shadow: var(--glow-controls, none);
+}
+.sky-pv-cta-primary {
+  background: var(--accent);
+  color: var(--page);
+  border-color: color-mix(in srgb, var(--accent) 80%, #000);
+  box-shadow: var(--glow-buttons, none);
+}
+.sky-pv-row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr auto;
+  gap: var(--space-2);
+  align-items: baseline;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--rule-soft);
+}
+.sky-pv-row:last-child {
+  border-bottom: 0;
+}
+.sky-pv-lbl {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+.sky-pv-ttl {
+  font-size: var(--text-sm);
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sky-pv-hl {
+  color: var(--tan);
+  font-weight: 600;
+}
+.sky-pv-tm {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+/* ---- contrast readout ---- */
+.sky-readout {
+  border: 1px solid var(--rule);
+  margin: var(--space-4) 0;
+}
+.sky-read-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--rule-soft);
+}
+.sky-read-row:last-child {
+  border-bottom: 0;
+}
+.sky-read-name {
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+}
+.sky-read-nums {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+}
+.sky-read-arrow {
+  color: var(--ink-faint);
+}
+.sky-read-target {
+  color: var(--ink-faint);
+}
+.sky-chip {
+  padding: 0.15em 0.55em;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid transparent;
+}
+.sky-chip.good {
+  color: #2f8f63;
+  background: color-mix(in srgb, #2f8f63 12%, transparent);
+}
+.sky-chip.warn {
+  color: #a9701b;
+  background: color-mix(in srgb, #a9701b 12%, transparent);
+}
+.sky-chip.bad {
+  color: #bd453c;
+  background: color-mix(in srgb, #bd453c 12%, transparent);
+}
+
+/* ---- controls ---- */
+.sky-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  margin: var(--space-5) 0;
+}
+.sky-group > .admin-collection-group-heading {
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--rule);
+}
+.sky-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-5);
+}
+.sky-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.sky-color-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.sky-color-row input[type='color'] {
+  width: 40px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--rule);
+  background: var(--page);
+  cursor: pointer;
+}
+.sky-color-hex {
+  font-family: var(--mono-ui);
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  text-transform: uppercase;
+}
+.sky-reset {
+  font-family: var(--mono-ui);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  background: transparent;
+  border: 1px solid var(--rule);
+  padding: 0.25em 0.5em;
+  cursor: pointer;
+}
+.sky-reset:hover {
+  color: var(--ink);
+  border-color: var(--accent-soft);
+}
+.sky-num-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.sky-num {
+  width: 5.5rem;
+  text-align: right;
+}
+.sky-num-suffix {
+  font-family: var(--mono-ui);
+  font-size: var(--text-sm);
+  color: var(--ink-faint);
+}
+.sky-targets {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.sky-targets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: var(--space-2) var(--space-4);
+}
+.sky-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-size: var(--text-sm);
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+.sky-check input {
+  accent-color: var(--accent);
+  width: 0.95rem;
+  height: 0.95rem;
+  flex: none;
+}
+
+/* ---- actions ---- */
+.sky-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--rule);
+}
+
+@media (max-width: 560px) {
+  .sky-arc-cell {
+    height: 30px;
+  }
+  .sky-pv-row {
+    grid-template-columns: 4.5rem 1fr auto;
+  }
+}

--- a/src/components/SkyThemeStudio.jsx
+++ b/src/components/SkyThemeStudio.jsx
@@ -1,0 +1,450 @@
+// Admin studio for is.dame.sky/self — the optional PDS override for the
+// hour-tracking sky theme (src/lib/skyTheme.js). Pick any of the 24 hours
+// and tune it: adjust the background, warm the borders and faint/muted
+// text toward the horizon for contrast, and add a soft glow to chosen
+// elements. Edits preview live on the whole site (tune on the fly) and
+// nothing persists until Save. With the override toggled off (or no
+// record), the site uses its built-in hourly palette. Follows the same
+// contract + shell as NavMenuPanel; controls are the site's own vocabulary
+// (color inputs, numeric fields, square/hairline chrome — no sliders).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageShell from './PageShell.jsx';
+import { AdminRecordListSkeleton } from './Skeleton.jsx';
+import {
+  paletteForHour,
+  applySkyTheme,
+  easternHour,
+  skyHourKey,
+  defaultPopForHour,
+} from '../lib/skyTheme.js';
+import {
+  recordToDraft,
+  draftToHoursArray,
+  draftToTuning,
+  identityHourCfg,
+  hasOverride,
+  GLOW_GROUPS,
+} from '../lib/skyTuning.js';
+import { skyAvatarUrl } from '../lib/skyAvatars.js';
+import { useTheme } from '../hooks/useTheme.jsx';
+import { SKY_NSID } from '../config.js';
+import './SkyThemeStudio.css';
+
+/* ---------- small color kit (hex + WCAG contrast) ---------- */
+function hexToRgb(hex) {
+  const n = parseInt(String(hex || '').replace('#', ''), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+function relLum(hex) {
+  const lin = hexToRgb(hex).map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+function contrast(a, b) {
+  const l1 = relLum(a);
+  const l2 = relLum(b);
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+const grade = (ratio, target) => (ratio >= target ? 'good' : ratio >= target * 0.8 ? 'warn' : 'bad');
+
+// Map a paletteForHour() var set onto the real theme-token custom props, so
+// the preview subtree renders in exactly the tuned palette.
+function previewStyle(vars) {
+  return {
+    '--page': vars['--sky-page'],
+    '--page-edge': vars['--sky-page-edge'],
+    '--surface-raised': vars['--sky-surface-raised'],
+    '--ink': vars['--sky-ink'],
+    '--ink-soft': vars['--sky-ink-soft'],
+    '--ink-muted': vars['--sky-ink-muted'],
+    '--ink-faint': vars['--sky-ink-faint'],
+    '--rule': vars['--sky-rule'],
+    '--rule-soft': vars['--sky-rule-soft'],
+    '--accent': vars['--sky-accent'],
+    '--accent-soft': vars['--sky-accent-soft'],
+    '--tan': vars['--sky-tan'],
+    '--glow-buttons': vars['--sky-glow-buttons'],
+    '--glow-avatar': vars['--sky-glow-avatar'],
+    '--glow-accent': vars['--sky-glow-accent'],
+    '--glow-controls': vars['--sky-glow-controls'],
+  };
+}
+
+const hourLabel = (h) => skyHourKey(h).replace('am', ' AM').replace('pm', ' PM').toUpperCase();
+
+export default function SkyThemeStudio({ agent, did }) {
+  const { installSkyTuning } = useTheme();
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [byHour, setByHour] = useState(null);
+  const [createdAt, setCreatedAt] = useState(null);
+  const [hour, setHour] = useState(() => easternHour());
+  const [liveApply, setLiveApply] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [flash, setFlash] = useState(false);
+
+  // Load the existing override (or seed the two shoulder hours with the fix).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      let record = null;
+      try {
+        const res = await agent.com.atproto.repo.getRecord({ repo: did, collection: SKY_NSID, rkey: 'self' });
+        record = res?.data ? { value: res.data.value } : null;
+      } catch {
+        record = null; // 404 until one exists
+      }
+      if (cancelled) return;
+      const draft = recordToDraft(record);
+      setEnabled(draft.enabled);
+      setByHour(draft.byHour);
+      setCreatedAt(draft.createdAt);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did]);
+
+  // Live preview on the whole site (tune on the fly). Forces the override on
+  // for the previewed hour regardless of the enable toggle, so a dormant
+  // draft still previews. Restores the real hour when off / on unmount.
+  useEffect(() => {
+    if (loading || !byHour) return undefined;
+    if (liveApply) applySkyTheme(hour, draftToTuning(true, byHour));
+    else applySkyTheme(easternHour());
+    return undefined;
+  }, [loading, liveApply, hour, byHour]);
+  useEffect(() => () => applySkyTheme(easternHour()), []);
+
+  const cfg = byHour ? byHour[hour] : null;
+
+  const patchHour = useCallback(
+    (fields) => {
+      setByHour((prev) => ({ ...prev, [hour]: { ...prev[hour], ...fields } }));
+    },
+    [hour],
+  );
+  const patchGlowTarget = useCallback(
+    (group, on) => {
+      setByHour((prev) => ({
+        ...prev,
+        [hour]: { ...prev[hour], glowTargets: { ...prev[hour].glowTargets, [group]: on } },
+      }));
+    },
+    [hour],
+  );
+  const resetHour = useCallback(() => {
+    setByHour((prev) => ({ ...prev, [hour]: identityHourCfg(hour) }));
+  }, [hour]);
+
+  // Tuned + baseline palettes for the selected hour, for the preview + readout.
+  const tunedVars = useMemo(
+    () => (byHour ? paletteForHour(hour, draftToTuning(true, byHour)).vars : null),
+    [byHour, hour],
+  );
+  const baseVars = useMemo(() => paletteForHour(hour, null).vars, [hour]);
+
+  const rows = useMemo(() => {
+    if (!tunedVars) return [];
+    const defs = [
+      { name: 'muted ink · on page', a: '--sky-ink-muted', bg: '--sky-page', target: 4.5 },
+      { name: 'faint ink · on page', a: '--sky-ink-faint', bg: '--sky-page', target: 3.0 },
+      { name: 'muted · on chrome', a: '--sky-ink-muted-raised', bg: '--sky-surface-raised', target: 4.0 },
+      { name: 'rule · on page', a: '--sky-rule', bg: '--sky-page', target: 3.0 },
+    ];
+    return defs.map((d) => ({
+      name: d.name,
+      target: d.target,
+      now: contrast(baseVars[d.a], baseVars[d.bg]),
+      tuned: contrast(tunedVars[d.a], tunedVars[d.bg]),
+    }));
+  }, [tunedVars, baseVars]);
+
+  const overriddenCount = useMemo(
+    () => (byHour ? Object.keys(byHour).filter((h) => hasOverride(byHour[h])).length : 0),
+    [byHour],
+  );
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setFlash(false);
+    try {
+      const hours = draftToHoursArray(byHour);
+      const now = new Date().toISOString();
+      const record = {
+        $type: SKY_NSID,
+        enabled,
+        hours,
+        createdAt: createdAt || now,
+        updatedAt: now,
+      };
+      await agent.com.atproto.repo.putRecord({ repo: did, collection: SKY_NSID, rkey: 'self', record });
+      setCreatedAt(record.createdAt);
+      // Push onto the live site immediately (or clear it, if disabled).
+      installSkyTuning(record);
+      setFlash(true);
+      setTimeout(() => setFlash(false), 2400);
+    } catch (err) {
+      setError(err?.message || String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const avatarUrl = skyAvatarUrl(hour);
+  const isDay = byHour ? paletteForHour(hour, null).day : true;
+
+  return (
+    <PageShell
+      title="Sky theme studio"
+      intro="Tune the hour-tracking palette. Pick an hour, adjust its background, warm the borders and faint/muted text toward the horizon for contrast, and add a soft glow to chosen elements. Edits preview live on the site; nothing is written until you Save. Turn the override off to fall back to the built-in palette."
+      headTitle="Sky theme studio — Admin — dame.is"
+    >
+      <div className="admin-toolbar">
+        <Link to="/admin" className="admin-link-subtle">← All collections</Link>
+        <code className="admin-collection-nsid">{SKY_NSID}/self</code>
+      </div>
+
+      {error && <p className="admin-error">{error}</p>}
+
+      {loading || !byHour ? (
+        <AdminRecordListSkeleton rows={5} />
+      ) : (
+        <>
+          <label className="sky-enable">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+            <span>
+              <strong>Use this override</strong>
+              <span className="sky-enable-hint">
+                {enabled
+                  ? 'Live on the site — the tuned hours below drive the palette for everyone.'
+                  : 'Off — the site is using its built-in palette. Your edits are saved but dormant.'}
+              </span>
+            </span>
+          </label>
+
+          {/* ---- hour arc ---- */}
+          <div className="sky-arc-wrap">
+            <div className="sky-arc-head">
+              <span className="admin-field-label">Hour</span>
+              <span className="sky-arc-meta">
+                {overriddenCount} of 24 tuned · <span className="sky-dot" /> has override
+              </span>
+            </div>
+            <div className="sky-arc" role="tablist" aria-label="Hour">
+              {Array.from({ length: 24 }, (_, h) => {
+                const pv = paletteForHour(h, draftToTuning(true, byHour)).vars['--sky-page'];
+                return (
+                  <button
+                    key={h}
+                    type="button"
+                    role="tab"
+                    aria-selected={h === hour}
+                    className={`sky-arc-cell ${h === hour ? 'is-sel' : ''} ${hasOverride(byHour[h]) ? 'is-ovr' : ''}`}
+                    style={{ background: pv }}
+                    title={skyHourKey(h)}
+                    onClick={() => setHour(h)}
+                  />
+                );
+              })}
+            </div>
+            <div className="sky-arc-nav">
+              <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 23) % 24)} aria-label="Previous hour">‹</button>
+              <span className="sky-hour-name">{hourLabel(hour)} <span className="sky-hour-tag">{isDay ? 'day' : 'night'}{hasOverride(cfg) ? ' · override' : ''}</span></span>
+              <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 1) % 24)} aria-label="Next hour">›</button>
+            </div>
+          </div>
+
+          {/* ---- preview ---- */}
+          <div className="sky-preview" style={previewStyle(tunedVars)}>
+            <div className="sky-pv-chrome">
+              {avatarUrl ? (
+                <img className="sky-pv-avatar" src={avatarUrl} alt="" />
+              ) : (
+                <span className="sky-pv-avatar sky-pv-avatar-empty" />
+              )}
+              <span className="sky-pv-id"><b>dame.is</b> <span className="sky-pv-note">trying to take a nap</span></span>
+              <span className="sky-pv-ago">1h</span>
+            </div>
+            <div className="sky-pv-body">
+              <div className="sky-pv-hero">
+                <span className="sky-pv-faint">who</span> <span className="sky-pv-muted">unconsciously</span>{' '}
+                <span className="sky-pv-accent">hums christmas music</span>
+              </div>
+              <div className="sky-pv-nav">
+                <span className="sky-pv-cta sky-pv-cta-primary">Resume</span>
+                <span className="sky-pv-cta">Projects</span>
+                <span className="sky-pv-cta">Blog</span>
+              </div>
+              <div className="sky-pv-row">
+                <span className="sky-pv-lbl">listening</span>
+                <span className="sky-pv-ttl">KNOWER, clown core · <span className="sky-pv-hl">5 songs</span></span>
+                <span className="sky-pv-tm">6:02 pm</span>
+              </div>
+              <div className="sky-pv-row">
+                <span className="sky-pv-lbl">posting</span>
+                <span className="sky-pv-ttl">The Hi-C Department of Fruit Punch</span>
+                <span className="sky-pv-tm">3:58 pm</span>
+              </div>
+            </div>
+          </div>
+
+          <label className="sky-live">
+            <input type="checkbox" checked={liveApply} onChange={(e) => setLiveApply(e.target.checked)} />
+            <span>Preview this hour on the whole site while I tune</span>
+          </label>
+
+          {/* ---- contrast readout ---- */}
+          <div className="sky-readout">
+            {rows.map((r) => (
+              <div key={r.name} className="sky-read-row">
+                <span className="sky-read-name">{r.name}</span>
+                <span className="sky-read-nums">
+                  <span className={`sky-chip ${grade(r.now, r.target)}`}>{r.now.toFixed(2)}</span>
+                  <span className="sky-read-arrow">→</span>
+                  <span className={`sky-chip ${grade(r.tuned, r.target)}`}>{r.tuned.toFixed(2)}</span>
+                  <span className="sky-read-target">/ {r.target.toFixed(1)}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* ---- controls ---- */}
+          <div className="sky-controls">
+            <section className="sky-group">
+              <h3 className="admin-collection-group-heading small-caps">Background</h3>
+              <div className="sky-fields">
+                <ColorField
+                  label="Page color"
+                  hint={cfg.page ? 'custom' : 'auto (sun-tracked)'}
+                  value={cfg.page || baseVars['--sky-page']}
+                  onChange={(v) => patchHour({ page: v })}
+                  onReset={cfg.page ? () => patchHour({ page: null }) : null}
+                />
+                <NumberField label="Surface separation" value={cfg.surfaceSep} min={0.4} max={2} step={0.1} onChange={(v) => patchHour({ surfaceSep: v })} />
+              </div>
+            </section>
+
+            <section className="sky-group">
+              <h3 className="admin-collection-group-heading small-caps">Horizon pop</h3>
+              <div className="sky-fields">
+                <ColorField
+                  label="Pop color"
+                  hint="warms borders + text + highlight"
+                  value={cfg.pop}
+                  onChange={(v) => patchHour({ pop: v })}
+                  onReset={cfg.pop !== defaultPopForHour(hour) ? () => patchHour({ pop: defaultPopForHour(hour) }) : null}
+                />
+              </div>
+            </section>
+
+            <section className="sky-group">
+              <h3 className="admin-collection-group-heading small-caps">Borders</h3>
+              <div className="sky-fields">
+                <NumberField label="Warmth" suffix="%" value={Math.round(cfg.ruleWarmth * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ ruleWarmth: v / 100 })} />
+                <NumberField label="Contrast" value={cfg.ruleContrast} min={0} max={0.45} step={0.02} onChange={(v) => patchHour({ ruleContrast: v })} />
+              </div>
+            </section>
+
+            <section className="sky-group">
+              <h3 className="admin-collection-group-heading small-caps">Faint &amp; muted text</h3>
+              <div className="sky-fields">
+                <NumberField label="Warmth" suffix="%" value={Math.round(cfg.inkWarmth * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ inkWarmth: v / 100 })} />
+                <NumberField label="Contrast" value={cfg.inkContrast} min={0} max={0.45} step={0.02} onChange={(v) => patchHour({ inkContrast: v })} />
+              </div>
+            </section>
+
+            <section className="sky-group">
+              <h3 className="admin-collection-group-heading small-caps">Glow / shine</h3>
+              <div className="sky-fields">
+                <ColorField label="Glow color" value={cfg.glowColor} onChange={(v) => patchHour({ glowColor: v })} onReset={cfg.glowColor !== cfg.pop ? () => patchHour({ glowColor: cfg.pop }) : null} />
+                <NumberField label="Size" suffix="px" value={cfg.glowSize} min={0} max={48} step={2} onChange={(v) => patchHour({ glowSize: v })} />
+                <NumberField label="Strength" suffix="%" value={Math.round(cfg.glowStrength * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ glowStrength: v / 100 })} />
+              </div>
+              <div className="sky-targets">
+                <span className="admin-field-label">Applies to</span>
+                <div className="sky-targets-grid">
+                  {GLOW_GROUPS.map((g) => (
+                    <label key={g} className="sky-check">
+                      <input type="checkbox" checked={Boolean(cfg.glowTargets[g])} onChange={(e) => patchGlowTarget(g, e.target.checked)} />
+                      {GLOW_LABELS[g]}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <div className="sky-actions">
+            <button type="button" className="admin-gate-button" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : flash ? 'Saved ✓' : 'Save'}
+            </button>
+            <button type="button" className="admin-link-subtle" onClick={resetHour} disabled={saving}>
+              Reset {skyHourKey(hour)}
+            </button>
+          </div>
+        </>
+      )}
+    </PageShell>
+  );
+}
+
+const GLOW_LABELS = {
+  buttons: 'Accent buttons',
+  avatar: 'Avatar mark',
+  accentText: 'Accent text',
+  controls: 'Outlined controls',
+};
+
+function ColorField({ label, hint, value, onChange, onReset }) {
+  return (
+    <label className="sky-field sky-color-field">
+      <span className="admin-field-label">
+        {label}
+        {hint ? <span className="admin-field-hint"> {hint}</span> : null}
+      </span>
+      <span className="sky-color-row">
+        <input type="color" value={value} onChange={(e) => onChange(e.target.value)} />
+        <code className="sky-color-hex">{value}</code>
+        {onReset ? (
+          <button type="button" className="sky-reset" onClick={onReset} title="Reset to default">reset</button>
+        ) : null}
+      </span>
+    </label>
+  );
+}
+
+function NumberField({ label, hint, value, min, max, step, suffix, onChange }) {
+  return (
+    <label className="sky-field sky-num-field">
+      <span className="admin-field-label">
+        {label}
+        {hint ? <span className="admin-field-hint"> {hint}</span> : null}
+      </span>
+      <span className="sky-num-row">
+        <input
+          className="admin-input sky-num"
+          type="number"
+          value={value}
+          min={min}
+          max={max}
+          step={step}
+          onChange={(e) => {
+            const n = Number(e.target.value);
+            if (Number.isFinite(n)) onChange(Math.min(max, Math.max(min, n)));
+          }}
+        />
+        {suffix ? <span className="sky-num-suffix">{suffix}</span> : null}
+      </span>
+    </label>
+  );
+}

--- a/src/config.js
+++ b/src/config.js
@@ -88,6 +88,15 @@ export const STATE_NSID = 'is.dame.state';
 // routes in src/lib/navRoutes.js. Edited in the admin "Nav menu" panel.
 export const NAV_NSID = 'is.dame.nav';
 
+// --- sky theme ---------------------------------------------------------------
+// Optional PDS override for the hour-tracking "sky" theme. The singleton at
+// is.dame.sky/self carries per-hour parametric tuning (horizon pop, warmth,
+// contrast, background color, glow) that layers on top of the built-in
+// derivation in src/lib/skyTheme.js. When its `enabled` flag is off (or no
+// record exists) the site uses the hardcoded hourly palette unchanged. Edited
+// live in the admin "Sky theme studio" panel; snapshotted to public/data/sky.json.
+export const SKY_NSID = 'is.dame.sky';
+
 // Infrastructure-only collections (not surfaced as feed verbs).
 const PAGE_NSID = 'is.dame.page';
 const PROFILE_NSID = 'is.dame.profile';
@@ -125,6 +134,7 @@ export const COLLECTIONS = {
   arenaChannel: ARENA_CHANNEL_NSID,
   state: STATE_NSID,
   nav: NAV_NSID,
+  sky: SKY_NSID,
 };
 
 /** Gerund verbs surfaced on the home feed. Sourced from the registry. */

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -4,7 +4,12 @@ import {
   easternHour,
   secondsUntilNextHour,
   skyHourKey,
+  setSkyTuning,
 } from '../lib/skyTheme.js';
+import { effectiveSkyTuning } from '../lib/skyTuning.js';
+import { fetchSnapshot } from '../lib/snapshot.js';
+import { resolvePds, getRecord } from '../lib/atproto.js';
+import { ME_DID, COLLECTIONS } from '../config.js';
 
 const ThemeContext = createContext(null);
 
@@ -72,19 +77,55 @@ export function ThemeProvider({ children }) {
   const skyHourRef = useRef(skyHour);
   skyHourRef.current = skyHour;
 
+  // Bumped once the is.dame.sky tuning override resolves (snapshot then
+  // live), so the apply effect below re-paints the palette with it. Kept
+  // in a ref too, for advanceSkyHour's synchronous apply guard.
+  const [tuningRev, setTuningRev] = useState(0);
+  const tuningRevRef = useRef(0);
+  tuningRevRef.current = tuningRev;
+
   // What applyTheme last painted. advanceSkyHour applies synchronously
   // (for the iOS same-gesture theme-color) and then sets state; without
   // this guard the state-driven effect would re-apply the identical hour
-  // right after — a second scroll nudge per tap.
+  // right after — a second scroll nudge per tap. The signature folds in
+  // tuningRev so a freshly-loaded override re-applies even on the same hour.
   const appliedRef = useRef(null);
 
   useEffect(() => {
-    const sig = `sky:${skyHour}`;
+    const sig = `sky:${skyHour}:${tuningRev}`;
     if (appliedRef.current !== sig) {
       applyTheme(skyHour);
       appliedRef.current = sig;
     }
-  }, [skyHour]);
+  }, [skyHour, tuningRev]);
+
+  // Load the optional is.dame.sky/self override: snapshot for an instant
+  // swap-in, then the live record. Installs it globally (setSkyTuning) and
+  // bumps tuningRev to re-paint. Absent / disabled / empty → the built-in
+  // hourly palette stands, exactly like the nav-menu override.
+  useEffect(() => {
+    let cancelled = false;
+    const install = (record) => {
+      const tuning = effectiveSkyTuning(record);
+      if (cancelled || !tuning) return;
+      setSkyTuning(tuning);
+      setTuningRev((n) => n + 1);
+    };
+    (async () => {
+      const seed = await fetchSnapshot('sky');
+      if (seed?.value) install(seed);
+      try {
+        const pds = await resolvePds(ME_DID);
+        const rec = await getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.sky, rkey: 'self' });
+        if (rec?.value) install(rec);
+      } catch {
+        // No override (getRecord 404s until one exists) — defaults stand.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Tick the clock over at the top of each Eastern hour (minutes/seconds
   // track UTC, so the boundary is computable locally). The avatar mark
@@ -118,8 +159,15 @@ export function ThemeProvider({ children }) {
     const next = (skyHourRef.current + 1) % 24;
     // Sync apply for the same iOS theme-color gesture reason as above.
     applyTheme(next);
-    appliedRef.current = `sky:${next}`;
+    appliedRef.current = `sky:${next}:${tuningRevRef.current}`;
     setSkyOverride(next);
+  }, []);
+
+  // Push a just-saved is.dame.sky record onto the live site (from the admin
+  // studio) so the whole app re-tints without a reload. Pass null to clear.
+  const installSkyTuning = useCallback((record) => {
+    setSkyTuning(record ? effectiveSkyTuning(record) : null);
+    setTuningRev((n) => n + 1);
   }, []);
 
   const value = useMemo(
@@ -129,8 +177,9 @@ export function ThemeProvider({ children }) {
       skyHourKey: skyHourKey(skyHour),
       skyOverridden: skyOverride != null,
       advanceSkyHour,
+      installSkyTuning,
     }),
-    [skyHour, skyOverride, advanceSkyHour],
+    [skyHour, skyOverride, advanceSkyHour, installSkyTuning],
   );
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/src/lib/skyTheme.js
+++ b/src/lib/skyTheme.js
@@ -169,11 +169,28 @@ const rgba = ([r, g, b], a) => `rgba(${r}, ${g}, ${b}, ${a})`;
 
 /* ---------- palette derivation ---------- */
 
+// The brighter true-horizon samples for the two shoulder hours, picked off
+// the actual avatar frames (the averaged SKY_BANDS bottom is muddier than
+// the glow at the very horizon). Used as the default "pop" a tuning
+// override warms its borders/text/glow from. Other hours default to their
+// own SKY_BANDS horizon band.
+const SAMPLED_POP = { 7: '#efa82b', 18: '#ce7175' };
+
+/** The default horizon "pop" color a tuning override starts from, per hour. */
+export function defaultPopForHour(hour) {
+  const h = ((hour % 24) + 24) % 24;
+  return SAMPLED_POP[h] || SKY_BANDS[h].bottom;
+}
+
 /**
- * The full token set for one hour of sky, as a map of --sky-* custom
- * properties plus the meta bits (theme-color, color-scheme, label).
+ * Build the untuned --sky-* var set for one hour, optionally with the page
+ * color replaced (absolute background override) and the chrome-surface
+ * offsets scaled (surfaceSep). With `pageOverride` null and `surfaceSep`
+ * 1 this reproduces the historical paletteForHour output exactly. Also
+ * returns a `ctx` with the raw HSL of every tunable token so an override
+ * layer can re-derive them.
  */
-export function paletteForHour(hour) {
+function buildBaseVars(hour, { pageOverride = null, surfaceSep = 1 } = {}) {
   const h24 = ((hour % 24) + 24) % 24;
   const { top, bottom } = SKY_BANDS[h24];
   const topRgb = hexToRgb(top);
@@ -184,9 +201,15 @@ export function paletteForHour(hour) {
   const [hh, hs] = rgbToHsl(botRgb); // horizon band
   const sun = SUN_CURVE[h24];
   const day = sun >= 0.5;
+  const sep = typeof surfaceSep === 'number' ? surfaceSep : 1;
+  // An absolute page-color override supplies its own hue/sat/lightness,
+  // and the whole neutral ramp (page, surfaces, ink, rules) re-derives
+  // from it. The art-based accents (--sky-accent from the top band, the
+  // horizon pop) stay tied to the frame.
+  const pageHsl = pageOverride ? rgbToHsl(hexToRgb(pageOverride)) : null;
 
   let vars;
-  let themeColor;
+  let raw;
 
   if (day) {
     // Sky-colored page, dark ink. The sun curve sets the lightness —
@@ -201,23 +224,32 @@ export function paletteForHour(hour) {
       hue = th;
       s = clamp((bs + ts) / 2, 0.2, 0.4);
     }
-    const l = sun;
+    let l = sun;
+    if (pageHsl) [hue, s, l] = pageHsl;
     const ink = hslToRgb([hue, 0.25, 0.1]);
     const accent = hslToRgb([th, clamp(ts, 0.35, 0.8), 0.3]);
+    raw = {
+      rule: [hue, s * 0.45, l - 0.18],
+      ruleSoft: [hue, s * 0.5, l - 0.1],
+      inkMuted: [hue, 0.15, Math.min(0.34, l - 0.32)],
+      inkFaint: [hue, 0.12, Math.min(0.46, l - 0.18)],
+      inkMutedRaised: [hue, 0.16, Math.min(0.28, l - 0.34)],
+      inkFaintRaised: [hue, 0.13, Math.min(0.38, l - 0.24)],
+    };
     vars = {
       '--sky-page': hsl(hue, s, l),
-      '--sky-page-edge': hsl(hue, s, l - 0.06),
-      '--sky-surface-raised': hsl(hue, s, l - 0.08),
-      '--sky-surface-deep': hsl(hue, s, l - 0.03),
+      '--sky-page-edge': hsl(hue, s, l - 0.06 * sep),
+      '--sky-surface-raised': hsl(hue, s, l - 0.08 * sep),
+      '--sky-surface-deep': hsl(hue, s, l - 0.03 * sep),
       '--sky-ink': rgbToHex(ink),
       // The muted/faint steps ride the page lightness down through the
       // dimmer shoulder hours (7am, 6pm) so secondary text keeps its
       // contrast when the page isn't at full brightness.
       '--sky-ink-soft': hsl(hue, 0.18, 0.22),
-      '--sky-ink-muted': hsl(hue, 0.15, Math.min(0.34, l - 0.32)),
-      '--sky-ink-faint': hsl(hue, 0.12, Math.min(0.46, l - 0.18)),
-      '--sky-rule': hsl(hue, s * 0.45, l - 0.18),
-      '--sky-rule-soft': hsl(hue, s * 0.5, l - 0.1),
+      '--sky-ink-muted': hsl(...raw.inkMuted),
+      '--sky-ink-faint': hsl(...raw.inkFaint),
+      '--sky-rule': hsl(...raw.rule),
+      '--sky-rule-soft': hsl(...raw.ruleSoft),
       // Deep-sky accent (from the frame's top band) and a horizon accent
       // (from its bottom band) — the sky-mode stand-ins for moss + tan.
       '--sky-accent': rgbToHex(accent),
@@ -225,17 +257,16 @@ export function paletteForHour(hour) {
       '--sky-tan': hsl(hh, clamp(hs, 0.3, 0.65), 0.38),
       '--sky-highlight': rgba(accent, 0.16),
       '--sky-shadow': rgba(hslToRgb([hue, 0.3, 0.09]), 0.16),
-      '--sky-scrim': rgba(hslToRgb([hue, s, l - 0.04]), 0.86),
-      '--sky-scrim-clear': rgba(hslToRgb([hue, s, l - 0.04]), 0),
+      '--sky-scrim': rgba(hslToRgb([hue, s, l - 0.04 * sep]), 0.86),
+      '--sky-scrim-clear': rgba(hslToRgb([hue, s, l - 0.04 * sep]), 0),
       '--sky-scrim-ink': rgba(ink, 0.9),
       // Muted/faint re-tuned for text sitting on --surface-raised
       // (mirrors the [data-theme] .chrome-bar rules in theme.css).
-      '--sky-ink-muted-raised': hsl(hue, 0.16, Math.min(0.28, l - 0.34)),
-      '--sky-ink-faint-raised': hsl(hue, 0.13, Math.min(0.38, l - 0.24)),
+      '--sky-ink-muted-raised': hsl(...raw.inkMutedRaised),
+      '--sky-ink-faint-raised': hsl(...raw.inkFaintRaised),
       '--sky-paper-rule': rgba(ink, 0.07),
       '--sky-paper-dot': rgba(ink, 0.1),
     };
-    themeColor = vars['--sky-surface-raised'];
   } else {
     // Deep-sky page, light ink, lightness from the sun curve (a hair
     // above black at 6pm's sunset drop, settling to the flat night
@@ -243,60 +274,185 @@ export function paletteForHour(hour) {
     // amber, dusk glows orchid, and dead-of-night (horizon too
     // desaturated to mean anything) falls back to a pale moonlit cast
     // of the sky's own hue.
-    const s = Math.min(bs, 0.45);
-    const l = sun;
-    const ink = hslToRgb([bh, 0.14, 0.89]);
-    const glowHue = hs < 0.1 ? bh : hh;
+    let hue = bh;
+    let s = Math.min(bs, 0.45);
+    let l = sun;
+    if (pageHsl) [hue, s, l] = pageHsl;
+    const ink = hslToRgb([hue, 0.14, 0.89]);
+    const glowHue = hs < 0.1 ? hue : hh;
     const glowSat = hs < 0.1 ? 0.22 : hs;
     const accent = hslToRgb([glowHue, clamp(glowSat, 0.3, 0.6), 0.7]);
+    raw = {
+      rule: [hue, Math.min(s + 0.05, 0.35), l + 0.12],
+      ruleSoft: [hue, Math.min(s + 0.03, 0.3), l + 0.06],
+      inkMuted: [hue, 0.09, Math.max(0.61, l + 0.26)],
+      inkFaint: [hue, 0.08, Math.max(0.45, l + 0.13)],
+      inkMutedRaised: [hue, 0.09, Math.max(0.61, l + 0.26)],
+      inkFaintRaised: [hue, 0.08, Math.max(0.52, l + 0.18)],
+    };
     vars = {
-      '--sky-page': hsl(bh, s, l),
-      '--sky-page-edge': hsl(bh, s, Math.max(l - 0.02, 0.05)),
-      '--sky-surface-raised': hsl(bh, s, Math.max(l - 0.045, 0.035)),
-      '--sky-surface-deep': hsl(bh, s, Math.max(l - 0.075, 0.02)),
+      '--sky-page': hsl(hue, s, l),
+      '--sky-page-edge': hsl(hue, s, Math.max(l - 0.02 * sep, 0.05)),
+      '--sky-surface-raised': hsl(hue, s, Math.max(l - 0.045 * sep, 0.035)),
+      '--sky-surface-deep': hsl(hue, s, Math.max(l - 0.075 * sep, 0.02)),
       '--sky-ink': rgbToHex(ink),
       // Muted/faint ride the page lightness up through the brighter
       // shoulder hours (6am dawn, 7pm sunset) so secondary text keeps
       // its contrast against the not-fully-dark page.
-      '--sky-ink-soft': hsl(bh, 0.11, 0.78),
-      '--sky-ink-muted': hsl(bh, 0.09, Math.max(0.61, l + 0.26)),
-      '--sky-ink-faint': hsl(bh, 0.08, Math.max(0.45, l + 0.13)),
-      '--sky-rule': hsl(bh, Math.min(s + 0.05, 0.35), l + 0.12),
-      '--sky-rule-soft': hsl(bh, Math.min(s + 0.03, 0.3), l + 0.06),
+      '--sky-ink-soft': hsl(hue, 0.11, 0.78),
+      '--sky-ink-muted': hsl(...raw.inkMuted),
+      '--sky-ink-faint': hsl(...raw.inkFaint),
+      '--sky-rule': hsl(...raw.rule),
+      '--sky-rule-soft': hsl(...raw.ruleSoft),
       '--sky-accent': rgbToHex(accent),
       '--sky-accent-soft': hsl(glowHue, clamp(glowSat * 0.8, 0.25, 0.5), 0.58),
       '--sky-tan': hsl(glowHue, clamp(glowSat, 0.25, 0.55), 0.64),
       '--sky-highlight': rgba(accent, 0.16),
       '--sky-shadow': 'rgba(0, 0, 0, 0.45)',
-      '--sky-scrim': rgba(hslToRgb([bh, s, Math.max(l - 0.06, 0.02)]), 0.8),
-      '--sky-scrim-clear': rgba(hslToRgb([bh, s, Math.max(l - 0.06, 0.02)]), 0),
+      '--sky-scrim': rgba(hslToRgb([hue, s, Math.max(l - 0.06 * sep, 0.02)]), 0.8),
+      '--sky-scrim-clear': rgba(hslToRgb([hue, s, Math.max(l - 0.06 * sep, 0.02)]), 0),
       '--sky-scrim-ink': rgba(ink, 0.9),
       // Night muted already clears the darker raised surface; only faint
       // needs a lift (same shape as the static dark theme's re-tune).
-      '--sky-ink-muted-raised': hsl(bh, 0.09, Math.max(0.61, l + 0.26)),
-      '--sky-ink-faint-raised': hsl(bh, 0.08, Math.max(0.52, l + 0.18)),
+      '--sky-ink-muted-raised': hsl(...raw.inkMutedRaised),
+      '--sky-ink-faint-raised': hsl(...raw.inkFaintRaised),
       '--sky-paper-rule': rgba(ink, 0.055),
       '--sky-paper-dot': rgba(ink, 0.08),
     };
-    themeColor = vars['--sky-surface-raised'];
   }
 
+  return { vars, ctx: { day, raw } };
+}
+
+// The tuning override's warmth/contrast model. Hue + saturation come from
+// an RGB blend of the token toward the horizon pop (a natural tan/rose
+// path, no magenta detour); lightness is pushed away from the page —
+// darker by day, lighter by night — so contrast rises predictably either
+// way. warmth 0 && push 0 returns the token unchanged (exact identity).
+function warmContrast(baseHsl, popRgb, warmth, push, day) {
+  if (warmth <= 0 && push <= 0) return hsl(...baseHsl);
+  const targetL = clamp01(baseHsl[2] + (day ? -push : push));
+  const b = hslToRgb(baseHsl);
+  const mixed = b.map((v, i) => v + (popRgb[i] - v) * warmth);
+  const [H, S] = rgbToHsl(mixed);
+  return hsl(H, Math.min(S, 0.72), targetL);
+}
+
+// The glow / shine box-shadow, split per target group (accent buttons,
+// avatar mark, accent text, outlined controls) so each element family can
+// opt in independently. Returns 'none' for a group the override doesn't
+// target, or when the glow is off.
+function glowVarsFrom(cfg) {
+  const off = { color: 'transparent', buttons: 'none', avatar: 'none', accent: 'none', controls: 'none' };
+  const strength = Number(cfg.glowStrength) || 0;
+  const size = Math.round(Number(cfg.glowSize) || 0);
+  if (strength <= 0 || size <= 0) return off;
+  const rgb = hexToRgb(cfg.glowColor || cfg.pop || '#ffffff');
+  const c1 = rgba(rgb, Number(strength.toFixed(3)));
+  const c2 = rgba(rgb, Number(Math.min(1, strength * 1.35).toFixed(3)));
+  const shadow = `0 0 ${size}px ${Math.round(size * 0.18)}px ${c1}, 0 0 ${Math.round(size * 0.45)}px ${c2}`;
+  const text = `0 0 ${Math.round(size * 0.7)}px ${c1}`;
+  const T = cfg.glowTargets || {};
   return {
-    hour: h24,
-    key: KEYS[h24],
-    day,
-    colorScheme: day ? 'light' : 'dark',
-    themeColor,
-    vars,
+    color: c1,
+    buttons: T.buttons ? shadow : 'none',
+    avatar: T.avatar ? shadow : 'none',
+    accent: T.accentText ? text : 'none',
+    controls: T.controls ? shadow : 'none',
   };
 }
 
-// Every var name paletteForHour emits, so clearSkyTheme can sweep them all.
-const SKY_VAR_NAMES = Object.keys(paletteForHour(0).vars);
+// The always-present glow vars in their "off" state — so every palette
+// carries the full var set (clearSkyTheme/theme.css stay consistent).
+const GLOW_OFF = {
+  '--sky-glow-color': 'transparent',
+  '--sky-glow-buttons': 'none',
+  '--sky-glow-avatar': 'none',
+  '--sky-glow-accent': 'none',
+  '--sky-glow-controls': 'none',
+};
+
+/**
+ * Layer one hour's parametric tuning override onto its base vars: re-warm
+ * the borders and faint/muted ink toward the pop, deepen for contrast,
+ * pull the inline highlight from the pop, and emit the per-target glow.
+ * Page / primary ink / link accent are left as the base derived them
+ * (the page itself may already carry an absolute override via buildBaseVars).
+ */
+function applyOverride(baseVars, ctx, cfg) {
+  const { day, raw } = ctx;
+  const popRgb = hexToRgb(cfg.pop || '#ffffff');
+  const rW = Number(cfg.ruleWarmth) || 0;
+  const rC = Number(cfg.ruleContrast) || 0;
+  const iW = Number(cfg.inkWarmth) || 0;
+  const iC = Number(cfg.inkContrast) || 0;
+  const v = { ...baseVars };
+  v['--sky-rule'] = warmContrast(raw.rule, popRgb, rW, rC, day);
+  v['--sky-rule-soft'] = warmContrast(raw.ruleSoft, popRgb, rW, rC * 0.55, day);
+  v['--sky-ink-faint'] = warmContrast(raw.inkFaint, popRgb, iW, iC, day);
+  v['--sky-ink-muted'] = warmContrast(raw.inkMuted, popRgb, iW, iC * 0.6, day);
+  v['--sky-ink-faint-raised'] = warmContrast(raw.inkFaintRaised, popRgb, iW, iC, day);
+  v['--sky-ink-muted-raised'] = warmContrast(raw.inkMutedRaised, popRgb, iW, iC * 0.6, day);
+  if (iW > 0 || rW > 0) {
+    const [ph, ps] = rgbToHsl(popRgb);
+    v['--sky-tan'] = hsl(ph, clamp(ps, 0.35, 0.72), day ? 0.42 : 0.6);
+    v['--sky-accent-soft'] = hsl(ph, clamp(ps * 0.7, 0.3, 0.6), day ? 0.5 : 0.58);
+  }
+  const g = glowVarsFrom(cfg);
+  v['--sky-glow-color'] = g.color;
+  v['--sky-glow-buttons'] = g.buttons;
+  v['--sky-glow-avatar'] = g.avatar;
+  v['--sky-glow-accent'] = g.accent;
+  v['--sky-glow-controls'] = g.controls;
+  return v;
+}
+
+// Module-level active tuning, installed once the is.dame.sky override
+// resolves (snapshot then live — see useSkyTuning). null = the built-in
+// hourly derivation, unchanged. Shaped { enabled, hours: {0..23: cfg} }.
+let activeTuning = null;
+
+/** Install the resolved sky-theme tuning (or null to clear). */
+export function setSkyTuning(tuning) {
+  activeTuning = tuning && tuning.enabled ? tuning : null;
+}
+
+/** The currently installed tuning (or null). */
+export function getSkyTuning() {
+  return activeTuning;
+}
+
+/**
+ * The full token set for one hour of sky, as a map of --sky-* custom
+ * properties plus the meta bits (theme-color, color-scheme, label).
+ * `tuning` defaults to the installed override; pass an explicit one (e.g.
+ * a draft from the admin studio) to preview it without installing it.
+ */
+export function paletteForHour(hour, tuning = activeTuning) {
+  const h24 = ((hour % 24) + 24) % 24;
+  const cfg = tuning && tuning.enabled && tuning.hours ? tuning.hours[h24] : null;
+  const { vars, ctx } = buildBaseVars(hour, {
+    pageOverride: cfg && cfg.page ? cfg.page : null,
+    surfaceSep: cfg ? cfg.surfaceSep : 1,
+  });
+  const outVars = cfg ? applyOverride(vars, ctx, cfg) : { ...vars, ...GLOW_OFF };
+  return {
+    hour: h24,
+    key: KEYS[h24],
+    day: ctx.day,
+    colorScheme: ctx.day ? 'light' : 'dark',
+    themeColor: outVars['--sky-surface-raised'],
+    vars: outVars,
+  };
+}
+
+// Every var name a palette emits, so clearSkyTheme can sweep them all
+// (base tokens + the glow group).
+const SKY_VAR_NAMES = Object.keys({ ...buildBaseVars(0).vars, ...GLOW_OFF });
 
 /** Write the given hour's palette onto <html> as --sky-* vars. */
-export function applySkyTheme(hour) {
-  const palette = paletteForHour(hour);
+export function applySkyTheme(hour, tuning = activeTuning) {
+  const palette = paletteForHour(hour, tuning);
   const root = document.documentElement;
   for (const name of SKY_VAR_NAMES) root.style.setProperty(name, palette.vars[name]);
   // Inline so form controls / scrollbars flip with the hour; theme.css's

--- a/src/lib/skyTuning.js
+++ b/src/lib/skyTuning.js
@@ -1,0 +1,179 @@
+// The parametric tuning layer for the sky theme.
+//
+// The hour-tracking palette in src/lib/skyTheme.js is computed from the
+// hardcoded SKY_BANDS + SUN_CURVE arrays. This module is the optional
+// *override* on top of it, stored as an is.dame.sky/self record on the PDS
+// (see lexicons/is.dame.sky.json) and edited in the admin "Sky theme
+// studio". It follows the same contract as the nav-menu override: when the
+// record is `enabled`, its per-hour entries layer onto the built-in
+// palette; otherwise the built-in derivation stands unchanged.
+//
+// Two shapes flow through here:
+//   - the RECORD (what lives on the PDS): { enabled, hours: [{hour, …}], … },
+//     compact — only overridden hours are listed, knobs default to no-ops.
+//   - the DRAFT (what the studio edits): a full 0–23 map of normalized cfg
+//     objects, every field present, so the controls always have a value.
+// effectiveSkyTuning() turns a record into the { enabled, hours:{h:cfg} }
+// map that skyTheme.setSkyTuning() applies at runtime.
+
+import { defaultPopForHour } from './skyTheme.js';
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+const isHex = (v) => typeof v === 'string' && HEX.test(v);
+const numOr = (v, d) => (Number.isFinite(Number(v)) ? Number(v) : d);
+const clamp01 = (v) => Math.min(1, Math.max(0, Number(v) || 0));
+
+export const GLOW_GROUPS = ['buttons', 'avatar', 'accentText', 'controls'];
+const DEFAULT_TARGETS = { buttons: true, avatar: true, accentText: true, controls: false };
+
+// The suggested contrast-fix starting point for the two shoulder hours —
+// what the studio seeds when no record exists yet (dawn 7am, dusk 6pm).
+// These are the values dialed in during the design pass.
+const FIX = { ruleWarmth: 0.5, ruleContrast: 0.24, inkWarmth: 0.3, inkContrast: 0.24, glowSize: 16, glowStrength: 0.3 };
+const FIX_HOURS = new Set([7, 18]);
+
+/** A no-op cfg for an hour: renders identically to the built-in palette. */
+export function identityHourCfg(hour) {
+  const pop = defaultPopForHour(hour);
+  return {
+    pop,
+    page: null,
+    surfaceSep: 1,
+    ruleWarmth: 0,
+    ruleContrast: 0,
+    inkWarmth: 0,
+    inkContrast: 0,
+    glowColor: pop,
+    glowSize: 16,
+    glowStrength: 0,
+    glowTargets: { ...DEFAULT_TARGETS },
+  };
+}
+
+/** The studio's seeded starting cfg for an hour (FIX on 7am/6pm, else identity). */
+export function seedHourCfg(hour) {
+  const cfg = identityHourCfg(hour);
+  if (FIX_HOURS.has(hour)) Object.assign(cfg, FIX);
+  return cfg;
+}
+
+/** A cfg is an override when it changes anything vs. the built-in palette. */
+export function hasOverride(cfg) {
+  if (!cfg) return false;
+  return (
+    cfg.page != null ||
+    numOr(cfg.surfaceSep, 1) !== 1 ||
+    clamp01(cfg.ruleWarmth) > 0 ||
+    numOr(cfg.ruleContrast, 0) > 0 ||
+    clamp01(cfg.inkWarmth) > 0 ||
+    numOr(cfg.inkContrast, 0) > 0 ||
+    clamp01(cfg.glowStrength) > 0
+  );
+}
+
+/** Normalize one record `hours` item into a full cfg (fills every field). */
+function normalizeHourCfg(item, hour) {
+  const pop = isHex(item?.pop) ? item.pop : defaultPopForHour(hour);
+  const targets = Array.isArray(item?.glowTargets) ? item.glowTargets : [];
+  return {
+    pop,
+    page: isHex(item?.page) ? item.page : null,
+    surfaceSep: numOr(item?.surfaceSep, 1),
+    ruleWarmth: clamp01(item?.ruleWarmth),
+    ruleContrast: numOr(item?.ruleContrast, 0),
+    inkWarmth: clamp01(item?.inkWarmth),
+    inkContrast: numOr(item?.inkContrast, 0),
+    glowColor: isHex(item?.glowColor) ? item.glowColor : pop,
+    glowSize: numOr(item?.glowSize, 16),
+    glowStrength: clamp01(item?.glowStrength),
+    glowTargets: GLOW_GROUPS.reduce((o, g) => ((o[g] = targets.includes(g)), o), {}),
+  };
+}
+
+/** The record's `value` whether it's wrapped ({value}) or already bare. */
+function recordValue(record) {
+  if (!record) return null;
+  return record.value ?? record.data?.value ?? (record.enabled !== undefined ? record : null);
+}
+
+/**
+ * Turn an is.dame.sky record into the runtime tuning map
+ * { enabled, hours: { <h>: cfg } }, or null when it's absent / disabled /
+ * empty (so callers cleanly fall back to the built-in palette).
+ */
+export function effectiveSkyTuning(record) {
+  const v = recordValue(record);
+  if (!v || !v.enabled || !Array.isArray(v.hours)) return null;
+  const hours = {};
+  for (const item of v.hours) {
+    const h = Number(item?.hour);
+    if (!Number.isInteger(h) || h < 0 || h > 23) continue;
+    const cfg = normalizeHourCfg(item, h);
+    if (hasOverride(cfg)) hours[h] = cfg;
+  }
+  if (!Object.keys(hours).length) return null;
+  return { enabled: true, hours };
+}
+
+/**
+ * Build the studio's editable draft from a record: a full 0–23 map of cfgs.
+ * With no record, seed the two shoulder hours with the contrast fix.
+ */
+export function recordToDraft(record) {
+  const v = recordValue(record);
+  const byHour = {};
+  const seeded = !v || !Array.isArray(v.hours) || !v.hours.length;
+  for (let h = 0; h < 24; h += 1) byHour[h] = seeded ? seedHourCfg(h) : identityHourCfg(h);
+  if (v && Array.isArray(v.hours)) {
+    for (const item of v.hours) {
+      const h = Number(item?.hour);
+      if (Number.isInteger(h) && h >= 0 && h <= 23) byHour[h] = normalizeHourCfg(item, h);
+    }
+  }
+  return { enabled: Boolean(v?.enabled), byHour, createdAt: v?.createdAt || null };
+}
+
+/** Compact a draft cfg down to only the fields that differ from an identity. */
+function compactHourCfg(cfg, hour) {
+  const out = { hour };
+  const base = defaultPopForHour(hour);
+  if ((cfg.ruleWarmth || cfg.ruleContrast) && cfg.pop && cfg.pop !== base) out.pop = cfg.pop;
+  else if ((cfg.inkWarmth || cfg.inkContrast) && cfg.pop && cfg.pop !== base) out.pop = cfg.pop;
+  else if (cfg.pop && cfg.pop !== base) out.pop = cfg.pop;
+  if (cfg.page) out.page = cfg.page;
+  if (numOr(cfg.surfaceSep, 1) !== 1) out.surfaceSep = round(cfg.surfaceSep, 2);
+  if (cfg.ruleWarmth) out.ruleWarmth = round(cfg.ruleWarmth, 2);
+  if (cfg.ruleContrast) out.ruleContrast = round(cfg.ruleContrast, 3);
+  if (cfg.inkWarmth) out.inkWarmth = round(cfg.inkWarmth, 2);
+  if (cfg.inkContrast) out.inkContrast = round(cfg.inkContrast, 3);
+  if (cfg.glowStrength > 0 && cfg.glowSize > 0) {
+    if (cfg.glowColor && cfg.glowColor !== cfg.pop) out.glowColor = cfg.glowColor;
+    out.glowSize = Math.round(cfg.glowSize);
+    out.glowStrength = round(cfg.glowStrength, 2);
+    out.glowTargets = GLOW_GROUPS.filter((g) => cfg.glowTargets?.[g]);
+  }
+  return out;
+}
+
+const round = (v, n) => {
+  const f = 10 ** n;
+  return Math.round(Number(v) * f) / f;
+};
+
+/** The record `hours` array from a draft — only overridden hours, compact. */
+export function draftToHoursArray(byHour) {
+  const hours = [];
+  for (let h = 0; h < 24; h += 1) {
+    if (hasOverride(byHour[h])) hours.push(compactHourCfg(byHour[h], h));
+  }
+  return hours;
+}
+
+/** A runtime tuning map from a draft, for live preview via setSkyTuning. */
+export function draftToTuning(enabled, byHour) {
+  const hours = {};
+  for (let h = 0; h < 24; h += 1) {
+    if (hasOverride(byHour[h])) hours[h] = byHour[h];
+  }
+  return { enabled: Boolean(enabled), hours };
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -8,6 +8,7 @@ import ResumeStudio from '../components/resume/ResumeStudio.jsx';
 import ResumeWorkbench from '../components/resume/ResumeWorkbench.jsx';
 import PublicationsManager from '../components/PublicationsManager.jsx';
 import NavMenuPanel from '../components/NavMenuPanel.jsx';
+import SkyThemeStudio from '../components/SkyThemeStudio.jsx';
 import { AdminRecordListSkeleton, AdminPagePanelsSkeleton } from '../components/Skeleton.jsx';
 import { VARIANTS_A, VARIANTS_B } from '../components/HeroSentence.jsx';
 import { useAtprotoSession } from '../hooks/useAtprotoSession.jsx';
@@ -85,6 +86,9 @@ export default function Admin() {
   }
   if (view === 'nav') {
     return <NavMenuPanel agent={agent} did={did} />;
+  }
+  if (view === 'sky') {
+    return <SkyThemeStudio agent={agent} did={did} />;
   }
   if (view === 'resume-tailor' && rkey) {
     return <ResumeWorkbench agent={agent} did={did} rkey={rkey} />;
@@ -224,6 +228,8 @@ const PICKER_GROUPS = [
         summary: 'Titles, intros, and page bodies — see which serve from the PDS vs local defaults, and edit the raw records.' },
       { to: '/admin?view=nav', label: 'Nav menu', nsid: 'is.dame.nav',
         summary: 'Override the dock-menu route list — select, reorder, relabel, or hide entries — or turn the override off to use the built-in routes.' },
+      { to: '/admin?view=sky', label: 'Sky theme studio', nsid: 'is.dame.sky',
+        summary: 'Tune the hour-tracking palette live — background, horizon-warmed borders and text, and a soft glow per element — for any of the 24 hours. Saves to an override record; off falls back to the built-in palette.' },
       { to: '/admin?view=publications', label: 'Publications', nsid: 'site.standard.publication',
         summary: 'The blog + portfolio publications behind the Bluesky Standard Site embeds — edit their fields, or apply the sky theme + a dynamic avatar.' },
       { to: '/admin?view=guestbook', label: 'Guestbook', nsid: 'is.dame.guestbook.entry',

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -32,6 +32,13 @@
   --scrim-clear: rgba(230, 222, 195, 0);
   --scrim-ink:   rgba(29, 36, 25, 0.9);
 
+  /* Glow / shine, per element family. Off by default; the sky theme's
+     optional per-hour tuning (is.dame.sky) turns them on. */
+  --glow-buttons:  none;
+  --glow-avatar:   none;
+  --glow-accent:   none;
+  --glow-controls: none;
+
   --bg:    var(--page);
   --fg:    var(--ink);
   --muted: var(--ink-muted);
@@ -162,10 +169,25 @@
   --scrim-clear:    var(--sky-scrim-clear, rgba(9, 9, 9, 0));
   --scrim-ink:      var(--sky-scrim-ink, rgba(223, 231, 231, 0.9));
 
+  /* Per-element glow, driven by the hour's tuning override (or `none`). */
+  --glow-buttons:   var(--sky-glow-buttons, none);
+  --glow-avatar:    var(--sky-glow-avatar, none);
+  --glow-accent:    var(--sky-glow-accent, none);
+  --glow-controls:  var(--sky-glow-controls, none);
+
   /* Daylight hours override this to `light` via an inline style set by
      skyTheme.js (inline wins over this static fallback). */
   color-scheme: dark;
 }
+
+/* Sky-theme glow / shine application. A tuning override (is.dame.sky) lights
+   up accent elements per hour; each family maps to one glow group chosen in
+   the studio. The tokens are `none` until an override turns them on, so these
+   rules are inert on the built-in palette. */
+[data-theme='sky'] .chrome-mark-img { box-shadow: var(--glow-avatar); }
+[data-theme='sky'] .home-hero-cta-primary { box-shadow: var(--glow-buttons); }
+[data-theme='sky'] .home-hero-cta-btn { box-shadow: var(--glow-controls); }
+[data-theme='sky'] .hero-rotator-b { text-shadow: var(--glow-accent); }
 
 /* Raised-surface ink re-tuning.
 


### PR DESCRIPTION
Externalizes the hour-tracking sky palette's tuning to an optional `is.dame.sky/self` override record, edited live in a new admin studio — the same singleton-override + build-snapshot pattern as `is.dame.nav`. With the override off (or absent), the site uses its built-in hourly palette unchanged (verified byte-for-byte identical across all 24 hours).

## What's here
- **`src/lib/skyTheme.js`** — `paletteForHour(hour, tuning)` now layers a per-hour parametric override (absolute background color, horizon-warmed borders + faint/muted text deepened for contrast, and a per-element glow) on top of the built-in derivation. The no-override path is unchanged.
- **`src/lib/skyTuning.js`** — config defaults + record↔draft normalization.
- **`lexicons/is.dame.sky.json`** — the override schema (parametric, per hour).
- **`src/hooks/useTheme.jsx`** — `ThemeProvider` loads the snapshot then the live record and installs the tuning; `installSkyTuning` pushes a fresh save onto the running site.
- **`scripts/prefetch.mjs`** — snapshots `is.dame.sky/self` to `public/data/sky.json` (build + 6-hour cron).
- **`src/styles/theme.css`** — per-element glow tokens (buttons / avatar / accent text / controls), wired to the brand mark, hero CTAs, and accent clause. Inert until an override turns them on.
- **`src/components/SkyThemeStudio.{jsx,css}`** + **`src/pages/Admin.jsx`** — the admin editor at `/admin?view=sky`: full-spectrum background color control, site-native controls (color pickers + numeric fields, no sliders), a live on-the-fly preview with a WCAG contrast readout, and Save to the override record.

## Verification
- Production build passes.
- Base (no-override) palette is byte-identical to before across all 24 hours.
- Tuning math, record↔draft round-trip, and runtime loader verified; dev site paints correctly and `/admin` loads the studio chunk with no errors.
- The authenticated studio UI could not be driven headlessly (OAuth-gated to the owner DID) — worth a quick smoke test on first Save.

## Follow-ups (not in this PR)
- First paint shows the built-in palette then swaps to the tuned one once the record loads (same handoff as the nav override).
- The server-rendered favicon art and OG social cards still use the built-in palette; wiring the override into those Vercel functions is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJnHBxMGvdQKDwHgTY2ZAP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJnHBxMGvdQKDwHgTY2ZAP)_