### PR TITLE
Auto-convert pasted markdown / multiple paragraphs into blocks

### DIFF
--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -120,6 +120,32 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
     [blocks, commit],
   );
 
+  // Replace the text block at `index` with a paste that was detected as
+  // markdown / multiple paragraphs: whatever preceded the caret (head) stays
+  // as a text block, the converted blocks land next, and whatever followed the
+  // caret (tail) trails as a text block. Empty head/tail are dropped, so
+  // pasting into an empty block simply swaps in the converted blocks. Committed
+  // as one structural op, so a single ⌘Z undoes the whole paste.
+  const pasteBlocksAt = useCallback(
+    (index, { head, tail, blocks: pasted }) => {
+      const seq = [];
+      if (head && head.text.trim()) {
+        seq.push({ $type: 'pub.leaflet.blocks.text', plaintext: head.text, facets: head.facets });
+      }
+      seq.push(...(pasted || []));
+      if (tail && tail.text.trim()) {
+        seq.push({ $type: 'pub.leaflet.blocks.text', plaintext: tail.text, facets: tail.facets });
+      }
+      if (seq.length === 0) return;
+      const wrapped = seq.map((b) => ({ $type: WRAPPER_TYPE, block: b }));
+      const next = blocks.slice();
+      next.splice(index, 1, ...wrapped);
+      commit(next, { kind: 'structural' });
+      setActiveIndex(null);
+    },
+    [blocks, commit],
+  );
+
   const removeBlock = useCallback(
     (index) => {
       const next = blocks.slice();
@@ -396,6 +422,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
                     did={did}
                     onChange={(next) => updateBlock(i, next)}
                     onSetCover={onSetCover}
+                    onPasteBlocks={(payload) => pasteBlocksAt(i, payload)}
                   />
                 </div>
               ) : (
@@ -438,10 +465,10 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
   );
 }
 
-function BlockBody({ block, agent, did, onChange, onSetCover }) {
+function BlockBody({ block, agent, did, onChange, onSetCover, onPasteBlocks }) {
   switch (block.$type) {
     case 'pub.leaflet.blocks.text':
-      return <TextBlockEditor block={block} onChange={onChange} />;
+      return <TextBlockEditor block={block} onChange={onChange} onPasteBlocks={onPasteBlocks} />;
     case 'pub.leaflet.blocks.header':
       return <HeadingBlockEditor block={block} onChange={onChange} />;
     case 'pub.leaflet.blocks.image':

--- a/src/components/blocks/TextBlockEditor.jsx
+++ b/src/components/blocks/TextBlockEditor.jsx
@@ -8,12 +8,14 @@ import {
   featureTypesForRange,
   facetRuns,
   runsToFacets,
+  sliceRichText,
   FORMAT_TYPES,
   LINK_TYPE,
   KEY_FOR_TYPE,
 } from './facetUtils.js';
+import { looksLikeMultiBlock, markdownToBlocks } from '../../lib/pasteBlocks.js';
 
-export default function TextBlockEditor({ block, onChange }) {
+export default function TextBlockEditor({ block, onChange, onPasteBlocks }) {
   return (
     <RichTextField
       text={block.plaintext || ''}
@@ -30,6 +32,7 @@ export default function TextBlockEditor({ block, onChange }) {
         }
       }}
       onChange={({ text, facets }) => onChange({ ...block, plaintext: text, facets })}
+      onPasteBlocks={onPasteBlocks}
       rows={4}
     />
   );
@@ -67,6 +70,7 @@ export function RichTextField({
   blockType = null,
   headingLevel = null,
   onConvert = null,
+  onPasteBlocks = null,
 }) {
   const editorRef = useRef(null);
   const lastEmittedRef = useRef('');
@@ -257,12 +261,41 @@ export function RichTextField({
     if (NAV_KEYS.has(e.key)) pendingMarksRef.current = {};
   }, []);
 
-  const handlePaste = useCallback((e) => {
-    e.preventDefault();
-    const clip = e.clipboardData || window.clipboardData;
-    const plain = clip ? clip.getData('text/plain') : '';
-    if (plain) document.execCommand('insertText', false, plain);
-  }, []);
+  const handlePaste = useCallback(
+    (e) => {
+      const clip = e.clipboardData || window.clipboardData;
+      const plain = clip ? clip.getData('text/plain') : '';
+      // When the host provides an onPasteBlocks handler (text blocks only) and
+      // the pasted text reads as markdown or several paragraphs, explode it into
+      // real blocks instead of flattening it into this one. Anything else — a
+      // word, a sentence, a single soft-wrapped paragraph — pastes as plain text.
+      if (onPasteBlocks && plain && looksLikeMultiBlock(plain)) {
+        const converted = markdownToBlocks(plain);
+        const structural =
+          converted.length > 1 ||
+          converted.some(
+            (b) => b.$type !== 'pub.leaflet.blocks.text' || (b.facets || []).length > 0,
+          );
+        if (structural) {
+          e.preventDefault();
+          const editor = editorRef.current;
+          const r = editor ? getSelectionRange(editor) : null;
+          const t = textRef.current;
+          const start = r ? r.start : t.length;
+          const end = r ? r.end : t.length;
+          // Split this block's rich text around the (possibly collapsed)
+          // selection: head keeps what preceded the caret, tail what followed.
+          const head = sliceRichText(t, facetsRef.current, 0, start);
+          const tail = sliceRichText(t, facetsRef.current, end, t.length);
+          onPasteBlocks({ head, tail, blocks: converted });
+          return;
+        }
+      }
+      e.preventDefault();
+      if (plain) document.execCommand('insertText', false, plain);
+    },
+    [onPasteBlocks],
+  );
 
   return (
     <div className="rich-text-field">

--- a/src/components/blocks/facetUtils.js
+++ b/src/components/blocks/facetUtils.js
@@ -272,6 +272,35 @@ export function runsToFacets(text, runs) {
   return segmentsToFacets(byteSegs);
 }
 
+/**
+ * Extract the `[startChar, endChar)` substring of `text` together with the
+ * facets that fall within it, re-based to the slice's own byte offsets. Used
+ * to split a text block's rich text around the caret when a paste is exploded
+ * into blocks (the head keeps what was before the caret, the tail what was
+ * after). Returns `{ text, facets }`.
+ */
+export function sliceRichText(text, facets, startChar, endChar) {
+  const safe = typeof text === 'string' ? text : '';
+  const start = Math.max(0, Math.min(startChar, safe.length));
+  const end = Math.max(start, Math.min(endChar, safe.length));
+  const sliceText = safe.slice(start, end);
+  if (!sliceText) return { text: '', facets: [] };
+  // facetRuns yields gap-free runs whose text concatenates to the whole string;
+  // clip each to the window, then rebuild facets against the slice.
+  const cut = [];
+  let pos = 0;
+  for (const run of facetRuns(safe, facets)) {
+    const runStart = pos;
+    const runEnd = pos + run.text.length;
+    pos = runEnd;
+    const from = Math.max(runStart, start);
+    const to = Math.min(runEnd, end);
+    if (to <= from) continue;
+    cut.push({ text: run.text.slice(from - runStart, to - runStart), features: run.features });
+  }
+  return { text: sliceText, facets: runsToFacets(sliceText, cut) };
+}
+
 function hasFeature(features, target) {
   return (features || []).some((f) => f?.$type === target.$type);
 }

--- a/src/lib/pasteBlocks.js
+++ b/src/lib/pasteBlocks.js
@@ -1,0 +1,84 @@
+// Paste-to-blocks: turn a pasted markdown / multi-paragraph string into the
+// editor's block shapes so the blocks editor can explode a paste into real
+// text / heading / list / code / image blocks instead of dropping everything
+// into one text block.
+//
+// The markdown → block conversion is the exact one the legacy-blog migration
+// uses (`markdownToContent` in legacyBlogMarkdown.js), so paste and migration
+// stay in lockstep and share its handling of headings, lists, code fences,
+// blockquotes, links, and inline formatting (bold / italic / strike / code)
+// as byte-offset facets. The only paste-specific tweak is images: the
+// migration resolves an image's `_src` to an uploaded PDS blob in a later
+// step, but a live paste has no such step — so an absolute image URL is kept
+// as a renderable `url` and an unresolvable local path collapses to an empty
+// image block (alt / caption preserved) for the author to fill in.
+
+import { markdownToContent } from './legacyBlogMarkdown.js';
+
+// Block-level markdown markers that, on their own, are strong enough evidence
+// of "this is markdown" to convert even a single pasted line.
+const STRONG_MARKERS = [
+  /^\s{0,3}#{1,6}\s+\S/, // ATX heading:  "# Title"
+  /^\s{0,3}!\[[^\]]*\]\([^)]*\)/, // standalone image:  "![alt](url)"
+  /^\s{0,3}(```|~~~)/, // fenced code start
+];
+
+// Markers that only imply structure when the paste spans several lines, so a
+// lone "- note" or "> hmm" or "1) call" still pastes as plain text.
+const MULTILINE_MARKERS = [
+  /^\s{0,3}[-*+]\s+\S/, // unordered list item
+  /^\s{0,3}\d+[.)]\s+\S/, // ordered list item
+  /^\s{0,3}>\s?/, // blockquote
+  /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/, // thematic break: ---, ***, ___
+];
+
+/**
+ * Should a pasted string be exploded into blocks rather than inserted as plain
+ * text? True when it spans multiple paragraphs (a blank-line break) or carries
+ * a block-level markdown marker. A single prose line — the everyday "paste a
+ * word or a sentence" case — returns false and pastes normally.
+ */
+export function looksLikeMultiBlock(input) {
+  const text = normalizeNewlines(input).trim();
+  if (!text) return false;
+  // Two or more paragraphs separated by a blank line.
+  if (/\n[ \t]*\n/.test(text)) return true;
+  const lines = text.split('\n');
+  if (lines.some((line) => STRONG_MARKERS.some((re) => re.test(line)))) return true;
+  if (lines.length > 1 && lines.some((line) => MULTILINE_MARKERS.some((re) => re.test(line)))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Convert a pasted markdown string into a flat list of editor blocks
+ * (unwrapped — plain `pub.leaflet.blocks.*` values, not the linearDocument
+ * wrapper). Returns `[]` for empty input.
+ */
+export function markdownToBlocks(input) {
+  const text = normalizeNewlines(input);
+  if (!text.trim()) return [];
+  const content = markdownToContent(text);
+  return (content?.pages?.[0]?.blocks || [])
+    .map((wrap) => wrap?.block)
+    .filter(Boolean)
+    .map(resolvePastedImage);
+}
+
+/**
+ * The migration leaves image blocks carrying a temporary `_src`; a live paste
+ * has no upload step, so map an absolute URL onto the renderable `url` field
+ * and drop `_src` (an unresolvable local path just leaves an empty image block
+ * the author can upload into).
+ */
+function resolvePastedImage(block) {
+  if (block?.$type !== 'pub.leaflet.blocks.image') return block;
+  const { _src, ...rest } = block;
+  if (_src && /^https?:\/\//i.test(_src)) return { ...rest, url: _src };
+  return rest;
+}
+
+function normalizeNewlines(input) {
+  return typeof input === 'string' ? input.replace(/\r\n?/g, '\n') : '';
+}


### PR DESCRIPTION
## What

In the admin blocks editor (used by the blogging & creating record editors), pasting into a text block previously flattened everything into that one block as plain text. Now, when the pasted text reads as **markdown** or spans **multiple paragraphs**, it is automatically exploded into real text / heading / list / code / image blocks.

## How

- **`src/lib/pasteBlocks.js`** (new)
  - `looksLikeMultiBlock()` gates the behaviour: fires on blank-line paragraph breaks or block-level markdown markers (headings, lists, blockquotes, fenced code, images, thematic breaks). A lone word, sentence, or soft-wrapped paragraph still pastes as plain text — no false positives.
  - `markdownToBlocks()` reuses the existing, battle-tested `markdownToContent()` conversion from the legacy-blog migration, so paste and migration stay in lockstep (headings, nested lists, code, blockquotes, links, and inline bold/italic/strike/code as byte-offset facets). Pasted image URLs are mapped onto the renderable `url` field since a live paste has no upload step.
- **`facetUtils.sliceRichText()`** (new) splits a block's rich text around the caret so any text before/after the paste is preserved along with its facets.
- **`TextBlockEditor`** — the paste handler detects a rich paste and delegates to a new `onPasteBlocks` callback. Scoped to text blocks only; headings and list items keep the plain-text paste behaviour.
- **`BlocksEditor.pasteBlocksAt()`** replaces the active block with `head + converted blocks + tail` as a single **undoable** structural commit (one ⌘Z reverts the whole paste). Pasting into an empty block simply swaps in the converted blocks.

## Notes / behaviour

- Detection is conservative on single lines: `# Heading`, `[alt](url)`, and code fences convert on their own; list / quote / hr markers only convert when the paste spans multiple lines.
- Inline-only markdown in a single pasted line (e.g. `Check **this**`) is intentionally *not* auto-converted, to avoid surprising anyone pasting literal asterisks. Easy to revisit if desired.
- Verified: `vite build` compiles; runtime checks confirm the heuristic, conversion (incl. image `url` mapping + inline facets), and caret-splitting all behave as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ybC17dEtcWWJsTmZLydiS

---
_Generated by [Claude Code](https://claude.ai/code/session_015ybC17dEtcWWJsTmZLydiS)_