### PR TITLE
Comments engagement bar: match home-feed post-card stats (no icons)

### DIFF
--- a/src/components/Comments.css
+++ b/src/components/Comments.css
@@ -18,7 +18,7 @@
 .comments-engagement {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   gap: var(--space-2) var(--space-4);
   margin: 0 0 var(--space-4);
@@ -26,55 +26,32 @@
   border-bottom: 1px solid var(--rule-soft);
 }
 
+/* Plain " · "-separated tally, matching the engagement stats on the home-feed
+   post cards (.post-card-stats): mono, faint, no icons. */
 .engagement-stats {
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2) var(--space-4);
-  margin: 0;
-  padding: 0;
-}
-
-.engagement-stat {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--ink-muted);
-  font-size: var(--text-sm);
-  line-height: 1.2;
-}
-
-.engagement-stat svg {
+  font-family: var(--mono);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  line-height: var(--leading-tight);
   color: var(--ink-faint);
-  flex: 0 0 auto;
-}
-
-.engagement-count {
-  color: var(--ink);
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-}
-
-.engagement-label {
-  color: var(--ink-muted);
+  overflow-wrap: anywhere;
 }
 
 /* Rendered as a <button> (opens the waypoints picker), so it needs the usual
-   button resets before it can read as the site's dotted-underline text link. */
+   button resets before it can read as the site's dotted-underline text link.
+   Kept in the same mono scale as the stats so the row reads as one line. */
 .engagement-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
   margin: 0;
   padding: 0;
   background: none;
   border: 0;
   border-bottom: 1px dotted transparent;
   color: var(--ink-muted);
-  font-family: inherit;
-  font-size: var(--text-sm);
-  line-height: 1.2;
+  font-family: var(--mono);
+  font-size: calc(var(--text-xs) * var(--mono-scale));
+  letter-spacing: 0.02em;
+  line-height: var(--leading-tight);
   white-space: nowrap;
   text-decoration: none;
   cursor: pointer;
@@ -84,10 +61,6 @@
 .engagement-link:focus-visible {
   color: var(--ink);
   border-bottom-color: var(--accent-soft);
-}
-
-.engagement-link svg {
-  flex: 0 0 auto;
 }
 
 .comments-tree {

--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -1,4 +1,3 @@
-import { Heart, Repeat2, Quote, MessageCircle, ArrowUpRight } from 'lucide-react';
 import { relativeTime } from '../lib/time.js';
 import { ME_DID } from '../config.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
@@ -49,14 +48,16 @@ export default function Comments({
 }
 
 /**
- * Engagement summary for the Bluesky post that hosts this thread — the four
- * tallies (likes, reposts, quotes, replies) plus a "Reply" action. Rendered
+ * Engagement summary for the Bluesky post that hosts this thread — the
+ * tallies (replies, reposts, quotes, likes) plus a "Reply" action. Rendered
  * above the replies when the parent supplies `metrics`; omitted otherwise
  * (e.g. the record page, which shows the post's own stats in its card).
  *
- * "Reply" opens the shared waypoints ("Open in…") picker for the thread's
- * `at://` URI, so a reader can jump to the post in whichever Atmosphere client
- * they actually use and reply there — rather than being forced onto bsky.app.
+ * The tallies are a plain " · "-separated text line, matching the engagement
+ * stats on the home-feed post cards (no icons). "Reply" opens the shared
+ * waypoints ("Open in…") picker for the thread's `at://` URI, so a reader can
+ * jump to the post in whichever Atmosphere client they use and reply there —
+ * rather than being forced onto bsky.app.
  */
 function EngagementBar({ metrics, atUri }) {
   const { openWaypoints } = useWaypointsModal();
@@ -65,39 +66,25 @@ function EngagementBar({ metrics, atUri }) {
   // line, and keeps a lightly-engaged post from reading as a wall of zeros. A
   // post with no engagement yet collapses to just the "Reply" nudge.
   const stats = [
-    { key: 'like', Icon: Heart, count: likeCount, one: 'like', many: 'likes' },
-    { key: 'repost', Icon: Repeat2, count: repostCount, one: 'repost', many: 'reposts' },
-    { key: 'quote', Icon: Quote, count: quoteCount, one: 'quote', many: 'quotes' },
-    { key: 'reply', Icon: MessageCircle, count: replyCount, one: 'reply', many: 'replies' },
-  ].filter((s) => s.count > 0);
+    replyCount ? `${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}` : null,
+    repostCount ? `${repostCount} ${repostCount === 1 ? 'repost' : 'reposts'}` : null,
+    quoteCount ? `${quoteCount} ${quoteCount === 1 ? 'quote' : 'quotes'}` : null,
+    likeCount ? `${likeCount} ${likeCount === 1 ? 'like' : 'likes'}` : null,
+  ].filter(Boolean);
   const canReply = typeof atUri === 'string' && atUri.startsWith('at://');
   if (stats.length === 0 && !canReply) return null;
   return (
     <div className="comments-engagement">
-      <ul className="engagement-stats">
-        {stats.map(({ key, Icon, count, one, many }) => {
-          const label = count === 1 ? one : many;
-          return (
-            <li
-              key={key}
-              className="engagement-stat"
-              title={`${count.toLocaleString()} ${label}`}
-            >
-              <Icon size={15} strokeWidth={1.75} aria-hidden="true" />
-              <span className="engagement-count">{count.toLocaleString()}</span>
-              <span className="engagement-label">{label}</span>
-            </li>
-          );
-        })}
-      </ul>
+      {stats.length > 0 && (
+        <span className="engagement-stats">{stats.join(' · ')}</span>
+      )}
       {canReply && (
         <button
           type="button"
           className="engagement-link"
           onClick={() => openWaypoints(atUri)}
         >
-          <span>Reply</span>
-          <ArrowUpRight size={14} strokeWidth={1.75} aria-hidden="true" />
+          Reply
         </button>
       )}
     </div>


### PR DESCRIPTION
Follow-up to #303. Renders the blog comments engagement tallies as a plain text line, matching the engagement stats on the home-feed post cards, instead of icon + count rows.

## Change

- The tallies are now a `" · "`-separated text line — `7 replies · 2 reposts · 1 quote · 40 likes` — using the same treatment as `.post-card-stats` on the home feed: `--mono` voice, faint color, raw numbers. It folds into whatever font mode / theme is active, identically to the feed cards.
- Order matches the post cards (replies → reposts → quotes → likes); zero counts stay hidden.
- Dropped **all** icons, including the arrow on the **"Reply"** action. "Reply" is now plain text and still opens the shared waypoints ("Open in…") picker for the thread's `at://` URI.
- Removed the now-unused `lucide-react` imports.

## Verification

Drove the real page in headless Chromium (light + dark) against captured live data: stats render as `7 replies · 2 reposts · 1 quote · 40 likes` with no icons in the bar, and "Reply" still opens the picker (Bluesky, Anisota, Red Dwarf, Aturi Explore). Production build passes.

## Files

- `src/components/Comments.jsx` — text tally + icon-free "Reply"; dropped lucide imports.
- `src/components/Comments.css` — `.engagement-stats` now mirrors `.post-card-stats`; removed the icon/row styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m2PMensNHxhMNNv5CuH9j

---
_Generated by [Claude Code](https://claude.ai/code/session_014m2PMensNHxhMNNv5CuH9j)_