### PR TITLE
Render OG cards with the live sky-theme tuning from the PDS

### DIFF
--- a/api/og.js
+++ b/api/og.js
@@ -19,6 +19,7 @@ import { ICONS } from '../og/assets/icons.js';
 import { easternHour, avatarKeys, secondsUntilNextHour, folio } from '../og/time.js';
 import { ogElement, themeFromSky } from '../og/design.js';
 import { paletteForHour } from '../src/lib/skyTheme.js';
+import { resolveSkyTuning } from '../og/skyTuning.js';
 import { pageMeta, segsFor, cleanPath, HOME_INDEX, DEFAULT } from '../og/pages.js';
 
 // One family throughout: Crimson Pro (serif) — breadcrumb, title, description,
@@ -56,11 +57,18 @@ export default async function handler(req, res) {
     }
 
     // Palette: the dynamic SKY theme for this hour by default, so cards match
-    // the site's own hour-tracking palette. `theme=light|dark` forces the
-    // fixed warm-paper fallbacks (handled inside ogElement).
-    const theme = q.theme === 'light' || q.theme === 'dark'
-      ? q.theme
-      : themeFromSky(paletteForHour(hour));
+    // the site's own hour-tracking palette — INCLUDING any per-hour tuning saved
+    // from the admin "Sky theme studio" (is.dame.sky/self). That override is
+    // only installed client-side (useTheme.jsx), so resolve it here from the
+    // same snapshot + live PDS the SPA reads and pass it to paletteForHour;
+    // otherwise cards render the untuned palette and drift from the live site —
+    // most visibly at dawn/dusk, whose raw page derivation is a muddy warm color
+    // that reads as an accent wash rather than the tuned background.
+    // `theme=light|dark` forces the fixed warm-paper fallbacks (in ogElement).
+    const fixed = q.theme === 'light' || q.theme === 'dark';
+    const origin = `https://${req.headers['x-forwarded-host'] || req.headers.host || 'dame.is'}`;
+    const tuning = fixed ? null : await resolveSkyTuning(origin);
+    const theme = fixed ? q.theme : themeFromSky(paletteForHour(hour, tuning));
 
     // Copy + routing: an explicit `page` wins (canonical per-page card), then a
     // `section`+`label` record card, then ad-hoc title/subtitle, else the home

--- a/og/skyTuning.js
+++ b/og/skyTuning.js
@@ -1,0 +1,86 @@
+// Edge/Node-safe resolver for the sky-theme tuning override, sourced from the
+// same is.dame.sky/self PDS record the SPA reads. Lets the dynamic OG card
+// (api/og.js) derive its palette from the LIVE, admin-tuned sky theme instead
+// of the built-in hourly derivation — so a card's background, borders, and
+// accents match exactly what the site paints for that hour, including any
+// tweaks saved from the "Sky theme studio".
+//
+// Without this, api/og.js calls paletteForHour(hour) with no tuning (the
+// module-level activeTuning is only ever installed client-side, in
+// useTheme.jsx), so cards always render the untuned palette — most visibly at
+// the dawn/dusk shoulder hours, whose raw derivation is a muddy warm color
+// that reads as an accent wash rather than the clean background the tuning
+// pins.
+//
+// Resolution order mirrors og/pageContent.js + useTheme.jsx:
+//   1. the build/deploy snapshot at /data/sky.json  (the "latest deployment")
+//   2. a time-boxed live getRecord                  (records newer than the build)
+//   3. null → caller falls back to the built-in hourly palette
+//
+// Everything is defensive: any miss/hiccup returns null so a slow or broken PDS
+// never blocks the card. Plain fetch only, so it runs in either runtime.
+
+import { ME_DID, COLLECTIONS } from '../src/config.js';
+import { resolvePds, getRecord } from '../src/lib/atproto.js';
+import { effectiveSkyTuning } from '../src/lib/skyTuning.js';
+
+const SNAPSHOT_TIMEOUT_MS = 2000;
+const PDS_TIMEOUT_MS = 2500;
+
+/** Resolve after `ms`, whichever comes first, so a hung fetch never blocks. */
+function withTimeout(promise, ms) {
+  return Promise.race([
+    Promise.resolve(promise).catch(() => null),
+    new Promise((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+async function fetchJson(url, ms) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** The build snapshot of is.dame.sky/self ({uri,cid,value}), or null. Prefetch
+ *  writes `{}` when no record exists yet, which has no `.value` → treated as a
+ *  miss so the live fallback still runs. */
+async function snapshotRecord(origin) {
+  if (!origin) return null;
+  const rec = await fetchJson(`${origin}/data/sky.json`, SNAPSHOT_TIMEOUT_MS);
+  return rec?.value ? rec : null;
+}
+
+async function liveRecord() {
+  const pds = await resolvePds(ME_DID).catch(() => null);
+  if (!pds) return null;
+  return getRecord(pds, { repo: ME_DID, collection: COLLECTIONS.sky, rkey: 'self' }).catch(() => null);
+}
+
+/** The is.dame.sky record: build snapshot first, then a live PDS fallback for a
+ *  record authored/edited since the last build. */
+async function resolveRecord(origin) {
+  const snap = await snapshotRecord(origin);
+  if (snap?.value) return snap;
+  const live = await withTimeout(liveRecord(), PDS_TIMEOUT_MS);
+  if (live?.value) return live;
+  return null;
+}
+
+/**
+ * The runtime sky-tuning map ({ enabled, hours: { <h>: cfg } }) for the OG
+ * palette, or null when there's no enabled override (→ caller uses the
+ * built-in hourly derivation). Pass the result straight to
+ * paletteForHour(hour, tuning).
+ */
+export async function resolveSkyTuning(origin) {
+  const record = await resolveRecord(origin);
+  return effectiveSkyTuning(record);
+}


### PR DESCRIPTION
## Problem

The dynamic Open Graph cards derive their palette from the hour-tracking sky theme, but `api/og.js` called `paletteForHour(hour)` with **no tuning**. The `is.dame.sky/self` override — edited in the admin "Sky theme studio" and stored on the PDS — is only ever installed **client-side** (`useTheme.jsx` → `setSkyTuning`). On the server that module-level tuning is always `null`, so cards rendered the built-in **untuned** palette and drifted from what the live site paints.

This is most visible at the dawn/dusk shoulder hours, whose raw page derivation is a muddy warm color that reads as an accent wash rather than a proper background — e.g. the 6am `/listening` card rendered a brown `#55412f` page while the live site (and the saved tuning) uses navy `#2a315f`.

## Fix

- **New `og/skyTuning.js`** — resolves the same `is.dame.sky` record the SPA reads, following the existing `og/pageContent.js` pattern: build snapshot at `/data/sky.json` first, then a time-boxed live `getRecord` fallback, turned into the runtime tuning map via `effectiveSkyTuning`. Fully defensive — any miss/hiccup returns `null` and the built-in palette stands, so a slow or broken PDS never blocks a card.
- **`api/og.js`** — resolves the tuning from the request origin and passes it through: `themeFromSky(paletteForHour(hour, tuning))`. The card's background, borders, and accents now match the live site's tuned theme exactly. The `theme=light|dark` debug fallbacks skip the fetch entirely.

## Verification

- Unit-tested the resolver across snapshot-present / empty-snapshot / network-error cases — never throws, falls back cleanly.
- Rendered real PNGs end-to-end through the `@vercel/og` handler for home, section, and record cards.
- Rendered before/after against the **real live PDS record**: the untuned 6am card reproduces the reported muddy brown; with the fix it renders the saved navy `#2a315f` (and hour 19 renders the saved purple `#41358d`), matching the live site.

Note: cards are cached per-hour with `stale-while-revalidate`, so already-scraped cards refresh on their next revalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBf15gxHizorfcgZ9gRQAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBf15gxHizorfcgZ9gRQAR)_