### PR TITLE
Chrome bar: stop right-cluster buttons animating on inspect toggle

### DIFF
--- a/src/components/ChromeBar.jsx
+++ b/src/components/ChromeBar.jsx
@@ -563,7 +563,23 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
   const layoutProp = reduce ? undefined : true;
 
   return (
-    <div className="chrome-bar chrome-bar-bottom" role="toolbar" aria-label="Global actions">
+    // `layoutScroll layoutRoot` — the bar is `position: fixed`, and its right-
+    // cluster buttons carry `layout` (so they slide over when back/home/count/
+    // account enter or exit). Motion measures layout in document coordinates and
+    // corrects for page scroll; for a fixed element that correction is spurious,
+    // so any re-render that coincides with a scroll-position change animates the
+    // buttons by the scroll delta. Toggling inspect (x-ray) collapses/expands the
+    // page enough that the browser clamps window.scrollY, which is exactly such a
+    // change — the buttons would jump vertically for no reason. Marking the fixed
+    // bar as a layout root makes its children resolve relative to the bar (not the
+    // scrolling document), so only genuine layout shifts inside the bar animate.
+    <motion.div
+      className="chrome-bar chrome-bar-bottom"
+      role="toolbar"
+      aria-label="Global actions"
+      layoutScroll
+      layoutRoot
+    >
       <div className="chrome-bottom-row">
         {/* Left cluster. While the nav dock is open, the page-level controls
             (theme / filter / search / info / inspect) hand off to the dock's
@@ -866,7 +882,7 @@ function ChromeBarBottom({ dockOpen, toggleDock }) {
       <InfoSheet />
       <GuestbookSheet />
       <DebugSheet />
-    </div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
Toggling inspect (x-ray) mode made the bottom chrome bar's right-cluster buttons (scroll-jump, menu, and the on-demand back/home/count/account controls) animate in and out even though none of them were changing.

## Root cause

Those buttons carry Motion's `layout` prop so the persistent buttons slide horizontally to fill the gap when an on-demand control enters or exits — intended behavior. But the bar is `position: fixed`, and Motion measures layout in **document coordinates** and applies a page-scroll correction that is spurious for a fixed element. Any re-render that coincides with a scroll-position change makes Motion mistake the scroll delta for a layout move and animate the buttons by it **vertically**.

Toggling inspect collapses/expands page content, changing the document height enough that the browser **clamps `window.scrollY`**. That scroll jump was then animated onto the fixed buttons as a pointless vertical slide — up to hundreds of pixels when toggling near the bottom of a long feed.

## Fix

Mark the fixed bar with `layoutScroll layoutRoot` (Motion's documented remedy for `position: fixed` layout ancestors) so its children resolve layout relative to the bar rather than the scrolling document.

## Verification (Playwright, real browser)

| Scenario | Before | After |
|---|---|---|
| `/blogging` toggle (scrollY 11→0) | buttons animate `translateY` | no animation |
| Home toggled near bottom (scrollY clamp ~1146px) | `translateY` up to 216px+ | 0px |
| No-toggle control | no animation | no animation |
| Intended slide on dock-open | horizontal slide (tx 35→0) | horizontal slide preserved |

The spurious vertical animation is gone across the on→off→on→off cycle and every feed page; the intended horizontal slide when controls enter/exit is unchanged; the production build compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1NW3bLLYxUWWbYW9dVjEN)_