### PR TITLE
Hide connected portfolio items from the resume print view

### DIFF
--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -458,17 +458,11 @@ a.resume-work-link:hover .resume-work-title {
     color: var(--ink-faint);
   }
 
-  /* Selected work: keep the titles as text, shed the card frame, the
-     portfolio thumbnails, and the external-link glyph. */
-  .resume-work-link {
-    padding: 0;
-    border: none;
-    background: none;
-  }
-
-  .resume-work-thumb,
-  .resume-work-ext {
-    display: none;
+  /* Selected work: the connected portfolio items are screen-only links —
+     drop the whole block (label + list) so the printout stays a clean,
+     self-contained text document rather than a list of dead URLs. */
+  .resume-work {
+    display: none !important;
   }
 
   /* The closing footnote is a site-navigation aside — not resume content. */


### PR DESCRIPTION
## What & why

Follow-up to the resume print-styling rework (#296). The "Selected work" block under each role is a set of screen-only portfolio links and embeds that print as dead URLs. Hide the whole block — label and list — in `@media print` so the printout stays a clean, self-contained text document.

This replaces the earlier print treatment that only stripped the card frame, thumbnails, and external-link glyph while keeping the titles as text.

## Change

```css
@media print {
  .resume-work { display: none !important; }
}
```

(removes the previous `.resume-work-link` / `.resume-work-thumb` / `.resume-work-ext` print rules, now redundant)

## Verification

Headless Chromium print-media emulation on the built CSS:

- `.resume-work` → `display: none` in print, `block` on screen
- Skills and every other section unaffected; body ground still white, text black
- Screenshot confirms the role flows straight from its bullets to Skills with no orphaned "Selected work" heading

Offline production build (`npm run build:offline`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F34Uixb5wxVh6hMYcuuaqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F34Uixb5wxVh6hMYcuuaqn)_