### PR TITLE
Add dynamic OG card for the welcoming (guestbook) page

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -66,6 +66,7 @@ export const config = {
     '/mothing',
     '/mothing/:rkey',
     '/sharing',
+    '/welcoming',
   ],
 };
 

--- a/og/pageContent.js
+++ b/og/pageContent.js
@@ -20,10 +20,12 @@ const PDS_TIMEOUT_MS = 2500;
 
 // Top-level routes whose OG copy is backed by an is.dame.page/<rkey> record.
 // The URL and the record key can differ — /available is backed by the
-// is.dame.page/resume record. Add a route here to let it drive its own social
-// copy from the PDS; unlisted routes keep their static og/pages.js copy.
+// is.dame.page/resume record, and /welcoming by is.dame.page/guestbook. Add a
+// route here to let it drive its own social copy from the PDS; unlisted routes
+// keep their static og/pages.js copy.
 const PAGE_RKEY_FOR_PATH = {
   '/available': 'resume',
+  '/welcoming': 'guestbook',
 };
 
 /** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */

--- a/og/pages.js
+++ b/og/pages.js
@@ -88,6 +88,16 @@ export const PAGES = {
     desc: 'Moths at the light — observations logged from nights spent watching the dark.',
     nsid: 'is.dame.mothing.observation',
   },
+  // The guestbook presents as "Welcoming" (dame is welcoming) at /welcoming;
+  // its slug and records stay `guestbook`. Same URL/slug split as resume →
+  // "Available" at /available. The card's NSID chip names the visitor-written
+  // signatures the page lists (is.dame.guestbook.entry), not the book singleton.
+  '/welcoming': {
+    label: 'welcoming',
+    title: 'dame.is welcoming',
+    desc: 'Sign in with any atproto account and leave a note that you were here. Every signature lives on the signer’s own PDS and reaches this page as a backlink.',
+    nsid: 'is.dame.guestbook.entry',
+  },
   '/sharing': {
     label: 'sharing',
     title: 'dame.is sharing',


### PR DESCRIPTION
## Summary

`/welcoming` (the guestbook, which presents as "dame is welcoming") was the only top-level surface with **no** page-specific Open Graph card. It wasn't in the crawler matcher or in `og/pages.js`, so social crawlers fell through to the generic home card — no dynamic image.

This wires `/welcoming` into the same path the other pages use, mirroring the existing `/available → resume` URL/slug split. No new endpoint — the existing `/api/og` renderer already handles `?page=…`.

## Changes

- **`og/pages.js`** — add a `/welcoming` entry: label `welcoming`, title `dame.is welcoming`, the guestbook intro as the description, and `is.dame.guestbook.entry` as the NSID chip (the visitor signatures the page lists, not the book singleton).
- **`middleware.js`** — add `/welcoming` to the crawler matcher, so the SPA shell's `<head>` gets `og:image = /api/og?page=/welcoming` plus matching title/description/twitter tags.
- **`og/pageContent.js`** — map `/welcoming → is.dame.page/guestbook` so the card subtitle and crawler description track the editable PDS record rather than static copy (same as `/available → resume`).

## Verification

- `pageMeta('/welcoming')` resolves the new copy (no longer the DEFAULT home card).
- Rendered the card through `@vercel/og` → valid 1200×630 PNG showing the hour-tracking sky avatar, the `dame.is / welcoming` breadcrumb, the serif `welcoming` headline, the intro subtitle, the day-of-life folio, and the `is.dame.guestbook.entry` chip — visually consistent with the other page cards.
- Confirmed `middleware.js` and `api/og.js` import cleanly, and that `pageContentMeta('/welcoming')` resolves the live PDS record (copy is now PDS-editable) and degrades gracefully to the static default if the record is ever absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lquyms4HK6KxnqwtP9aaEb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lquyms4HK6KxnqwtP9aaEb)_