### PR TITLE
Sky studio: sliders + sticky hour bar

### DIFF
--- a/src/components/SkyThemeStudio.css
+++ b/src/components/SkyThemeStudio.css
@@ -39,78 +39,44 @@
   font-size: var(--text-sm);
 }
 
-/* ---- hour arc ---- */
-.sky-arc-wrap {
-  margin: var(--space-5) 0 var(--space-4);
+/* ---- hour bar: a sticky expanded panel above the bottom chrome ----
+   Portalled to <body> and pinned just above the fixed bottom chrome bar,
+   like the owner edit-mode action bar. Its height is fed back into the
+   .app-shell bottom padding (--sky-hourbar-h) so content always clears it. */
+.sky-hourbar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--chrome-h) + env(safe-area-inset-bottom, 0px));
+  z-index: 31;
+  background: var(--surface-deep);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
 }
-.sky-arc-head {
+.sky-hourbar-inner {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: var(--space-2) var(--space-4) calc(var(--space-2) + 2px);
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: var(--space-2);
+  flex-direction: column;
+  gap: var(--space-2);
 }
-.sky-arc-meta {
+.sky-hourbar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.sky-hourbar-meta {
+  margin-left: auto;
   font-family: var(--mono-ui);
   font-size: var(--text-xs);
-  color: var(--ink-faint);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
-}
-.sky-dot,
-.sky-arc-meta .sky-dot {
-  display: inline-block;
-  width: 0.7em;
-  height: 3px;
-  background: var(--accent);
-  vertical-align: middle;
-}
-.sky-arc {
-  display: grid;
-  grid-template-columns: repeat(24, 1fr);
-  gap: 2px;
-  border: 1px solid var(--rule);
-  padding: 2px;
-  background: var(--rule-soft);
-}
-.sky-arc-cell {
-  position: relative;
-  height: 38px;
-  border: 0;
-  padding: 0;
-  cursor: pointer;
-  outline: none;
-}
-.sky-arc-cell:hover {
-  filter: brightness(1.08);
-}
-.sky-arc-cell.is-ovr::before {
-  content: '';
-  position: absolute;
-  left: 1px;
-  right: 1px;
-  top: 1px;
-  height: 3px;
-  background: var(--accent);
-}
-.sky-arc-cell.is-sel {
-  box-shadow: inset 0 0 0 2px var(--ink), inset 0 0 0 3px var(--page);
-  z-index: 1;
-}
-.sky-arc-cell:focus-visible {
-  box-shadow: inset 0 0 0 2px var(--accent);
-  z-index: 2;
-}
-.sky-arc-nav {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-4);
-  margin-top: var(--space-3);
+  color: var(--ink-muted);
+  white-space: nowrap;
 }
 .sky-step {
-  width: 2rem;
-  height: 2rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  flex: none;
   border: 1px solid var(--rule);
   background: var(--surface-raised);
   color: var(--ink-soft);
@@ -123,17 +89,48 @@
   border-color: var(--accent-soft);
 }
 .sky-hour-name {
-  font-size: var(--text-lg);
+  font-size: var(--text-base);
   font-weight: 600;
-  min-width: 12ch;
-  text-align: center;
 }
 .sky-hour-tag {
   font-family: var(--mono-ui);
   font-size: var(--text-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-faint);
+  color: var(--ink-muted);
+}
+.sky-arc {
+  display: grid;
+  grid-template-columns: repeat(24, 1fr);
+  gap: 2px;
+}
+.sky-arc-cell {
+  position: relative;
+  height: 26px;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+}
+.sky-arc-cell:hover {
+  filter: brightness(1.1);
+}
+.sky-arc-cell.is-ovr::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 3px;
+  background: var(--accent);
+}
+.sky-arc-cell.is-sel {
+  box-shadow: inset 0 0 0 2px var(--ink), inset 0 0 0 3px var(--surface-deep);
+  z-index: 1;
+}
+.sky-arc-cell:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--accent);
+  z-index: 2;
 }
 
 /* ---- live preview card ---- */
@@ -362,19 +359,56 @@
   color: var(--ink);
   border-color: var(--accent-soft);
 }
-.sky-num-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
+.sky-slider-field {
+  flex: 1 1 220px;
+  min-width: 200px;
 }
-.sky-num {
-  width: 5.5rem;
-  text-align: right;
+.sky-slider-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
 }
-.sky-num-suffix {
+.sky-field-val {
   font-family: var(--mono-ui);
   font-size: var(--text-sm);
-  color: var(--ink-faint);
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+.sky-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 2px;
+  background: var(--rule);
+  cursor: pointer;
+  margin: 0.45em 0;
+}
+.sky-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 0;
+  background: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 65%, #000);
+  cursor: grab;
+}
+.sky-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 0;
+  background: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 65%, #000);
+  cursor: grab;
+}
+.sky-slider:focus-visible::-webkit-slider-thumb {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 2px;
+}
+.sky-slider:focus-visible::-moz-range-thumb {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 2px;
 }
 .sky-targets {
   margin-top: var(--space-4);
@@ -414,7 +448,10 @@
 
 @media (max-width: 560px) {
   .sky-arc-cell {
-    height: 30px;
+    height: 22px;
+  }
+  .sky-hourbar-meta {
+    display: none;
   }
   .sky-pv-row {
     grid-template-columns: 4.5rem 1fr auto;

--- a/src/components/SkyThemeStudio.jsx
+++ b/src/components/SkyThemeStudio.jsx
@@ -6,9 +6,12 @@
 // nothing persists until Save. With the override toggled off (or no
 // record), the site uses its built-in hourly palette. Follows the same
 // contract + shell as NavMenuPanel; controls are the site's own vocabulary
-// (color inputs, numeric fields, square/hairline chrome — no sliders).
+// (color inputs, square/hairline sliders). The hour selector rides in a
+// sticky bar pinned above the bottom chrome (portalled to <body>, like the
+// owner edit-mode action bar), so you can switch hours from anywhere.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import PageShell from './PageShell.jsx';
 import { AdminRecordListSkeleton } from './Skeleton.jsx';
@@ -89,6 +92,27 @@ export default function SkyThemeStudio({ agent, did }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [flash, setFlash] = useState(false);
+  const hourBarRef = useRef(null);
+
+  // Reserve page space for the fixed hour bar (measured live) by feeding its
+  // height into the .app-shell bottom padding, the same way the edit-mode
+  // action bar does — so the last controls always clear it.
+  useEffect(() => {
+    if (loading || !byHour) return undefined;
+    const el = hourBarRef.current;
+    if (!el) return undefined;
+    const root = document.documentElement;
+    const measure = () => root.style.setProperty('--sky-hourbar-h', `${el.offsetHeight}px`);
+    measure();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    ro?.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener('resize', measure);
+      root.style.removeProperty('--sky-hourbar-h');
+    };
+  }, [loading, byHour]);
 
   // Load the existing override (or seed the two shoulder hours with the fix).
   useEffect(() => {
@@ -232,38 +256,6 @@ export default function SkyThemeStudio({ agent, did }) {
             </span>
           </label>
 
-          {/* ---- hour arc ---- */}
-          <div className="sky-arc-wrap">
-            <div className="sky-arc-head">
-              <span className="admin-field-label">Hour</span>
-              <span className="sky-arc-meta">
-                {overriddenCount} of 24 tuned · <span className="sky-dot" /> has override
-              </span>
-            </div>
-            <div className="sky-arc" role="tablist" aria-label="Hour">
-              {Array.from({ length: 24 }, (_, h) => {
-                const pv = paletteForHour(h, draftToTuning(true, byHour)).vars['--sky-page'];
-                return (
-                  <button
-                    key={h}
-                    type="button"
-                    role="tab"
-                    aria-selected={h === hour}
-                    className={`sky-arc-cell ${h === hour ? 'is-sel' : ''} ${hasOverride(byHour[h]) ? 'is-ovr' : ''}`}
-                    style={{ background: pv }}
-                    title={skyHourKey(h)}
-                    onClick={() => setHour(h)}
-                  />
-                );
-              })}
-            </div>
-            <div className="sky-arc-nav">
-              <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 23) % 24)} aria-label="Previous hour">‹</button>
-              <span className="sky-hour-name">{hourLabel(hour)} <span className="sky-hour-tag">{isDay ? 'day' : 'night'}{hasOverride(cfg) ? ' · override' : ''}</span></span>
-              <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 1) % 24)} aria-label="Next hour">›</button>
-            </div>
-          </div>
-
           {/* ---- preview ---- */}
           <div className="sky-preview" style={previewStyle(tunedVars)}>
             <div className="sky-pv-chrome">
@@ -330,7 +322,7 @@ export default function SkyThemeStudio({ agent, did }) {
                   onChange={(v) => patchHour({ page: v })}
                   onReset={cfg.page ? () => patchHour({ page: null }) : null}
                 />
-                <NumberField label="Surface separation" value={cfg.surfaceSep} min={0.4} max={2} step={0.1} onChange={(v) => patchHour({ surfaceSep: v })} />
+                <SliderField label="Surface separation" value={cfg.surfaceSep} min={0.4} max={2} step={0.1} display={`${cfg.surfaceSep.toFixed(1)}×`} onChange={(v) => patchHour({ surfaceSep: v })} />
               </div>
             </section>
 
@@ -350,16 +342,16 @@ export default function SkyThemeStudio({ agent, did }) {
             <section className="sky-group">
               <h3 className="admin-collection-group-heading small-caps">Borders</h3>
               <div className="sky-fields">
-                <NumberField label="Warmth" suffix="%" value={Math.round(cfg.ruleWarmth * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ ruleWarmth: v / 100 })} />
-                <NumberField label="Contrast" value={cfg.ruleContrast} min={0} max={0.45} step={0.02} onChange={(v) => patchHour({ ruleContrast: v })} />
+                <SliderField label="Warmth" value={Math.round(cfg.ruleWarmth * 100)} min={0} max={100} step={5} display={`${Math.round(cfg.ruleWarmth * 100)}%`} onChange={(v) => patchHour({ ruleWarmth: v / 100 })} />
+                <SliderField label="Contrast" value={cfg.ruleContrast} min={0} max={0.45} step={0.02} display={cfg.ruleContrast.toFixed(2)} onChange={(v) => patchHour({ ruleContrast: v })} />
               </div>
             </section>
 
             <section className="sky-group">
               <h3 className="admin-collection-group-heading small-caps">Faint &amp; muted text</h3>
               <div className="sky-fields">
-                <NumberField label="Warmth" suffix="%" value={Math.round(cfg.inkWarmth * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ inkWarmth: v / 100 })} />
-                <NumberField label="Contrast" value={cfg.inkContrast} min={0} max={0.45} step={0.02} onChange={(v) => patchHour({ inkContrast: v })} />
+                <SliderField label="Warmth" value={Math.round(cfg.inkWarmth * 100)} min={0} max={100} step={5} display={`${Math.round(cfg.inkWarmth * 100)}%`} onChange={(v) => patchHour({ inkWarmth: v / 100 })} />
+                <SliderField label="Contrast" value={cfg.inkContrast} min={0} max={0.45} step={0.02} display={cfg.inkContrast.toFixed(2)} onChange={(v) => patchHour({ inkContrast: v })} />
               </div>
             </section>
 
@@ -367,8 +359,8 @@ export default function SkyThemeStudio({ agent, did }) {
               <h3 className="admin-collection-group-heading small-caps">Glow / shine</h3>
               <div className="sky-fields">
                 <ColorField label="Glow color" value={cfg.glowColor} onChange={(v) => patchHour({ glowColor: v })} onReset={cfg.glowColor !== cfg.pop ? () => patchHour({ glowColor: cfg.pop }) : null} />
-                <NumberField label="Size" suffix="px" value={cfg.glowSize} min={0} max={48} step={2} onChange={(v) => patchHour({ glowSize: v })} />
-                <NumberField label="Strength" suffix="%" value={Math.round(cfg.glowStrength * 100)} min={0} max={100} step={5} onChange={(v) => patchHour({ glowStrength: v / 100 })} />
+                <SliderField label="Size" value={cfg.glowSize} min={0} max={48} step={2} display={`${cfg.glowSize}px`} onChange={(v) => patchHour({ glowSize: v })} />
+                <SliderField label="Strength" value={Math.round(cfg.glowStrength * 100)} min={0} max={100} step={5} display={`${Math.round(cfg.glowStrength * 100)}%`} onChange={(v) => patchHour({ glowStrength: v / 100 })} />
               </div>
               <div className="sky-targets">
                 <span className="admin-field-label">Applies to</span>
@@ -392,6 +384,42 @@ export default function SkyThemeStudio({ agent, did }) {
               Reset {skyHourKey(hour)}
             </button>
           </div>
+
+          {/* Hour selector: a sticky bar above the bottom chrome (portalled so
+              a transformed route wrapper can't break its fixed position). */}
+          {createPortal(
+            <div className="sky-hourbar" ref={hourBarRef}>
+              <div className="sky-hourbar-inner">
+                <div className="sky-hourbar-row">
+                  <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 23) % 24)} aria-label="Previous hour">‹</button>
+                  <span className="sky-hour-name">
+                    {hourLabel(hour)}{' '}
+                    <span className="sky-hour-tag">{isDay ? 'day' : 'night'}{hasOverride(cfg) ? ' · override' : ''}</span>
+                  </span>
+                  <button type="button" className="sky-step" onClick={() => setHour((h) => (h + 1) % 24)} aria-label="Next hour">›</button>
+                  <span className="sky-hourbar-meta">{overriddenCount}/24 tuned</span>
+                </div>
+                <div className="sky-arc" role="tablist" aria-label="Hour">
+                  {Array.from({ length: 24 }, (_, h) => {
+                    const pv = paletteForHour(h, draftToTuning(true, byHour)).vars['--sky-page'];
+                    return (
+                      <button
+                        key={h}
+                        type="button"
+                        role="tab"
+                        aria-selected={h === hour}
+                        className={`sky-arc-cell ${h === hour ? 'is-sel' : ''} ${hasOverride(byHour[h]) ? 'is-ovr' : ''}`}
+                        style={{ background: pv }}
+                        title={skyHourKey(h)}
+                        onClick={() => setHour(h)}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )}
         </>
       )}
     </PageShell>
@@ -423,28 +451,25 @@ function ColorField({ label, hint, value, onChange, onReset }) {
   );
 }
 
-function NumberField({ label, hint, value, min, max, step, suffix, onChange }) {
+function SliderField({ label, hint, value, min, max, step, display, onChange }) {
   return (
-    <label className="sky-field sky-num-field">
-      <span className="admin-field-label">
-        {label}
-        {hint ? <span className="admin-field-hint"> {hint}</span> : null}
+    <label className="sky-field sky-slider-field">
+      <span className="admin-field-label sky-slider-label">
+        <span>
+          {label}
+          {hint ? <span className="admin-field-hint"> {hint}</span> : null}
+        </span>
+        <span className="sky-field-val">{display}</span>
       </span>
-      <span className="sky-num-row">
-        <input
-          className="admin-input sky-num"
-          type="number"
-          value={value}
-          min={min}
-          max={max}
-          step={step}
-          onChange={(e) => {
-            const n = Number(e.target.value);
-            if (Number.isFinite(n)) onChange(Math.min(max, Math.max(min, n)));
-          }}
-        />
-        {suffix ? <span className="sky-num-suffix">{suffix}</span> : null}
-      </span>
+      <input
+        className="sky-slider"
+        type="range"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
     </label>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10,10 +10,11 @@
      the revealed strip lands in its own band instead of over the last line
      of content (which, unlike the top, can't scroll out from under it). The
      owner edit-mode action bar (--edit-bar-h, 0 when off) rides above the bar
-     too — reserve it so the admin editor's last field clears it. */
+     too — reserve it so the admin editor's last field clears it. The sky-theme
+     studio's hour selector (--sky-hourbar-h, 0 when not open) rides there too. */
   padding-bottom: calc(
-    var(--chrome-h) + var(--edit-bar-h, 0px) + var(--chrome-bottom-footer-h, 0px) +
-      env(safe-area-inset-bottom, 0px)
+    var(--chrome-h) + var(--edit-bar-h, 0px) + var(--sky-hourbar-h, 0px) +
+      var(--chrome-bottom-footer-h, 0px) + env(safe-area-inset-bottom, 0px)
   );
 }
 


### PR DESCRIPTION
Follow-up to the sky theme studio (#290): two UI refinements.

- **Sliders for the values** — replace the numeric fields with square/hairline sliders (accent thumb + value readout beside each label). Colors stay as native full-spectrum pickers.
- **Sticky hour bar** — move the 24-hour selector into a bar pinned just above the bottom chrome, styled as an expanded `--surface-deep` panel. Portalled to `<body>` (like the owner edit-mode action bar) so a transformed route wrapper can't break its fixed position; its measured height feeds `--sky-hourbar-h` into the `.app-shell` bottom padding so the last controls always clear it.

## Verification
- Production build passes.
- Studio is OAuth-gated, so the interactive UI was verified via a static visual mock reusing the real `SkyThemeStudio.css` + theme tokens against a simulated bottom chrome — confirmed the slider styling and the bar's placement above the chrome at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJnHBxMGvdQKDwHgTY2ZAP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJnHBxMGvdQKDwHgTY2ZAP)_