### PR TITLE
Resume: use name + repeated header in the print view

### DIFF
--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -12,6 +12,18 @@
   gap: var(--space-3);
 }
 
+/* Print-only pieces of the header, hidden on screen: the name that stands in
+   for the "Available" title on paper, and the identity block repeated above
+   the experience section on the printout's continuation page. Both are
+   switched on inside the @media print block at the foot of this file. */
+.resume-title-print {
+  display: none;
+}
+
+.resume-running-header {
+  display: none;
+}
+
 .resume-title {
   font-family: var(--serif);
   font-size: var(--text-3xl);
@@ -435,6 +447,28 @@ a.resume-work-link:hover .resume-work-title {
   .resume-org,
   .resume-role {
     break-inside: avoid;
+  }
+
+  /* On paper the résumé is a formal document, so the on-screen page title
+     ("Available") gives way to the name at the top of the sheet. */
+  .resume-title-live {
+    display: none;
+  }
+  .resume-title-print {
+    display: inline;
+  }
+
+  /* Start the experience on a fresh page so the first sheet reads as a cover
+     (name, headline, contact, summary), and repeat the identity block above it
+     so the continuation page carries the same header rather than opening cold
+     on the experience. `.resume-running-header` reuses `.resume-header`, so it
+     inherits the same layout; it's only revealed here in print. */
+  .resume-experience {
+    break-before: page;
+  }
+  .resume-running-header {
+    display: flex;
+    margin-bottom: var(--space-4);
   }
 
   /* Links read as plain black text — the on-screen underline hairline is a

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -23,6 +23,13 @@ import './Resume.css';
 
 const STANDARD_DOC = 'site.standard.document';
 
+// Printed, the résumé is a formal document, so the on-screen page title
+// ("Available") gives way to Dame's name — at the top of the first sheet and on
+// the identity block repeated above the experience section. Screen view keeps
+// the "Available" title; only the printout swaps in the name. See Resume.css
+// (.resume-title-print / .resume-running-header, @media print).
+const PRINT_NAME = 'Dame';
+
 /**
  * The x-ray annotation for a resume part — names the canonical record the
  * resume version backlinks (a job / education entry), so the mode reveals
@@ -169,6 +176,45 @@ function ResumeWorkLink({ item }) {
   );
 }
 
+/**
+ * The résumé's identity block — title, headline, and contact line. Rendered in
+ * the page header and again (print-only) above the experience section so a
+ * multi-page printout carries the name + contact onto the continuation sheet.
+ * On screen the title shows `screenTitle` ("Available"); in print it swaps to
+ * `printName` (see the .resume-title-live/-print rules in Resume.css).
+ */
+function ResumeIdentity({ screenTitle, printName, headline, contact }) {
+  return (
+    <>
+      <div>
+        <h1 className="resume-title">
+          <span className="resume-title-live">{screenTitle}</span>
+          <span className="resume-title-print">{printName}</span>
+        </h1>
+        {headline && <p className="resume-headline">{headline}</p>}
+      </div>
+
+      {contact && (
+        <ul className="resume-contact">
+          {contact.location && <li>{contact.location}</li>}
+          {contact.email && (
+            <li>
+              <a href={`mailto:${contact.email}`}>{contact.email}</a>
+            </li>
+          )}
+          {(contact.links || []).map((l) => (
+            <li key={l.url}>
+              <a href={l.url} target="_blank" rel="noreferrer noopener">
+                {l.label || l.url}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}
+
 export default function Resume() {
   const { slug } = useParams();
   const { title: pageTitle, intro: pageIntro } = usePageContent('resume');
@@ -238,28 +284,12 @@ export default function Resume() {
     >
       <article className="resume reveal">
         <header className="resume-header">
-          <div>
-            <h1 className="resume-title">{pageTitle || 'Available'}</h1>
-            {v.headline && <p className="resume-headline">{v.headline}</p>}
-          </div>
-
-          {contact && (
-            <ul className="resume-contact">
-              {contact.location && <li>{contact.location}</li>}
-              {contact.email && (
-                <li>
-                  <a href={`mailto:${contact.email}`}>{contact.email}</a>
-                </li>
-              )}
-              {(contact.links || []).map((l) => (
-                <li key={l.url}>
-                  <a href={l.url} target="_blank" rel="noreferrer noopener">
-                    {l.label || l.url}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
+          <ResumeIdentity
+            screenTitle={pageTitle || 'Available'}
+            printName={PRINT_NAME}
+            headline={v.headline}
+            contact={contact}
+          />
         </header>
 
         {summaryHtml && (
@@ -269,7 +299,18 @@ export default function Resume() {
         )}
 
         {resolved.experience.length > 0 && (
-          <section className="resume-section">
+          <section className="resume-section resume-experience">
+            {/* Print-only: repeat the identity block above the experience so a
+                multi-page printout carries the name + contact onto the second
+                sheet. Hidden on screen; see .resume-running-header in the CSS. */}
+            <header className="resume-header resume-running-header" aria-hidden="true">
+              <ResumeIdentity
+                screenTitle={pageTitle || 'Available'}
+                printName={PRINT_NAME}
+                headline={v.headline}
+                contact={contact}
+              />
+            </header>
             <h2 className="resume-section-title small-caps">Experience</h2>
             <div className="resume-orgs">
               {resolved.experience.map((org, oi) => (


### PR DESCRIPTION
The print button on `/available` triggers the browser's native print, so the printout is governed entirely by the `@media print` rules in `Resume.css`. This makes two changes to the printed résumé (screen view is unchanged):

- **Name instead of the page title.** In print, the "Available" title is swapped for the name ("Dame") at the top of the sheet. On screen it still reads "Available" — the two are spans in the `<h1>` toggled by `@media print`.
- **Repeated header above the experience.** The identity block (name, headline, location, email, links) repeats above the Experience section, and that section starts on a fresh page — so the first sheet reads as a cover (name → headline → contact → summary) and the continuation page opens with the same header above the roles rather than cold.

The header markup is factored into a shared `ResumeIdentity` component used by both the page header and the print-only repeated header.

### Verification
Rendered a faithful copy of the résumé (embedding the real `Resume.css`) through headless Chromium and inspected the actual print output:
- The print PDF paginates to a cover + continuation: page 1 shows the "Dame" title and no experience; page 2 opens with "Dame" again directly above the roles.
- The repeated header carries the full contact line (`United States · contact@dame.is · Website · Bluesky · LinkedIn`), not just the name.
- On-screen render is unchanged: title still "Available", no duplicate header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yhYrRDWUE8vFoXAaxoZg5

---
_Generated by [Claude Code](https://claude.ai/code/session_014yhYrRDWUE8vFoXAaxoZg5)_