### PR TITLE
Comments: stop deep reply nesting from overflowing on mobile

### DIFF
--- a/src/components/Comments.css
+++ b/src/components/Comments.css
@@ -25,12 +25,31 @@
 
 .comments-tree-nested {
   --comment-avatar: 2rem;
+  /* Per-level horizontal indent for nested replies. Kept modest — and
+     capped past a few levels (see .comments-tree-capped) — so a deep thread
+     never accumulates enough left-offset to push content off the right edge
+     and force horizontal scroll on narrow screens. */
+  --reply-indent: var(--space-4);
   margin-top: var(--space-3);
-  margin-left: var(--space-2);
-  padding-left: var(--space-5);
+  padding-left: var(--reply-indent);
   /* A soft green rail reads as a thread spine, distinct from the tan
      hairline rules that separate sibling replies. */
   border-left: 2px solid color-mix(in srgb, var(--accent-soft) 55%, transparent);
+}
+
+/* Past the indent cap, replies stop shifting right: the ancestor thread rails
+   already convey lineage, so deep sub-threads stay readable instead of
+   marching off-screen. Keep a sliver of padding so the spine doesn't collide
+   with the content. */
+.comments-tree-capped {
+  padding-left: var(--space-2);
+}
+
+@media (max-width: 700px) {
+  .comments-tree-nested {
+    --reply-indent: var(--space-3);
+    margin-top: var(--space-2);
+  }
 }
 
 .comment {
@@ -102,6 +121,9 @@
   line-height: 1.25;
   text-decoration: none;
   border-bottom: 1px dotted transparent;
+  /* Break rather than overflow: in a deeply-nested (narrow) column a long
+     unbroken name/handle would otherwise push past the right edge. */
+  overflow-wrap: anywhere;
 }
 
 a.comment-author-name:hover,
@@ -114,6 +136,7 @@ a.comment-author-name:focus-visible {
   font-size: var(--text-sm);
   line-height: 1.2;
   letter-spacing: 0.04em;
+  overflow-wrap: anywhere;
 }
 
 .comment-time {

--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -8,6 +8,14 @@ import { CommentsSkeleton } from './Skeleton.jsx';
 import './Comments.css';
 
 /**
+ * Nested replies stop shifting right past this depth. The ancestor thread
+ * rails already convey lineage, so capping the horizontal indent keeps deep
+ * sub-threads from marching off the right edge and forcing horizontal scroll
+ * on narrow screens (the thread is fetched up to six levels deep).
+ */
+const REPLY_INDENT_CAP = 4;
+
+/**
  * Replies tree powered by `app.bsky.feed.getPostThread`.
  *
  * Pure rendering — the parent (Record.jsx) is responsible for fetching the
@@ -109,7 +117,13 @@ function ReplyNode({ node, depth }) {
         )}
       </article>
       {childReplies.length > 0 && (
-        <ul className="comments-tree comments-tree-nested" data-depth={depth + 1}>
+        <ul
+          className={
+            'comments-tree comments-tree-nested' +
+            (depth + 1 > REPLY_INDENT_CAP ? ' comments-tree-capped' : '')
+          }
+          data-depth={depth + 1}
+        >
           {childReplies.map((child, i) => (
             <ReplyNode key={child.post?.uri || i} node={child} depth={depth + 1} />
           ))}


### PR DESCRIPTION
## Problem

On blog posts with deep threaded replies (fetched up to six levels deep), each nested level accumulated ~34px of left indent (`margin-left` + `padding-left` + rail border) with **no cap**. On a phone this pushed the content column far enough right that a long handle like `@essentialrandom.bsky.social` — which had no wrap rule — spilled past the viewport and forced horizontal scroll.

Reported on `/blogging/a-guestbook-and-welcome-message-for-my-pds`.

## Changes

**`src/components/Comments.css`**
- Shrink the per-level indent (drop the extra `margin-left`, route padding through a `--reply-indent` custom property) and tighten it further under 700px.
- Cap the indent past four levels via `.comments-tree-capped` so deep sub-threads stop marching right — the ancestor thread rails still convey lineage.
- Let the byline name/handle wrap (`overflow-wrap: anywhere`), matching the existing quote-embed fix in `PostEmbed.css`, so a long unbroken handle can never overflow.

**`src/components/Comments.jsx`**
- Add `REPLY_INDENT_CAP = 4`, tagging nested lists past that depth with the capped class.

## Verification

Rendered a six-level-deep thread with a long handle in headless Chromium and measured actual horizontal overflow:

| Viewport | Before | After |
|---|---|---|
| 390px | **61px** overflow (handle 60.8px past edge) | **0px** |

Confirmed 0px overflow at 320 / 360 / 390 / 414 / 768px, with a readable ~212px text column even at the deepest level on a 320px screen. Production build (`vite build`) compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSP3bjwZY8ySiemZHDmTz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSP3bjwZY8ySiemZHDmTz5)_