### PR TITLE
Resume: continuous print flow — drop cover page + summary drop cap

### DIFF
--- a/src/pages/Resume.css
+++ b/src/pages/Resume.css
@@ -12,15 +12,9 @@
   gap: var(--space-3);
 }
 
-/* Print-only pieces of the header, hidden on screen: the name that stands in
-   for the "Available" title on paper, and the identity block repeated above
-   the experience section on the printout's continuation page. Both are
-   switched on inside the @media print block at the foot of this file. */
+/* The name that stands in for the "Available" title on paper — hidden on
+   screen, switched on inside the @media print block at the foot of this file. */
 .resume-title-print {
-  display: none;
-}
-
-.resume-running-header {
   display: none;
 }
 
@@ -442,11 +436,17 @@ a.resume-work-link:hover .resume-work-title {
     transform: none !important;
   }
 
-  /* Keep whole sections, tenures, and roles from splitting across breaks. */
-  .resume-section,
+  /* Keep each tenure and role together across a page break, but let the
+     top-level sections flow: break-inside:avoid on the whole experience section
+     (which is taller than a sheet) would shove it onto a fresh page — a
+     de-facto cover page — instead of letting it begin right after the summary
+     and run across sheets. A section title never sits stranded at a page foot. */
   .resume-org,
   .resume-role {
     break-inside: avoid;
+  }
+  .resume-section-title {
+    break-after: avoid;
   }
 
   /* On paper the résumé is a formal document, so the on-screen page title
@@ -458,17 +458,22 @@ a.resume-work-link:hover .resume-work-title {
     display: inline;
   }
 
-  /* Start the experience on a fresh page so the first sheet reads as a cover
-     (name, headline, contact, summary), and repeat the identity block above it
-     so the continuation page carries the same header rather than opening cold
-     on the experience. `.resume-running-header` reuses `.resume-header`, so it
-     inherits the same layout; it's only revealed here in print. */
-  .resume-experience {
-    break-before: page;
-  }
-  .resume-running-header {
-    display: flex;
-    margin-bottom: var(--space-4);
+  /* The summary is résumé prose, not long-form book text, so drop the
+     first-letter drop cap (applied globally to .blog-prose in typography.css)
+     for a plain opening paragraph on paper — the summary then reads straight
+     into the experience. Screen keeps the drop cap. The extra .resume-summary
+     scope outranks the global rule, and resetting `float` also neutralizes the
+     Firefox float fallback. */
+  .resume-summary .blog-prose > p:first-of-type::first-letter {
+    initial-letter: normal;
+    -webkit-initial-letter: normal;
+    float: none;
+    font-size: inherit;
+    line-height: inherit;
+    font-weight: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
   }
 
   /* Links read as plain black text — the on-screen underline hairline is a

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -24,10 +24,9 @@ import './Resume.css';
 const STANDARD_DOC = 'site.standard.document';
 
 // Printed, the résumé is a formal document, so the on-screen page title
-// ("Available") gives way to Dame's name — at the top of the first sheet and on
-// the identity block repeated above the experience section. Screen view keeps
-// the "Available" title; only the printout swaps in the name. See Resume.css
-// (.resume-title-print / .resume-running-header, @media print).
+// ("Available") gives way to Dame's name at the top of the sheet. Screen view
+// keeps the "Available" title; only the printout swaps in the name. See
+// Resume.css (.resume-title-print, @media print).
 const PRINT_NAME = 'Dame';
 
 /**
@@ -177,11 +176,9 @@ function ResumeWorkLink({ item }) {
 }
 
 /**
- * The résumé's identity block — title, headline, and contact line. Rendered in
- * the page header and again (print-only) above the experience section so a
- * multi-page printout carries the name + contact onto the continuation sheet.
- * On screen the title shows `screenTitle` ("Available"); in print it swaps to
- * `printName` (see the .resume-title-live/-print rules in Resume.css).
+ * The résumé's identity block — title, headline, and contact line. On screen
+ * the title shows `screenTitle` ("Available"); in print it swaps to `printName`
+ * (see the .resume-title-live / .resume-title-print rules in Resume.css).
  */
 function ResumeIdentity({ screenTitle, printName, headline, contact }) {
   return (
@@ -299,18 +296,7 @@ export default function Resume() {
         )}
 
         {resolved.experience.length > 0 && (
-          <section className="resume-section resume-experience">
-            {/* Print-only: repeat the identity block above the experience so a
-                multi-page printout carries the name + contact onto the second
-                sheet. Hidden on screen; see .resume-running-header in the CSS. */}
-            <header className="resume-header resume-running-header" aria-hidden="true">
-              <ResumeIdentity
-                screenTitle={pageTitle || 'Available'}
-                printName={PRINT_NAME}
-                headline={v.headline}
-                contact={contact}
-              />
-            </header>
+          <section className="resume-section">
             <h2 className="resume-section-title small-caps">Experience</h2>
             <div className="resume-orgs">
               {resolved.experience.map((org, oi) => (


### PR DESCRIPTION
Follow-up to the printed résumé work (#301). Simplifies the printout to a single continuous document instead of a cover sheet plus a repeated header. Screen view is unchanged.

- **No cover page / summary straight into experience.** Removes the forced page break before Experience and the print-only repeated header. The underlying cause of the cover-page effect was the pre-existing `break-inside: avoid` on the whole `.resume-section`: the experience section is taller than a sheet, so the browser was pushing it onto a fresh page. Now `break-inside: avoid` stays only on individual tenures/roles (no job splits mid-page) while the top-level sections flow, and section titles get `break-after: avoid` so a heading never strands at a page foot.
- **Drop cap removed in print only.** The summary's first-letter drop cap (applied globally to `.blog-prose` in `typography.css`) is neutralized in the printout; the on-screen résumé keeps it. Resetting `float` also covers the Firefox fallback.
- The name-for-title swap in the printout ("Available" → "Dame") is unchanged.

### Verification
Rendered a faithful copy of the résumé (embedding the real `typography.css` + `Resume.css`) through headless Chromium:
- Print PDF is now 2 pages (was 3): page 1 flows Dame → headline → contact → summary → Experience + roles continuously; no drop cap, no repeated header.
- On-screen render unchanged: title still "Available", drop cap intact, contact line present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yhYrRDWUE8vFoXAaxoZg5

---
_Generated by [Claude Code](https://claude.ai/code/session_014yhYrRDWUE8vFoXAaxoZg5)_