### PR TITLE
Fix intermittent white-screen from stale SPA shell after deploy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,44 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      Boot recovery for the stale-shell white-screen.
+
+      Every deploy content-hashes this page's entry module
+      (/assets/index-<hash>.js) and deletes the previous hash. If a visitor is
+      ever handed an HTML shell from an older build — a CDN- or edge-cached copy
+      that outlived the deploy — the module it references is gone. Vercel serves
+      that 404 as text/plain, the browser refuses to run it as a module
+      ("blocked because of a disallowed MIME type"), and the page stays blank
+      forever: React never mounts, so the in-app auto-updater
+      (src/hooks/useAutoUpdate.js) never gets a chance to help.
+
+      This inline script runs regardless of the module. It catches the failed
+      load and reloads once against a cache-busted URL — a fresh key misses any
+      cached shell and re-fetches HTML that points at the current build. The
+      "_r" param in the URL is itself the loop guard (present ⇒ we already
+      retried), so a genuine outage can never loop and no storage is needed. A
+      successful boot strips the param (see src/main.jsx).
+    -->
+    <script>
+      (function () {
+        window.addEventListener(
+          'error',
+          function (e) {
+            // Only the entry module failing to load blanks the page. Ignore
+            // everything else (images, fonts, inline scripts, CSS links).
+            var t = e && e.target;
+            if (!t || t.tagName !== 'SCRIPT') return;
+            if (String(t.src || '').indexOf('/assets/') === -1) return;
+            var u = new URL(window.location.href);
+            if (u.searchParams.has('_r')) return; // already retried — don't loop
+            u.searchParams.set('_r', Date.now().toString(36));
+            window.location.replace(u.toString());
+          },
+          true, // capture: resource load errors don't bubble
+        );
+      })();
+    </script>
     <!-- Icons rotate hourly to match Dame's sun-tracking avatar (see api/favicon.js).
          The larger sizes + web manifest (api/manifest.js) make the site installable
          as a PWA with the current-hour sky avatar as its app icon. -->

--- a/middleware.js
+++ b/middleware.js
@@ -207,9 +207,12 @@ export default async function middleware(request) {
     }
 
     // Pull the built SPA shell. The matcher never matches /index.html, so this
-    // subrequest can't loop back through the middleware.
+    // subrequest can't loop back through the middleware. Read it fresh
+    // (no-store) so a revalidated response always embeds the CURRENT
+    // deployment's content-hashed entry asset — never a stale/deleted hash.
     const shellRes = await fetch(new URL('/index.html', url.origin), {
       headers: { 'x-og-shell': '1' },
+      cache: 'no-store',
     });
     if (!shellRes.ok) return undefined; // fall through to normal serving
     let html = await shellRes.text();
@@ -238,9 +241,17 @@ export default async function middleware(request) {
       status: 200,
       headers: {
         'content-type': 'text/html; charset=utf-8',
-        // Cache the rendered shell at the edge; it only changes when the build
-        // or the page copy changes.
-        'cache-control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
+        // Edge-cache the rendered shell briefly to keep middleware cost down —
+        // but NEVER serve it stale. The shell embeds the build's content-hashed
+        // entry asset (/assets/index-<hash>.js), and every deploy rotates that
+        // hash and deletes the old file. A shell cached across a deploy points
+        // at a now-404 asset that Vercel serves as text/plain, which the
+        // browser refuses to run as a module — blanking the page. So: a short
+        // s-maxage that revalidates promptly onto the new build, and NO
+        // stale-while-revalidate (its 24h stale-serve was the crash window).
+        // The inline boot-recovery in index.html covers the brief post-deploy
+        // sliver where a still-fresh shell can be served.
+        'cache-control': 'public, max-age=0, s-maxage=60',
       },
     });
   } catch {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,20 @@ import './styles/typography.css';
 import './styles/app.css';
 import './styles/paper.css';
 
+// We're running, so the entry module loaded — the boot-recovery reload in
+// index.html (if it fired) succeeded. Strip its one-shot "_r" cache-bust param
+// before React mounts, so the router only ever sees the clean URL and a future
+// deploy's stale shell can trigger a fresh recovery.
+try {
+  const url = new URL(window.location.href);
+  if (url.searchParams.has('_r')) {
+    url.searchParams.delete('_r');
+    window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+  }
+} catch {
+  /* URL/history unavailable — nothing to clean up */
+}
+
 // The site runs a single, always-on theme: the hour-tracking sky mode.
 // Set it here (before React mounts) so the first paint is in the right
 // palette. The retired static light/dark themes are no longer selectable.


### PR DESCRIPTION
## Problem

Opening a middleware-rendered route (`/welcoming`, `/themself`, `/blogging`, …) would **sometimes crash to a white screen** with:

> Loading module from `…/assets/index-<hash>.js` was blocked because of a disallowed MIME type ("text/plain").

**Root cause — a caching race with Vercel's immutable deploys** (confirmed against the live site):

1. Those routes edge-cache their rendered HTML shell with `stale-while-revalidate=86400`, so a shell can be served up to ~25h after it was generated.
2. The shell hard-codes the build's content-hashed entry module (`/assets/index-<hash>.js`). Every deploy rotates that hash and **deletes** the old file.
3. A shell served across a deploy points at the now-deleted asset. Vercel returns that 404 as `content-type: text/plain`, the browser refuses to execute a module served as `text/plain`, and the page stays blank — React never mounts, so `useAutoUpdate.js` never gets a chance to reload.

This only affected middleware routes (the static `/` uses a safe `must-revalidate` policy), and only in the window after a code deploy — hence "sometimes".

## Fix (defense in depth)

- **`middleware.js`** — drop `stale-while-revalidate` (the ~24h stale-serve window) and shorten the edge cache to `s-maxage=60`, so a shell revalidates promptly onto the current build; fetch `index.html` with `no-store` so a revalidated shell always embeds the live asset hash.
- **`index.html`** — an inline boot-recovery script (runs even when the module can't) catches the failed entry-module load and reloads **once** against a cache-busted URL, which misses any cached shell and re-fetches HTML pointing at the current build. The `?_r=` param doubles as the loop guard, so a genuine outage can't loop and no storage is needed.
- **`src/main.jsx`** — strip the one-shot `?_r=` param on successful boot so the router only sees a clean URL and a future stale shell can recover again.

## Verification

Drove real Chromium against a server reproducing the exact failure (module → `404 text/plain`):

- **Recovery**: dead module → one cache-busted reload → boots on the fresh shell → URL cleaned back to `/welcoming`.
- **No-loop safety**: permanently-dead module → exactly one recovery attempt, then stops.

`npm run build:offline` succeeds and the recovery script is emitted intact in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ACXJCSgsGdgdhDBrC4aMN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ACXJCSgsGdgdhDBrC4aMN)_