### PR TITLE
Blog feed links + ledger summaries, per-block layout controls, Bluesky comments field

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1673,6 +1673,18 @@ a.ledger-verb:focus-visible {
   overflow-wrap: anywhere;
 }
 
+/* Blog rows add a muted summary/description beneath the title, clamped to a
+   couple of lines so the ledger stays scannable. */
+.ledger-subtext {
+  margin-top: 3px;
+  color: var(--ink-faint);
+  font-size: var(--text-sm);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Links and link-like emphasis inside a summary read as quiet accents —
    color only, no underline until hover. */
 .ledger-body a {

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -63,7 +63,11 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
   // iNaturalist observations render a specimen thumbnail beside stacked
   // common/scientific names (see ObservationLedgerBody), not a text summary.
   const isObservation = item.verb === 'mothing' || item.verb === 'observing';
-  const summary = isRepost || isObservation ? null : summarize(item, { expanded, onToggle });
+  // Blog entries render title + a muted summary line beneath (BlogLedgerBody)
+  // rather than the single-line title summary.
+  const isBlog = item.verb === 'blogging';
+  const summary =
+    isRepost || isObservation || isBlog ? null : summarize(item, { expanded, onToggle });
   const embed = isRepost ? null : ledgerEmbed(item);
   // Observations show their stored local wall-clock time-of-day directly, never
   // localized — the record's timestamp is that wall-clock pinned to `Z`, so
@@ -91,6 +95,7 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
       <div className="ledger-body">
         {isRepost && <RepostQuote item={item} />}
         {isObservation && <ObservationLedgerBody item={item} />}
+        {isBlog && <BlogLedgerBody item={item} />}
         {summary && <p className="ledger-text">{summary}</p>}
         {embed && (
           <div className="ledger-embed">
@@ -432,6 +437,36 @@ function ObservationLedgerBody({ item }) {
         {showSci && <span className="ledger-obs-sci">{sci}</span>}
       </span>
     </div>
+  );
+}
+
+/**
+ * A blog entry as a ledger body: the title on top, then a muted summary /
+ * description line beneath (CSS-clamped to two lines). Mirrors the cards
+ * layout (BlogCard), which already shows a summary — the ledger just did
+ * title-only before. `summary` is baked by feedBuilder (an explicit summary,
+ * else a synopsis of the leading text); `description` is the standard.site
+ * meta description.
+ */
+function BlogLedgerBody({ item }) {
+  const payload = item.payload || {};
+  const title = (payload.title || payload.name || payload.slug || '').trim();
+  const summary = (payload.summary || payload.description || '').trim();
+  return (
+    <>
+      <p className="ledger-text">
+        {title ? (
+          renderPlainTextWithTruncatedUrls(title)
+        ) : (
+          <Placeholder>an untitled entry</Placeholder>
+        )}
+      </p>
+      {summary && (
+        <p className="ledger-text ledger-subtext">
+          {renderPlainTextWithTruncatedUrls(summary)}
+        </p>
+      )}
+    </>
   );
 }
 

--- a/src/components/LeafletDocument.jsx
+++ b/src/components/LeafletDocument.jsx
@@ -1,4 +1,4 @@
-import { createContext, Fragment, useContext, useEffect, useMemo, useState } from 'react';
+import { cloneElement, createContext, Fragment, useContext, useEffect, useMemo, useState } from 'react';
 import { renderLeafletText } from '../lib/leafletRichText.jsx';
 import { getPostThread } from '../lib/atproto.js';
 import PostEmbed from './PostEmbed.jsx';
@@ -132,53 +132,89 @@ function LeafletPage({ page }) {
   return <Fragment>{out}</Fragment>;
 }
 
+// Optional per-block layout hints (dame.is rendering extensions, set in the
+// admin blocks editor): `indent` forces a text paragraph's first-line indent
+// on/off (overriding the automatic book-style adjacency indent), and
+// `spaceTop`/`spaceBottom` add extra margin above/below any block so an author
+// can open up space without inserting empty spacer blocks.
+const BLOCK_SPACE_SCALE = {
+  sm: 'var(--space-4)',
+  md: 'var(--space-6)',
+  lg: 'var(--space-8)',
+};
+
+function blockLayoutStyle(block) {
+  const style = {};
+  if (BLOCK_SPACE_SCALE[block.spaceTop]) style.marginTop = BLOCK_SPACE_SCALE[block.spaceTop];
+  if (BLOCK_SPACE_SCALE[block.spaceBottom]) style.marginBottom = BLOCK_SPACE_SCALE[block.spaceBottom];
+  // Indent is a paragraph concept; only text blocks honor it. `null`/absent =
+  // leave the CSS default (adjacent paragraphs auto-indent) untouched.
+  if (block.$type === 'pub.leaflet.blocks.text' && block.indent != null) {
+    style.textIndent = block.indent ? '1.5em' : '0';
+  }
+  return Object.keys(style).length ? style : null;
+}
+
 export function LeafletBlock({ block }) {
   if (!block) return null;
+  // Layout hints ride as an inline style on the block's own root element so
+  // they win over the stylesheet's adjacency rules (e.g. the `margin-bottom: 0`
+  // on stacked paragraphs) without wrapping the block — wrapping would break
+  // those `+` selectors. `null` when the block carries no hints.
+  const style = blockLayoutStyle(block);
   switch (block.$type) {
     case 'pub.leaflet.blocks.text':
-      return <TextBlock block={block} />;
+      return <TextBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.header':
-      return <HeaderBlock block={block} />;
+      return <HeaderBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.image':
-      return <ImageBlock block={block} />;
+      return <ImageBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.website':
-      return <WebsiteBlock block={block} />;
+      return <WebsiteBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.bskyPost':
-      return <BskyPostBlock block={block} />;
+      return <BskyPostBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.code':
-      return <CodeBlock block={block} />;
+      return <CodeBlock block={block} style={style} />;
     case 'pub.leaflet.blocks.unorderedList':
     case 'pub.leaflet.blocks.orderedList':
-      return <ListBlock block={block} ordered={block.$type === 'pub.leaflet.blocks.orderedList'} />;
+      return (
+        <ListBlock
+          block={block}
+          ordered={block.$type === 'pub.leaflet.blocks.orderedList'}
+          style={style}
+        />
+      );
     default:
       return null;
   }
 }
 
-function TextBlock({ block }) {
+function TextBlock({ block, style }) {
   const text = block.plaintext || '';
   // Empty text blocks function as paragraph breaks. Render an empty
   // spacer paragraph rather than nothing so the rhythm is preserved.
   if (!text.trim()) {
-    return <p className="leaflet-spacer" aria-hidden="true" />;
+    return <p className="leaflet-spacer" aria-hidden="true" style={style || undefined} />;
   }
   return (
-    <p className="leaflet-paragraph">{renderLeafletText(text, block.facets)}</p>
+    <p className="leaflet-paragraph" style={style || undefined}>
+      {renderLeafletText(text, block.facets)}
+    </p>
   );
 }
 
-function HeaderBlock({ block }) {
+function HeaderBlock({ block, style }) {
   const level = clampLevel(block.level);
   const Tag = `h${level}`;
   const text = block.plaintext || '';
   return (
-    <Tag className={`leaflet-heading leaflet-heading-${level}`}>
+    <Tag className={`leaflet-heading leaflet-heading-${level}`} style={style || undefined}>
       {renderLeafletText(text, block.facets)}
     </Tag>
   );
 }
 
-function ImageBlock({ block }) {
+function ImageBlock({ block, style }) {
   const lightbox = useContext(LeafletLightboxContext);
   const url = imageBlockUrl(block);
   if (!url) return null;
@@ -187,7 +223,7 @@ function ImageBlock({ block }) {
   // Legacy blocks doubled `alt` as the caption, so fall back to it.
   const caption = block.caption || alt;
   const ar = block.aspectRatio;
-  const style = ar?.width && ar?.height
+  const imgStyle = ar?.width && ar?.height
     ? { aspectRatio: `${ar.width} / ${ar.height}` }
     : undefined;
   const img = (
@@ -196,11 +232,11 @@ function ImageBlock({ block }) {
       alt={alt}
       loading="lazy"
       decoding="async"
-      style={style}
+      style={imgStyle}
     />
   );
   return (
-    <figure className="leaflet-image">
+    <figure className="leaflet-image" style={style || undefined}>
       {lightbox?.openImage ? (
         <button
           type="button"
@@ -246,7 +282,7 @@ export function videoEmbedSrc(url) {
   return null;
 }
 
-function WebsiteBlock({ block }) {
+function WebsiteBlock({ block, style }) {
   const raw = block.src;
   if (!raw) return null;
   // Authors can enter a bare host ("anisota.net"); make the link (and the
@@ -257,7 +293,7 @@ function WebsiteBlock({ block }) {
   const embed = videoEmbedSrc(href);
   if (embed) {
     return (
-      <figure className="leaflet-embed">
+      <figure className="leaflet-embed" style={style || undefined}>
         <div className="leaflet-embed-frame">
           <iframe
             src={embed}
@@ -285,6 +321,7 @@ function WebsiteBlock({ block }) {
       href={href}
       target="_blank"
       rel="noreferrer noopener"
+      style={style || undefined}
     >
       {thumb && (
         <div className="leaflet-website-thumb">
@@ -304,7 +341,7 @@ function WebsiteBlock({ block }) {
   );
 }
 
-function CodeBlock({ block }) {
+function CodeBlock({ block, style }) {
   const code = block.plaintext || block.code || '';
   const lang = block.language || '';
   // highlight.js is lazy-loaded so it never weighs down pages without code.
@@ -332,7 +369,7 @@ function CodeBlock({ block }) {
   }, [code, lang]);
 
   return (
-    <pre className="leaflet-code hljs">
+    <pre className="leaflet-code hljs" style={style || undefined}>
       {html ? (
         <code dangerouslySetInnerHTML={{ __html: html }} />
       ) : (
@@ -346,11 +383,11 @@ function CodeBlock({ block }) {
  * Recursive list. Each `#listItem` carries a `content` text block and
  * an optional `children` array of more list items (nested lists).
  */
-function ListBlock({ block, ordered }) {
+function ListBlock({ block, ordered, style }) {
   const Tag = ordered ? 'ol' : 'ul';
   const items = Array.isArray(block?.children) ? block.children : [];
   return (
-    <Tag className="leaflet-list">
+    <Tag className="leaflet-list" style={style || undefined}>
       {items.map((item, i) => (
         <ListItem key={i} item={item} ordered={ordered} />
       ))}
@@ -378,7 +415,7 @@ function ListItem({ item, ordered }) {
  * `getPostThread` endpoint (depth 0). On miss, renders a hint linking
  * to bsky.app so the reader can still chase the reference.
  */
-function BskyPostBlock({ block }) {
+function BskyPostBlock({ block, style }) {
   const uri = block?.postRef?.uri || null;
   const [post, setPost] = useState(null);
   const [status, setStatus] = useState('idle');
@@ -408,11 +445,15 @@ function BskyPostBlock({ block }) {
 
   if (!uri) return null;
   if (status === 'loading' || status === 'idle') {
-    return <div className="leaflet-bsky-post leaflet-bsky-post-loading">Loading post…</div>;
+    return (
+      <div className="leaflet-bsky-post leaflet-bsky-post-loading" style={style || undefined}>
+        Loading post…
+      </div>
+    );
   }
   if (!post) {
     return (
-      <div className="leaflet-bsky-post leaflet-bsky-post-missing">
+      <div className="leaflet-bsky-post leaflet-bsky-post-missing" style={style || undefined}>
         <a href={bskyAppUrlFromAtUri(uri)} target="_blank" rel="noreferrer noopener">
           Open the embedded post on bsky.app
         </a>
@@ -429,7 +470,7 @@ function BskyPostBlock({ block }) {
   const externalHref = !localHref ? bskyAppUrlFromAtUri(post.uri, author.handle) : null;
 
   return (
-    <article className="leaflet-bsky-post" data-at-uri={post.uri}>
+    <article className="leaflet-bsky-post" data-at-uri={post.uri} style={style || undefined}>
       <header className="leaflet-bsky-post-head">
         {author.avatar && (
           <img

--- a/src/components/RecordEditor.jsx
+++ b/src/components/RecordEditor.jsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { COLLECTIONS } from '../config.js';
+import { COLLECTIONS, ME_DID } from '../config.js';
 import { lexiconFor, blankRecordFor } from '../lib/lexicons.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { resolvePds } from '../lib/atproto.js';
@@ -625,6 +625,9 @@ function Field({ field, value, record, onChange, agent, did, collection, rkey, o
     case 'json':
       control = <JsonField id={id} value={value} onChange={onChange} />;
       break;
+    case 'bskyThread':
+      control = <BskyThreadField id={id} value={value} onChange={onChange} />;
+      break;
     case 'highlights':
       control = (
         <HighlightsField
@@ -817,6 +820,74 @@ function stringifyJson(v) {
   } catch {
     return '';
   }
+}
+
+/**
+ * Links a Bluesky post whose reply thread becomes a blog post's comments
+ * (stored on `commentsUri`, which BlogPost.jsx feeds to getPostThread). The
+ * author can paste any of: a bsky.app post URL, an `at://` URI, or a bare
+ * rkey — all normalized to the canonical `at://{did}/app.bsky.feed.post/{rkey}`
+ * form that legacy migrated posts already use. A handle-based URL (or bare
+ * rkey) assumes the post is the site owner's own; a DID in the URL is kept.
+ */
+function BskyThreadField({ id, value, onChange }) {
+  // `raw` mirrors what the author typed; the record stores the normalized URI.
+  const [raw, setRaw] = useState(value || '');
+  // Ignore the echo of our own emit so re-normalization doesn't clobber typing;
+  // still re-sync when the record itself loads/changes underneath us.
+  const lastEmitted = useRef(value || '');
+  useEffect(() => {
+    if ((value || '') !== lastEmitted.current) {
+      setRaw(value || '');
+      lastEmitted.current = value || '';
+    }
+  }, [value]);
+
+  const normalized = normalizeBskyThread(raw);
+  return (
+    <div>
+      <input
+        id={id}
+        className="admin-input"
+        type="text"
+        value={raw}
+        onChange={(e) => {
+          const next = e.target.value;
+          setRaw(next);
+          const norm = normalizeBskyThread(next) || undefined;
+          lastEmitted.current = norm || '';
+          onChange(norm);
+        }}
+        placeholder="https://bsky.app/profile/you/post/3k… — or an rkey"
+      />
+      {raw.trim() &&
+        (normalized ? (
+          <p className="admin-field-hint">
+            Comments load from <code>{normalized}</code>
+          </p>
+        ) : (
+          <p className="admin-field-hint admin-error-inline">
+            Couldn’t read a Bluesky post reference from that.
+          </p>
+        ))}
+    </div>
+  );
+}
+
+/** rkey / bsky.app URL / at:// URI → canonical at:// post URI (or '' if none). */
+function normalizeBskyThread(input) {
+  const s = (input || '').trim();
+  if (!s) return '';
+  if (s.startsWith('at://')) return s;
+  // A post URL: …/profile/{handle-or-did}/post/{rkey}
+  const url = s.match(/\/profile\/([^/\s]+)\/post\/([a-z0-9]+)/i);
+  if (url) {
+    const repo = url[1].startsWith('did:') ? url[1] : ME_DID;
+    return `at://${repo}/app.bsky.feed.post/${url[2]}`;
+  }
+  // A bare rkey — assume the owner's own post.
+  if (/^[a-z0-9]+$/i.test(s)) return `at://${ME_DID}/app.bsky.feed.post/${s}`;
+  return '';
 }
 
 function RawJsonEditor({ value, onChange }) {

--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -424,6 +424,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
                     onSetCover={onSetCover}
                     onPasteBlocks={(payload) => pasteBlocksAt(i, payload)}
                   />
+                  <BlockLayoutControls block={block} onChange={(next) => updateBlock(i, next)} />
                 </div>
               ) : (
                 <div
@@ -497,6 +498,69 @@ function BlockBody({ block, agent, did, onChange, onSetCover, onPasteBlocks }) {
         </pre>
       );
   }
+}
+
+/**
+ * Per-block layout controls under the active block's editor: indent (text
+ * paragraphs only) plus extra space above / below any block, so an author can
+ * shape spacing without inserting empty spacer blocks. Values are stored on the
+ * block (`indent`, `spaceTop`, `spaceBottom`) and read by the renderer (see
+ * LeafletDocument's blockLayoutStyle). Absent = the default: stacked paragraphs
+ * auto-indent, and there's no extra space.
+ */
+function BlockLayoutControls({ block, onChange }) {
+  const isText = block.$type === 'pub.leaflet.blocks.text';
+  const setField = (key, value) => {
+    const next = { ...block };
+    if (value === undefined) delete next[key];
+    else next[key] = value;
+    onChange(next);
+  };
+  const indentValue = block.indent == null ? 'auto' : block.indent ? 'on' : 'off';
+  return (
+    <div className="block-layout-controls">
+      {isText && (
+        <label className="block-layout-field">
+          <span className="small-caps">Indent</span>
+          <select
+            className="block-layout-select"
+            value={indentValue}
+            onChange={(e) => {
+              const v = e.target.value;
+              setField('indent', v === 'auto' ? undefined : v === 'on');
+            }}
+          >
+            <option value="auto">Auto</option>
+            <option value="on">Indented</option>
+            <option value="off">Flush</option>
+          </select>
+        </label>
+      )}
+      <label className="block-layout-field">
+        <span className="small-caps">Space above</span>
+        <SpaceSelect value={block.spaceTop} onChange={(v) => setField('spaceTop', v)} />
+      </label>
+      <label className="block-layout-field">
+        <span className="small-caps">Space below</span>
+        <SpaceSelect value={block.spaceBottom} onChange={(v) => setField('spaceBottom', v)} />
+      </label>
+    </div>
+  );
+}
+
+function SpaceSelect({ value, onChange }) {
+  return (
+    <select
+      className="block-layout-select"
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value || undefined)}
+    >
+      <option value="">None</option>
+      <option value="sm">Small</option>
+      <option value="md">Medium</option>
+      <option value="lg">Large</option>
+    </select>
+  );
 }
 
 /**

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -528,3 +528,35 @@
 .website-block-actions .admin-field-hint {
   margin: 0;
 }
+
+/* Per-block layout controls (indent + extra space above/below), shown beneath
+   the active block's editor so an author can shape spacing without inserting
+   empty spacer blocks. */
+.block-layout-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--rule, rgba(0, 0, 0, 0.12));
+}
+
+.block-layout-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--ink-faint, var(--ink));
+}
+
+.block-layout-select {
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--ink);
+  background: var(--page);
+  border: 1px solid var(--rule, rgba(0, 0, 0, 0.18));
+  border-radius: 6px;
+  padding: 0.15rem 0.35rem;
+  cursor: pointer;
+}

--- a/src/lib/lexicons.js
+++ b/src/lib/lexicons.js
@@ -117,6 +117,10 @@ export const LEXICONS = {
       { key: 'publishedAt', label: 'Published at', type: 'datetime', default: 'now', required: true },
       { key: 'content',     label: 'Body',         type: 'blocks' },
       {
+        key: 'commentsUri', label: 'Bluesky comments post', type: 'bskyThread',
+        hint: 'Link a Bluesky post whose replies become this post’s comments. Paste its URL, at:// URI, or rkey.',
+      },
+      {
         key: 'links', label: 'Links', type: 'json',
         hint: 'Optional external links (standard.site union — raw JSON).',
       },

--- a/src/lib/verbRegistry.js
+++ b/src/lib/verbRegistry.js
@@ -89,6 +89,16 @@ export const VERB_REGISTRY = [
     icon: 'BookOpen',
     renderer: 'BlogCard',
     pastTense: 'blogged',
+    // Blog posts get the native /blogging/{rkey} reader (BlogPost.jsx matches
+    // `:id` as an rkey; both standard.site and leaflet docs key by rkey).
+    // Publications aren't posts, so they fall through to the generic
+    // /{nsid}/{rkey} explorer. Mirrors BlogCard's own `blogHref` logic.
+    recordHref: ({ atUri, rkey }) => {
+      const nsid = nsidFromAtUri(atUri);
+      return rkey && (nsid === 'site.standard.document' || nsid === 'pub.leaflet.document')
+        ? `/blogging/${encodeURIComponent(rkey)}`
+        : null;
+    },
     collections: [
       { nsid: 'site.standard.document', source: 'standard', kind: 'content', max: 100 },
       { nsid: 'site.standard.publication', source: 'standard', kind: 'content', max: 50 },


### PR DESCRIPTION
Four related fixes to the blog/creating experience and its admin editor.

## 1. Feed links go to the right page
The `blogging` verb had no `recordHref`, so home-feed rows (ledger layout + whole-row click) linked to the generic `/site.standard.document/{rkey}` explorer instead of the native reader. Added one that routes `site.standard.document` / `pub.leaflet.document` to `/blogging/{rkey}` (BlogPost.jsx matches `:id` as an rkey), while publications correctly fall through to the generic explorer. Mirrors `BlogCard`'s own `blogHref` logic. (`creating` already had a working `recordHref`.)

## 2. Blog summary under the title in the ledger
Ledger rows for blog posts showed only the title. They now render a muted summary/description line beneath it (`BlogLedgerBody`), matching what the cards layout already showed — clamped to two lines via a new `.ledger-subtext` style. Uses the `summary` feedBuilder already bakes (explicit summary, else a synopsis), falling back to `description`.

## 3. Per-block indent + top/bottom spacing (no more spacer blocks)
Blocks can now carry optional layout hints, set from a compact controls row under the active block in the editor:
- **`indent`** (text blocks only) — force a paragraph's first-line indent on/off, overriding the automatic book-style indent. Tri-state: Auto / Indented / Flush.
- **`spaceTop` / `spaceBottom`** (any block) — add extra margin above/below (Small/Medium/Large) so authors can open up space without inserting empty spacer blocks.

The renderer applies these as inline styles on each block's own root element, so they win over the stylesheet's adjacency rules (e.g. `margin-bottom: 0` on stacked paragraphs) without wrapping the block — wrapping would have broken the `.leaflet-paragraph + .leaflet-paragraph` selectors. Values live on the block and round-trip through the PDS; absent = today's behaviour, so existing docs are unchanged.

## 4. Bluesky comments field for new posts
Blog posts show a comments thread when the record carries a `commentsUri` (an `at://` URI to a Bluesky post whose replies become the comments). Only legacy migrated posts had it — the editor offered no way to set it. Added a `commentsUri` field to `site.standard.document` that accepts a **bsky.app URL, `at://` URI, or bare rkey** and normalizes to the canonical `at://{did}/app.bsky.feed.post/{rkey}` form, with a live hint showing what will be stored.

## Verification
- `vite build` compiles (3926 modules).
- Runtime-checked: `recordHrefFor('blogging', …)` → `/blogging/{rkey}` for docs and `/site.standard.document/{rkey}` for publications; the comments-URI normalizer across rkey / handle-URL / DID-URL / at-uri / garbage inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ybC17dEtcWWJsTmZLydiS

---
_Generated by [Claude Code](https://claude.ai/code/session_015ybC17dEtcWWJsTmZLydiS)_