### PR TITLE
Rescue stale shells server-side via /api/asset-recovery

### DIFF
--- a/api/asset-recovery.js
+++ b/api/asset-recovery.js
@@ -1,0 +1,74 @@
+// Recovery endpoint for requests to deleted build assets.
+//
+// Every deploy content-hashes the bundle (/assets/index-<hash>.js) and deletes
+// the previous hashes. An HTML shell cached anywhere — Vercel's edge, a browser
+// HTTP cache, an in-app webview — can outlive the deploy that built it, and its
+// asset requests then miss. Vercel's default answer is a 404 served as
+// text/plain, which browsers refuse to execute as a module ("blocked because
+// of a disallowed MIME type"), leaving the page permanently blank.
+//
+// index.html carries an inline recovery script for exactly that failure, but it
+// can only save shells that already contain it. Shells cached before it shipped
+// — or HTML mangled by some cache we've never heard of — still die. This
+// endpoint closes that hole from the server side: vercel.json rewrites misses
+// under /assets/* here (static files win over rewrites, so live assets never
+// hit this), and a missing *script* gets a tiny valid-MIME module that performs
+// the same guarded one-shot reload. A fresh, cache-busted navigation re-fetches
+// HTML that points at the current build.
+//
+// The "_r" query param on the page URL is the shared loop guard (same protocol
+// as the inline script, stripped on successful boot in src/main.jsx): if it's
+// already present, the previous recovery attempt didn't produce a working
+// shell, so we log and stop — a genuine outage must never reload-loop.
+//
+// Everything is no-store: no cache may ever adopt a recovery response as the
+// real asset.
+//
+// Routed in vercel.json:    /assets/:path*  ->  /api/asset-recovery?path=:path*
+// (only when no static file matches)
+
+export default function handler(req, res) {
+  const raw = req.query?.path;
+  const path = String(Array.isArray(raw) ? raw.join('/') : raw || '');
+
+  res.statusCode = 200;
+  res.setHeader('Cache-Control', 'no-store');
+
+  if (path.endsWith('.css')) {
+    // A stale shell's stylesheet link. Valid empty CSS keeps the console quiet
+    // for the moment before the script-side recovery reloads the page.
+    res.setHeader('Content-Type', 'text/css; charset=utf-8');
+    res.end('/* dame.is: stale asset — recovered on reload */\n');
+    return;
+  }
+
+  if (path.endsWith('.js') || path.endsWith('.mjs')) {
+    // The missing path is echoed into the snippet for console forensics;
+    // JSON.stringify makes it safe to embed.
+    const assetPath = JSON.stringify(`/assets/${path}`);
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+    res.end(
+      '(function () {\n' +
+        '  try {\n' +
+        '    var u = new URL(window.location.href);\n' +
+        "    if (u.searchParams.has('_r')) {\n" +
+        '      // Already retried once — the fresh shell still references a\n' +
+        '      // missing asset, so the deploy itself is broken. Stop here.\n' +
+        `      console.error('[dame.is] asset still missing after recovery reload:', ${assetPath});\n` +
+        '      return;\n' +
+        '    }\n' +
+        `    console.warn('[dame.is] stale shell detected (missing', ${assetPath}, ') — reloading fresh');\n` +
+        "    u.searchParams.set('_r', Date.now().toString(36));\n" +
+        '    window.location.replace(u.toString());\n' +
+        '  } catch (e) {}\n' +
+        '})();\n',
+    );
+    return;
+  }
+
+  // Images, fonts, sourcemaps… nothing executable hangs on these — keep honest
+  // 404 semantics.
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end('Not found\n');
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
       "_r" param in the URL is itself the loop guard (present ⇒ we already
       retried), so a genuine outage can never loop and no storage is needed. A
       successful boot strips the param (see src/main.jsx).
+
+      Shells that PREDATE this script can't heal themselves — for those,
+      api/asset-recovery.js serves the same guarded reload from the missing
+      asset's own URL (wired in vercel.json). The two nets share the "_r"
+      protocol, so together they retry at most once.
     -->
     <script>
       (function () {

--- a/middleware.js
+++ b/middleware.js
@@ -247,11 +247,14 @@ export default async function middleware(request) {
         // hash and deletes the old file. A shell cached across a deploy points
         // at a now-404 asset that Vercel serves as text/plain, which the
         // browser refuses to run as a module — blanking the page. So: a short
-        // s-maxage that revalidates promptly onto the new build, and NO
-        // stale-while-revalidate (its 24h stale-serve was the crash window).
-        // The inline boot-recovery in index.html covers the brief post-deploy
-        // sliver where a still-fresh shell can be served.
-        'cache-control': 'public, max-age=0, s-maxage=60',
+        // s-maxage that revalidates promptly onto the new build, NO
+        // stale-while-revalidate (its 24h stale-serve was the crash window),
+        // and must-revalidate so no cache — browser, webview, or intermediary —
+        // may ever serve this shell stale. The inline boot-recovery in
+        // index.html covers the brief post-deploy sliver where a still-fresh
+        // shell can be served, and /api/asset-recovery rescues any stale shell
+        // that slips through from a cache we don't control.
+        'cache-control': 'public, max-age=0, must-revalidate, s-maxage=60',
       },
     });
   } catch {

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,7 @@
     { "source": "/site.standard.document/:rkey", "destination": "/index.html" },
     { "source": "/pub.leaflet.document/:rkey", "destination": "/index.html" },
     { "source": "/is.dame.creating.work/:rkey", "destination": "/index.html" },
+    { "source": "/assets/:path*", "destination": "/api/asset-recovery?path=:path*" },
     { "source": "/((?!api/|assets/|version.json).*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Problem

Follow-up to #307. That fix (short shell cache + inline boot-recovery) only protects shells that **contain** the new inline script. Shells cached **before** it shipped — at Vercel's edge, in browser HTTP caches, and in in-app webview caches, all stored with the old `stale-while-revalidate=86400` policy — still reference deleted asset hashes and have no recovery script, so they white-screen until their stale window expires (~24h per URL). Confirmed live: the post-merge crash on `/blogging/3mqrsdovjjf2d` was the **pre-fix** build's `index-DAMJ-E2l.js`.

## Fix

Put recovery at the asset URL itself — the one place every stale shell, wherever cached, can still be reached:

- **`vercel.json`** — rewrite **misses** under `/assets/*` to `/api/asset-recovery` (static files win over rewrites, so live assets are untouched).
- **`api/asset-recovery.js`** — a missing **script** returns a tiny valid-MIME module performing the same guarded one-shot reload as the inline script (shared `?_r` loop guard → at most one retry across both nets; a genuinely broken deploy logs and stops). Missing **CSS** gets valid empty CSS; images/sourcemaps keep honest 404s. All responses `no-store`.
- **`middleware.js`** — add `must-revalidate` so no cache may ever serve the shell stale; cross-reference the nets in comments (also `index.html`).

## Verification

Mounted the real handler in a Vercel-like server (filesystem first, rewrite on miss) and drove Chromium:

- A **pre-fix shell with no inline script** — the exact artifact cached in the wild — recovers in one cache-busted reload and boots with a clean URL.
- A permanently-dead asset makes exactly one retry, then stops (no reload loop).
- Unit checks: missing `.js` → 200 JS MIME `no-store` snippet; `.css` → 200 empty CSS; `.png`/`.js.map` → 404. 14/14 pass; `npm run build:offline` green; `vercel.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ACXJCSgsGdgdhDBrC4aMN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ACXJCSgsGdgdhDBrC4aMN)_