### PR TITLE
Guestbook: auto-hide signatures that trip a language filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^1.14.0",
         "marked": "^14.1.3",
         "motion": "^12.38.0",
+        "obscenity": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0"
@@ -3162,6 +3163,15 @@
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obscenity": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/obscenity/-/obscenity-0.4.6.tgz",
+      "integrity": "sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/pako": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^1.14.0",
     "marked": "^14.1.3",
     "motion": "^12.38.0",
+    "obscenity": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0"

--- a/src/components/GuestbookEntryRow.jsx
+++ b/src/components/GuestbookEntryRow.jsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Fingerprint, MapPinned } from 'lucide-react';
 import { explorerPathFromAtUri } from '../lib/atproto.js';
-import { censorProfanity } from '../lib/profanity.js';
 import { relativeTime } from '../lib/time.js';
 import { useXray } from '../hooks/useXray.jsx';
 import { XrayTag, XraySubstratePanel } from './XraySubstrate.jsx';
@@ -29,12 +28,8 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
   // decentralization visible. entry.uri already points at it (a foreign repo).
   const inspectable = xray.active && !!entry.uri;
   const focused = inspectable && xray.focusUri === entry.uri;
-  // The signer authored `signature`, `text`, and `location` for this book, so
-  // those are masked for offensive words as they render (the record on the
-  // signer's PDS is untouched — see src/lib/profanity.js). Profile-derived
-  // names/handles are left to Bluesky's own moderation.
   const name =
-    censorProfanity(value.signature?.trim()) ||
+    value.signature?.trim() ||
     profile?.displayName?.trim() ||
     (profile?.handle && profile.handle !== 'handle.invalid' ? `@${profile.handle}` : null) ||
     shortDid(entry.did);
@@ -47,7 +42,9 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
   // rendering an empty permalink.
   const when = relativeTime(value.createdAt);
   const hasControls = mine || moderating;
-  const noteText = censorProfanity(value.text);
+  // Flagged by the language filter (or on the host's hidden list): benched from
+  // the public view. Both only ever render here in moderation, dimmed.
+  const suppressed = entry.hidden || entry.flagged;
 
   async function remove() {
     if (removing) return;
@@ -75,7 +72,7 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
 
   return (
     <li
-      className={`guestbook-entry${entry.hidden ? ' guestbook-entry-is-hidden' : ''}${focused ? ' is-xray-focus' : ''}`}
+      className={`guestbook-entry${suppressed ? ' guestbook-entry-is-hidden' : ''}${focused ? ' is-xray-focus' : ''}`}
       data-nsid={entry.collection || undefined}
       data-atproto={entry.uri ? '' : undefined}
       data-at-uri={entry.uri || undefined}
@@ -116,9 +113,9 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
           )}
         </header>
 
-        {noteText ? (
+        {value.text ? (
           <p className="guestbook-entry-text">
-            {noteText}
+            {value.text}
             {value.mark && <span className="guestbook-entry-inline-mark"> {value.mark}</span>}
           </p>
         ) : value.mark ? (
@@ -141,13 +138,21 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
             {value.location && (
               <span className="guestbook-entry-location gutter">
                 <MapPinned size={12} strokeWidth={1.75} aria-hidden="true" />
-                {censorProfanity(value.location)}
+                {value.location}
               </span>
             )}
             {hasControls && (
               <div className="guestbook-entry-controls">
                 {entry.hidden && moderating && (
                   <span className="guestbook-entry-hidden-badge small-caps">hidden</span>
+                )}
+                {entry.flagged && !entry.hidden && moderating && (
+                  <span
+                    className="guestbook-entry-flagged-badge small-caps"
+                    title="Auto-hidden from public display: flagged by the language filter"
+                  >
+                    auto-hidden
+                  </span>
                 )}
                 {mine && (
                   <button

--- a/src/components/GuestbookEntryRow.jsx
+++ b/src/components/GuestbookEntryRow.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Fingerprint, MapPinned } from 'lucide-react';
 import { explorerPathFromAtUri } from '../lib/atproto.js';
+import { censorProfanity } from '../lib/profanity.js';
 import { relativeTime } from '../lib/time.js';
 import { useXray } from '../hooks/useXray.jsx';
 import { XrayTag, XraySubstratePanel } from './XraySubstrate.jsx';
@@ -28,8 +29,12 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
   // decentralization visible. entry.uri already points at it (a foreign repo).
   const inspectable = xray.active && !!entry.uri;
   const focused = inspectable && xray.focusUri === entry.uri;
+  // The signer authored `signature`, `text`, and `location` for this book, so
+  // those are masked for offensive words as they render (the record on the
+  // signer's PDS is untouched — see src/lib/profanity.js). Profile-derived
+  // names/handles are left to Bluesky's own moderation.
   const name =
-    value.signature?.trim() ||
+    censorProfanity(value.signature?.trim()) ||
     profile?.displayName?.trim() ||
     (profile?.handle && profile.handle !== 'handle.invalid' ? `@${profile.handle}` : null) ||
     shortDid(entry.did);
@@ -42,6 +47,7 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
   // rendering an empty permalink.
   const when = relativeTime(value.createdAt);
   const hasControls = mine || moderating;
+  const noteText = censorProfanity(value.text);
 
   async function remove() {
     if (removing) return;
@@ -110,9 +116,9 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
           )}
         </header>
 
-        {value.text ? (
+        {noteText ? (
           <p className="guestbook-entry-text">
-            {value.text}
+            {noteText}
             {value.mark && <span className="guestbook-entry-inline-mark"> {value.mark}</span>}
           </p>
         ) : value.mark ? (
@@ -135,7 +141,7 @@ export default function GuestbookEntryRow({ entry, mine, onRemove, moderating, o
             {value.location && (
               <span className="guestbook-entry-location gutter">
                 <MapPinned size={12} strokeWidth={1.75} aria-hidden="true" />
-                {value.location}
+                {censorProfanity(value.location)}
               </span>
             )}
             {hasControls && (

--- a/src/components/GuestbookModerationPanel.jsx
+++ b/src/components/GuestbookModerationPanel.jsx
@@ -19,6 +19,7 @@ export default function GuestbookModerationPanel({ agent }) {
   const [entries, setEntries] = useState(null);
   const [total, setTotal] = useState(null);
   const [hiddenCount, setHiddenCount] = useState(0);
+  const [flaggedCount, setFlaggedCount] = useState(0);
   const [book, setBook] = useState(null);
   const [cursor, setCursor] = useState(null);
   const [status, setStatus] = useState('loading'); // loading | ready | error
@@ -34,6 +35,7 @@ export default function GuestbookModerationPanel({ agent }) {
     setEntries(page.entries);
     setTotal(page.total);
     setHiddenCount(page.hiddenCount || 0);
+    setFlaggedCount(page.flaggedCount || 0);
     setBook(page.book);
     setCursor(page.cursor);
     setStatus('ready');
@@ -50,6 +52,7 @@ export default function GuestbookModerationPanel({ agent }) {
     if (page) {
       setEntries((prev) => [...(prev || []), ...page.entries]);
       setCursor(page.cursor);
+      setFlaggedCount((c) => c + (page.flaggedCount || 0));
     }
     setLoadingMore(false);
   }
@@ -60,11 +63,15 @@ export default function GuestbookModerationPanel({ agent }) {
       (prev || []).map((e) => (e.uri === entry.uri ? { ...e, hidden: hide } : e)),
     );
     setHiddenCount((c) => Math.max(0, c + (hide ? 1 : -1)));
+    // A flagged entry is already counted as auto-hidden; moving it onto (or off)
+    // the manual list shifts it between the tallies so `publicCount` stays right.
+    if (entry.flagged) setFlaggedCount((c) => Math.max(0, c + (hide ? -1 : 1)));
     // A hide can auto-create the book record; reflect that without refetching.
     setBook((b) => b || { created: true });
   }
 
-  const publicCount = typeof total === 'number' ? Math.max(0, total - hiddenCount) : null;
+  const publicCount =
+    typeof total === 'number' ? Math.max(0, total - hiddenCount - flaggedCount) : null;
 
   return (
     <PageShell
@@ -99,9 +106,11 @@ export default function GuestbookModerationPanel({ agent }) {
           {typeof total === 'number'
             ? `${total.toLocaleString()} ${total === 1 ? 'signature' : 'signatures'}`
             : 'Signatures'}
-          {hiddenCount > 0 && (
+          {(hiddenCount > 0 || flaggedCount > 0) && (
             <span className="guestbook-hidden-count">
-              {' '}· {hiddenCount} hidden · {publicCount} public
+              {hiddenCount > 0 && <> · {hiddenCount} hidden</>}
+              {flaggedCount > 0 && <> · {flaggedCount} auto-hidden</>}
+              {' '}· {publicCount} public
             </span>
           )}
         </h2>

--- a/src/lib/guestbook.js
+++ b/src/lib/guestbook.js
@@ -12,6 +12,7 @@
 
 import { getBacklinks, getBacklinkCount } from './constellation.js';
 import { getRecordCached } from './slingshot.js';
+import { hasProfanity } from './profanity.js';
 import { resolvePds, getRecord, toAtUri, tidToTimestamp } from './atproto.js';
 import { compareIsoDesc } from './time.js';
 import {
@@ -69,15 +70,18 @@ export async function fetchGuestbookBook() {
  * chronological — no cross-source interleaving is needed. The compound `cursor`
  * that threads this two-phase walk is opaque to callers (they pass it back).
  *
- * Returns `{ total, publicTotal, hiddenCount, cursor, entries, book }` where
- * each entry is `{ uri, cid, did, rkey, collection, legacy, value, profile, hidden }`,
+ * Returns `{ total, publicTotal, hiddenCount, flaggedCount, cursor, entries, book }`
+ * where each entry is
+ * `{ uri, cid, did, rkey, collection, legacy, value, profile, hidden, flagged }`,
  * newest first. `value` is normalized so both record shapes render through one
  * row (a legacy `message` surfaces as `text`, and a missing `createdAt` is
  * recovered from the TID rkey where possible). `hidden` reflects the book's
  * moderation list — which may name legacy at-uris too, so hiding spans both
- * books. Returns `null` only when the backlink index is unreachable with
- * nothing to show; individual records that can't be hydrated are dropped from
- * the page rather than failing it.
+ * books. `flagged` marks a signature the language filter auto-hides from public
+ * display (see src/lib/profanity.js); `flaggedCount` is how many on this page
+ * (excluding ones already hidden). Returns `null` only when the backlink index
+ * is unreachable with nothing to show; individual records that can't be
+ * hydrated are dropped from the page rather than failing it.
  */
 export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, cursor } = {}) {
   const state = decodeGuestbookCursor(cursor);
@@ -148,13 +152,21 @@ export async function fetchGuestbookEntries({ limit = GUESTBOOK_PAGE_SIZE, curso
 
 /** Assemble the public return shape shared by every page and phase. */
 function finalizePage({ entries, total, hiddenUris, book, cursor }) {
+  // Signatures the language filter auto-hides on THIS page (that aren't already
+  // on the manual hidden list, so the two counts don't overlap). Unlike the
+  // manual list — known in full from the book record — flagged entries surface
+  // one page at a time as records hydrate, so a caller's running tally is exact
+  // only once every page has loaded. Same best-effort spirit as the
+  // hidden-but-deleted approximation below.
+  const flaggedCount = entries.reduce((n, e) => n + (e.flagged && !e.hidden ? 1 : 0), 0);
   return {
     total,
     // Approximate when a hidden record has since been deleted by its signer
     // (the backlink drops out of `total` but its uri lingers in the list);
     // close enough for a count caption.
-    publicTotal: total != null ? Math.max(0, total - hiddenUris.size) : null,
+    publicTotal: total != null ? Math.max(0, total - hiddenUris.size - flaggedCount) : null,
     hiddenCount: hiddenUris.size,
+    flaggedCount,
     cursor: cursor || null,
     entries,
     book,
@@ -181,10 +193,28 @@ async function fetchLegacyEntries(hiddenUris) {
  */
 async function hydrateEntries(refs, hydrate, hiddenUris) {
   const hydrated = (await Promise.all(refs.map(hydrate))).filter(Boolean);
-  for (const entry of hydrated) entry.hidden = hiddenUris.has(entry.uri);
+  for (const entry of hydrated) {
+    entry.hidden = hiddenUris.has(entry.uri); // host-curated hidden list
+    entry.flagged = entryHasProfanity(entry.value); // language filter
+  }
   const profiles = await fetchProfiles(hydrated.map((e) => e.did));
   for (const entry of hydrated) entry.profile = profiles.get(entry.did) || null;
   return hydrated;
+}
+
+/**
+ * Whether any of the signer's own free-text fields (the note, the sign-as
+ * name, the "signing from" location) trips the language filter. This drives
+ * the read-time auto-hide: a flagged signature is curated out of the public
+ * view exactly like one on the book's `hidden` list — but computed per render
+ * rather than written to the book, so it needs no host write and covers even
+ * records authored straight to a PDS. See src/lib/profanity.js.
+ */
+function entryHasProfanity(value) {
+  if (!value) return false;
+  return (
+    hasProfanity(value.text) || hasProfanity(value.signature) || hasProfanity(value.location)
+  );
 }
 
 /**

--- a/src/lib/profanity.js
+++ b/src/lib/profanity.js
@@ -1,0 +1,59 @@
+// Display-time profanity masking for user-authored guestbook text.
+//
+// The guestbook has no database we control — every signature is a record on
+// the SIGNER's own PDS, assembled at read time (see src/lib/guestbook.js). We
+// can't edit anyone's words; we can only choose how to render them. So this
+// masks slurs and profanity as text is displayed, leaving the record itself
+// untouched. It's the same posture as the book's `hidden` list, one notch
+// finer: `hidden` tucks away a whole signature, this blanks just the offending
+// word and keeps the rest of the note readable.
+//
+// Built on `obscenity`, whose English dataset is word-boundary aware (so
+// "Scunthorpe", "classic", and "assassin" pass through clean) and
+// obfuscation-resistant (so "sh!t" and light leetspeak don't slip past). The
+// matcher is a little expensive to assemble, so it's built once, lazily, on
+// first use.
+
+import {
+  RegExpMatcher,
+  TextCensor,
+  asteriskCensorStrategy,
+  englishDataset,
+  englishRecommendedTransformers,
+} from 'obscenity';
+
+let filter = null; // { matcher, censor }, built on first use
+
+function ensureFilter() {
+  if (!filter) {
+    const matcher = new RegExpMatcher({
+      ...englishDataset.build(),
+      ...englishRecommendedTransformers,
+    });
+    // Blank each matched region with asterisks of the same width — reads as a
+    // deliberate redaction without leaking the word's shape.
+    const censor = new TextCensor().setStrategy(asteriskCensorStrategy());
+    filter = { matcher, censor };
+  }
+  return filter;
+}
+
+/**
+ * Mask any profanity/slurs in `text`, returning a display-safe string. Clean
+ * text — and any non-string — comes back untouched, so this is safe to wrap
+ * around every rendered field. Only the offending word is blanked ("you're a
+ * ****"), so a note that merely contains one bad word stays otherwise readable.
+ */
+export function censorProfanity(text) {
+  if (typeof text !== 'string' || text === '') return text;
+  const { matcher, censor } = ensureFilter();
+  const matches = matcher.getAllMatches(text);
+  if (matches.length === 0) return text;
+  return censor.applyTo(text, matches);
+}
+
+/** True when `text` contains anything the filter would mask. */
+export function hasProfanity(text) {
+  if (typeof text !== 'string' || text === '') return false;
+  return ensureFilter().matcher.hasMatch(text);
+}

--- a/src/lib/profanity.js
+++ b/src/lib/profanity.js
@@ -1,12 +1,13 @@
-// Display-time profanity masking for user-authored guestbook text.
+// Profanity/slur detection (and masking) for user-authored guestbook text.
 //
 // The guestbook has no database we control — every signature is a record on
 // the SIGNER's own PDS, assembled at read time (see src/lib/guestbook.js). We
-// can't edit anyone's words; we can only choose how to render them. So this
-// masks slurs and profanity as text is displayed, leaving the record itself
-// untouched. It's the same posture as the book's `hidden` list, one notch
-// finer: `hidden` tucks away a whole signature, this blanks just the offending
-// word and keeps the rest of the note readable.
+// can't edit anyone's words; we can only choose how to render them. The read
+// path uses `hasProfanity` to auto-hide a whole signature from public display
+// when it trips the filter — the same posture as the book's host-curated
+// `hidden` list, just computed per-render instead of written to the book.
+// `censorProfanity` (blank the offending word, keep the rest) is kept for a
+// finer touch — e.g. a heads-up in the sign form before publishing.
 //
 // Built on `obscenity`, whose English dataset is word-boundary aware (so
 // "Scunthorpe", "classic", and "assassin" pass through clean) and

--- a/src/pages/Guestbook.css
+++ b/src/pages/Guestbook.css
@@ -326,6 +326,18 @@
   padding: 0 var(--space-2);
 }
 
+/* Auto-hidden by the language filter (vs the host's manual hidden list) —
+   same benched treatment, a quieter neutral badge so the reason is legible. */
+.guestbook-entry-flagged-badge {
+  font-family: var(--sans);
+  letter-spacing: 0.14em;
+  font-size: var(--text-xs);
+  color: var(--ink-muted);
+  border: 1px solid color-mix(in srgb, var(--ink-muted) 40%, transparent);
+  border-radius: var(--radius-2);
+  padding: 0 var(--space-2);
+}
+
 .guestbook-entry-moderate {
   font-family: var(--sans);
   font-variant: all-small-caps;

--- a/src/pages/Guestbook.jsx
+++ b/src/pages/Guestbook.jsx
@@ -40,6 +40,7 @@ export default function Guestbook() {
   const [entries, setEntries] = useState(null);
   const [total, setTotal] = useState(null);
   const [hiddenCount, setHiddenCount] = useState(0);
+  const [flaggedCount, setFlaggedCount] = useState(0);
   const [cursor, setCursor] = useState(null);
   const [status, setStatus] = useState('loading'); // loading | ready | error
   const [loadingMore, setLoadingMore] = useState(false);
@@ -54,6 +55,7 @@ export default function Guestbook() {
     setEntries(page.entries);
     setTotal(page.total);
     setHiddenCount(page.hiddenCount || 0);
+    setFlaggedCount(page.flaggedCount || 0);
     setCursor(page.cursor);
     setStatus('ready');
   }, []);
@@ -70,6 +72,8 @@ export default function Guestbook() {
       setEntries((prev) => [...(prev || []), ...page.entries]);
       setCursor(page.cursor);
       if (page.total != null) setTotal(page.total);
+      // Flagged entries surface page by page; add this page's to the tally.
+      setFlaggedCount((c) => c + (page.flaggedCount || 0));
     }
     setLoadingMore(false);
   }
@@ -116,12 +120,23 @@ export default function Guestbook() {
       (prev || []).map((e) => (e.uri === entry.uri ? { ...e, hidden: hide } : e)),
     );
     setHiddenCount((c) => Math.max(0, c + (hide ? 1 : -1)));
+    // A flagged entry is already counted as auto-hidden; when the host promotes
+    // it to (or releases it from) the manual list, move it between the tallies
+    // so the public count doesn't subtract the same signature twice.
+    if (entry.flagged) setFlaggedCount((c) => Math.max(0, c + (hide ? -1 : 1)));
   }
 
-  // The public page renders the curated book; moderation sees everything.
-  const visible = entries ? (moderating ? entries : entries.filter((e) => !e.hidden)) : null;
+  // The public page renders the curated book — signatures the host hid AND ones
+  // the language filter flagged are tucked away; moderation sees everything.
+  const visible = entries
+    ? moderating
+      ? entries
+      : entries.filter((e) => !e.hidden && !e.flagged)
+    : null;
   const count =
-    typeof total === 'number' ? Math.max(0, total - hiddenCount) : visible?.length ?? null;
+    typeof total === 'number'
+      ? Math.max(0, total - hiddenCount - flaggedCount)
+      : visible?.length ?? null;
 
   return (
     <PageShell
@@ -150,11 +165,16 @@ export default function Guestbook() {
           {moderating && hiddenCount > 0 && (
             <span className="guestbook-hidden-count"> · {hiddenCount} hidden</span>
           )}
+          {moderating && flaggedCount > 0 && (
+            <span className="guestbook-hidden-count"> · {flaggedCount} auto-hidden</span>
+          )}
         </h2>
         {moderating && (
           <p className="guestbook-moderation-note">
             Edit mode: hiding tucks a signature out of public display by listing it on the
-            book record. The signer's own record is untouched.
+            book record. The signer's own record is untouched. Entries badged{' '}
+            <span className="small-caps">auto-hidden</span> tripped the language filter and are
+            already kept from public view; hide one to record it on the book too.
           </p>
         )}
         {status === 'loading' ? (


### PR DESCRIPTION
Adds an offensive-language filter to the guestbook so slurs and profanity don't appear on `/welcoming`.

## What

- New `src/lib/profanity.js` — a small wrapper over [`obscenity`](https://github.com/jo3-l/obscenity) exposing `hasProfanity` / `censorProfanity` (matcher built once, lazily).
- The read layer (`src/lib/guestbook.js`) computes a `flagged` bit per signature — profanity in the note, the sign-as name, or the "signing from" location — right beside the existing host-curated `hidden` bit, and reports a per-page `flaggedCount`.
- The public page (`/welcoming`) and the admin moderation panel drop flagged signatures and subtract them from the signature count. When you're moderating, they still show — dimmed, badged **auto-hidden** — with the usual hide control to promote one onto the book record permanently. Hiding/unhiding a flagged entry moves it between the tallies so the public count never subtracts it twice.

## Why this shape

Every signature is a record on the signer's own PDS, assembled at read time, so — like the `hidden` list — this is a render-time curation decision, not an edit to anyone's record. Computing `flagged` per render (rather than writing flagged at-uris onto the book) needs no host write, applies instantly for every viewer, and covers records authored straight to a PDS, not only ones made through the sign form.

`obscenity` was chosen for its low false-positive rate: its English dataset is word-boundary aware ("Scunthorpe", "classic", "assassin" pass clean) and obfuscation-resistant ("sh!t" and light leetspeak don't slip past).

## Notes / tradeoffs

- Hiding the whole entry is more aggressive than masking words: a false positive removes the signature rather than a word. `obscenity`'s false-positive rate is low, and a one-line whitelist in `profanity.js` handles any stray term.
- `censorProfanity` (word-level masking) is kept in the module for a future lighter touch — e.g. a heads-up in the sign form before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmMnu6gBKzhjmn8agmFBKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmMnu6gBKzhjmn8agmFBKR)_