### PR TITLE
Drive every page's OG description from its PDS record

### DIFF
--- a/og/pageContent.js
+++ b/og/pageContent.js
@@ -20,12 +20,14 @@ const PDS_TIMEOUT_MS = 2500;
 
 // Top-level routes whose OG copy is backed by an is.dame.page/<rkey> record.
 // The URL and the record key can differ — /available is backed by the
-// is.dame.page/resume record, and /welcoming by is.dame.page/guestbook. Add a
-// route here to let it drive its own social copy from the PDS; unlisted routes
-// keep their static og/pages.js copy.
+// is.dame.page/resume record, and /welcoming by is.dame.page/guestbook — or
+// match, as /mothing → is.dame.page/mothing does. Add a route here to let it
+// drive its own social copy from the PDS; unlisted routes keep their static
+// og/pages.js copy.
 const PAGE_RKEY_FOR_PATH = {
   '/available': 'resume',
   '/welcoming': 'guestbook',
+  '/mothing': 'mothing',
 };
 
 /** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */

--- a/og/pageContent.js
+++ b/og/pageContent.js
@@ -1,12 +1,12 @@
 // Edge-safe resolver for a top-level page surface's editable copy, sourced from
-// the is.dame.page record the SPA itself renders. Lets the crawler-facing <head>
+// the PDS record the SPA itself renders. Lets the crawler-facing <head>
 // description and the OG card subtitle track what's on the user's PDS instead of
-// the static defaults in og/pages.js — so the social card is editable, not
+// the static defaults in og/pages.js — so every social card is editable, not
 // hardcoded.
 //
 // Resolution order (mirrors src/hooks/usePageContent.js + og/records.js):
-//   1. the build/deploy snapshot at /data/pages.json  (the "latest deployment")
-//   2. a time-boxed live is.dame.page getRecord         (records newer than the build)
+//   1. the build/deploy snapshot under /data/*.json  (the "latest deployment")
+//   2. a time-boxed live getRecord                    (records newer than the build)
 //   3. null → caller keeps the static og/pages.js copy
 //
 // Everything is defensive: any miss/hiccup returns null so a slow or broken PDS
@@ -18,17 +18,40 @@ import { resolvePds, getRecord } from '../src/lib/atproto.js';
 const SNAPSHOT_TIMEOUT_MS = 2000;
 const PDS_TIMEOUT_MS = 2500;
 
-// Top-level routes whose OG copy is backed by an is.dame.page/<rkey> record.
-// The URL and the record key can differ — /available is backed by the
-// is.dame.page/resume record, and /welcoming by is.dame.page/guestbook — or
-// match, as /mothing → is.dame.page/mothing does. Add a route here to let it
-// drive its own social copy from the PDS; unlisted routes keep their static
+// Which PDS record backs each routed top-level surface's OG copy. Every content
+// page reads from an is.dame.page/<rkey> record, and by DEFAULT the rkey is the
+// path segment (/blogging → is.dame.page/blogging), so pages are covered without
+// listing them one by one. Only the exceptions need an entry below:
+//   • URL and record key differ — /available is is.dame.page/resume,
+//     /welcoming is is.dame.page/guestbook;
+//   • the record lives in another collection — /themself is is.dame.profile/self.
+// `fields` are the record-value keys tried in order for the description; the
+// page default (`description` then `intro`) matches the fields the SPA renders
+// via usePageContent, and the profile uses its own `tagline`. A route that
+// resolves to no record — or a record missing those fields — keeps the static
 // og/pages.js copy.
-const PAGE_RKEY_FOR_PATH = {
-  '/available': 'resume',
-  '/welcoming': 'guestbook',
-  '/mothing': 'mothing',
+const DEFAULT_FIELDS = ['description', 'intro'];
+const SOURCE_OVERRIDES = {
+  '/available': { collection: COLLECTIONS.page, rkey: 'resume' },
+  '/welcoming': { collection: COLLECTIONS.page, rkey: 'guestbook' },
+  '/themself': { collection: COLLECTIONS.profile, rkey: 'self', fields: ['tagline'] },
 };
+
+/**
+ * The PDS record source backing a route's OG copy, or null when the route has
+ * no backing record — the home index and any nested/dynamic route (those carry
+ * their own cards, resolved in og/records.js).
+ *
+ *   { collection, rkey, fields }
+ */
+function sourceForPath(pathname) {
+  const override = SOURCE_OVERRIDES[pathname];
+  if (override) return { fields: DEFAULT_FIELDS, ...override };
+  // Default: a single-segment route maps 1:1 to is.dame.page/<segment>.
+  const seg = String(pathname || '').replace(/^\/+|\/+$/g, '');
+  if (!seg || seg.includes('/')) return null;
+  return { collection: COLLECTIONS.page, rkey: seg, fields: DEFAULT_FIELDS };
+}
 
 /** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */
 function withTimeout(promise, ms) {
@@ -60,41 +83,57 @@ const firstText = (...vals) => {
   return '';
 };
 
-/** The is.dame.page record for a route's rkey: snapshot first, then a live PDS fallback. */
-async function resolvePageRecord(origin, rkey) {
-  // 1. Build snapshot — public/data/pages.json is a { [rkey]: record } map.
-  if (origin) {
-    const pages = await fetchJson(`${origin}/data/pages.json`, SNAPSHOT_TIMEOUT_MS);
-    const rec = pages && typeof pages === 'object' ? pages[rkey] : null;
-    if (rec?.value) return rec;
+/**
+ * The build snapshot for a source, or null. The is.dame.page snapshot is a
+ * { [rkey]: record } map at /data/pages.json; the extended profile is a single
+ * record at /data/extendedProfile.json. Both carry the { uri, cid, value } shape.
+ */
+async function snapshotRecord(origin, source) {
+  if (!origin) return null;
+  if (source.collection === COLLECTIONS.profile) {
+    const rec = await fetchJson(`${origin}/data/extendedProfile.json`, SNAPSHOT_TIMEOUT_MS);
+    return rec?.value ? rec : null;
   }
-  // 2. Live PDS — catches a record authored/edited since the last build.
-  const live = await withTimeout(livePageRecord(rkey), PDS_TIMEOUT_MS);
+  const pages = await fetchJson(`${origin}/data/pages.json`, SNAPSHOT_TIMEOUT_MS);
+  const rec = pages && typeof pages === 'object' ? pages[source.rkey] : null;
+  return rec?.value ? rec : null;
+}
+
+/** The record for a source: build snapshot first, then a live PDS fallback for
+ *  records authored/edited since the last build. */
+async function resolveRecord(origin, source) {
+  const snap = await snapshotRecord(origin, source);
+  if (snap?.value) return snap;
+  const live = await withTimeout(liveRecord(source), PDS_TIMEOUT_MS);
   if (live?.value) return live;
   return null;
 }
 
-async function livePageRecord(rkey) {
+async function liveRecord(source) {
   const pds = await resolvePds(ME_DID).catch(() => null);
   if (!pds) return null;
-  return getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.page, rkey }).catch(() => null);
+  return getRecord(pds, {
+    repo: ME_DID,
+    collection: source.collection,
+    rkey: source.rkey,
+  }).catch(() => null);
 }
 
 /**
  * Resolve a top-level page route to its PDS-backed OG copy, or null when the
- * route isn't page-backed or no record exists yet (→ caller keeps the static
+ * route has no backing record / no copy yet (→ caller keeps the static
  * og/pages.js defaults).
  *
- *   { title, desc }  — `desc` prefers a dedicated `description` on the record,
- *   else its `intro`; `title` is the record's own title. Empty strings when the
- *   record omits them.
+ *   { title, desc }  — `desc` is the record's first non-empty copy field (a
+ *   dedicated `description`, else `intro` for pages / `tagline` for the profile);
+ *   `title` is the record's own title when it has one. Empty strings otherwise.
  */
 export async function pageContentMeta(pathname, origin) {
-  const rkey = PAGE_RKEY_FOR_PATH[pathname];
-  if (!rkey) return null;
-  const rec = await resolvePageRecord(origin, rkey);
+  const source = sourceForPath(pathname);
+  if (!source) return null;
+  const rec = await resolveRecord(origin, source);
   const v = rec?.value || {};
-  const desc = firstText(v.description, v.intro);
+  const desc = firstText(...source.fields.map((f) => v[f]));
   const title = firstText(v.title);
   if (!desc && !title) return null;
   return { title, desc };


### PR DESCRIPTION
## Problem

Top-level page surfaces served a **hardcoded** Open Graph description from `og/pages.js`, diverging from what the page and its backing PDS record actually read. The `/mothing` card, for example, said "Moths at the light — observations logged from nights spent watching the dark." while the page and the `is.dame.page/mothing` record read "Moths I've seen and photographed, pulled from iNaturalist and mirrored to my PDS."

The resolver that fixes this (`pageContentMeta`) already existed, but only three routes were wired into its allowlist (`/available`, `/welcoming`, and — as of the first commit here — `/mothing`).

## Change

Generalize `og/pageContent.js` so **every** top-level route drives its OG copy (both the crawler `<head>` description and the OG card subtitle) from its backing PDS record:

- **Default:** a route maps 1:1 to `is.dame.page/<segment>` (so `/blogging`, `/creating`, `/curating`, `/listening`, `/posting`, `/logging`, `/sharing` are all covered without listing them).
- **Overrides** for the exceptions: `/available` → `is.dame.page/resume`, `/welcoming` → `is.dame.page/guestbook`, and `/themself` → `is.dame.profile/self` (its `tagline`).
- The snapshot lookup handles both shapes — the `{ [rkey]: record }` map at `/data/pages.json` and the single record at `/data/extendedProfile.json`.
- Resolution stays **snapshot-first with a time-boxed live PDS fallback**; any miss returns `null` so the route keeps its static `og/pages.js` copy.

Record/leaf routes (`/blogging/:slug`, `/posting/:rkey`, individual moths, …) were already dynamic via `og/records.js`, so this closes the gap for the top-level surfaces. The middleware is unchanged — it already threads the resolved copy into both the description meta and the `/api/og` card.

## Verification

Ran the real resolver against production for every matched route: the 10 `is.dame.page`-backed pages now resolve their record intros (9 changed from the old hardcoded copy, `/welcoming` already matched), while `/`, `/themself` (no profile record yet), and nested routes correctly fall back. `node --check` passes on the changed module and the middleware that imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbHgUCv3W38ckmmUVHyLdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbHgUCv3W38ckmmUVHyLdE)_