### PR TITLE
Make listening and logging pages update live like the home feed

### DIFF
--- a/src/hooks/useLiveFeed.js
+++ b/src/hooks/useLiveFeed.js
@@ -1,5 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { fetchSnapshot } from '../lib/snapshot.js';
+import { subscribeRefreshTick } from '../lib/refreshTick.js';
+
+// Stable empty set so "nothing new" always returns the same reference —
+// page-side memos keyed on `newKeys` then stay stable between refreshes.
+const EMPTY_KEYS = new Set();
+// How long a freshly-arrived row stays flagged, so the entrance animation
+// plays once and unrelated later re-renders (search, layout toggle) don't
+// replay it.
+const ARRIVAL_HOLD_MS = 1200;
+
+const defaultArrivalKey = (item) => item?.atUri;
 
 /**
  * Dual-strategy data hook for PDS-backed surfaces.
@@ -26,7 +37,21 @@ import { fetchSnapshot } from '../lib/snapshot.js';
  * `deps` is the effect dependency array. Pass `[]` for unparameterized
  * pages; pass `[slug]` for routes with a URL parameter, etc.
  *
- *   { items, status: 'loading' | 'ready' | 'stale' | 'error', refreshedAt }
+ * `live` opts the surface into the shared 30s refresh tick (the same one
+ * NowPlaying, NowStatus and the home feed ride), so new records appear
+ * without a reload. On each live refresh the fresh records are diffed
+ * against what's already on screen and their keys returned as `newKeys`,
+ * so the page can slide them in (see the home feed's arrival animation).
+ * The very first paint never animates. `getRev` is an optional
+ * `async () => string` probe (repo head rev via getLatestCommit); when it
+ * returns the same rev as the last live fetch, the tick skips the — possibly
+ * multi-page — `fetchLive` call entirely, so an idle page costs one cheap
+ * request per tick instead of re-paginating the whole collection.
+ * `arrivalKey` derives the identity used for arrival diffing (default the
+ * record's `atUri`).
+ *
+ *   { items, status: 'loading' | 'ready' | 'stale' | 'error', refreshedAt,
+ *     newKeys: Set<string> }
  */
 export function useLiveFeed({
   name,
@@ -35,22 +60,58 @@ export function useLiveFeed({
   fetchSnapshotOverride,
   strategy = 'snapshot-first',
   fallbackOnError = true,
+  live = false,
+  getRev = null,
+  arrivalKey = defaultArrivalKey,
   deps = [],
 }) {
   const [state, setState] = useState({ items: null, status: 'loading', refreshedAt: null });
+  // Keys that arrived on the most recent live refresh (empty on first paint
+  // and between refreshes). Held separate from `state` so a snapshot/cache
+  // repaint can't accidentally flag arrivals.
+  const [newKeys, setNewKeys] = useState(EMPTY_KEYS);
 
   // Latest-callback refs so closures over slugs / params don't trap stale
   // versions, but the effect itself only re-runs when `deps` changes.
   const fetchLiveRef = useRef(fetchLive);
   const mapItemsRef = useRef(mapItems);
   const fetchSnapshotRef = useRef(fetchSnapshotOverride);
+  const getRevRef = useRef(getRev);
+  const arrivalKeyRef = useRef(arrivalKey);
   fetchLiveRef.current = fetchLive;
   mapItemsRef.current = mapItems;
   fetchSnapshotRef.current = fetchSnapshotOverride;
+  getRevRef.current = getRev;
+  arrivalKeyRef.current = arrivalKey;
+
+  // Mirror the currently-displayed items so the first live poll can seed its
+  // "already seen" set from the initial paint without threading it through
+  // the (multi-exit-path) initial load.
+  const itemsRef = useRef(null);
+  itemsRef.current = state.items;
+
+  // Live-polling coordination. `didInit` gates polling until the initial
+  // load settles; `inflight` prevents overlapping ticks; `lastRev` is the
+  // repo head as of our last successful live fetch (for the getRev skip);
+  // `seenKeys` is every key shown so far (null until first seeded);
+  // `clearTimer` retires the arrival highlight after the entrance plays.
+  const didInitRef = useRef(false);
+  const inflightRef = useRef(false);
+  const lastRevRef = useRef(null);
+  const seenKeysRef = useRef(null);
+  const clearTimerRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
+    didInitRef.current = false;
+    lastRevRef.current = null;
+    seenKeysRef.current = null;
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = null;
+    }
     setState({ items: null, status: 'loading', refreshedAt: null });
+    setNewKeys(EMPTY_KEYS);
 
     const apply = (data) => (mapItemsRef.current ? mapItemsRef.current(data) : data);
 
@@ -115,12 +176,104 @@ export function useLiveFeed({
       setState({ items: null, status: 'error', refreshedAt: null });
     }
 
-    run();
+    // `didInit` unblocks the live tick only once the initial load settles
+    // (success or failure), so a fast first tick can't race the first paint.
+    run().finally(() => {
+      if (!cancelled) didInitRef.current = true;
+    });
     return () => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
-  return state;
+  // Live surfaces re-fetch on the shared 30s tick so new records appear
+  // without a reload. The tick already pauses while the tab is hidden and
+  // fires on visibility return. A cheap getRev probe (when provided) skips
+  // the full re-fetch whenever the repo head hasn't advanced since our last
+  // live build — cheap-request-per-tick instead of re-paginating idly.
+  useEffect(() => {
+    if (!live) return undefined;
+    let cancelled = false;
+
+    const poll = async () => {
+      if (cancelled || inflightRef.current || !didInitRef.current) return;
+      inflightRef.current = true;
+      try {
+        let rev = null;
+        if (getRevRef.current) {
+          try {
+            rev = await getRevRef.current();
+          } catch {
+            rev = null; // probe failed — fall through and re-fetch
+          }
+          if (cancelled) return;
+          if (rev && rev === lastRevRef.current) return; // repo unchanged
+        }
+
+        let data;
+        try {
+          data = await fetchLiveRef.current();
+        } catch {
+          return; // transient failure — keep current data, retry next tick
+        }
+        if (cancelled) return;
+        const mapped = mapItemsRef.current ? mapItemsRef.current(data) : data;
+        if (mapped == null) return;
+
+        // Diff the refreshed records against everything shown so far. The
+        // first poll seeds from the initial paint (via itemsRef) so nothing
+        // that was already on screen slides in — only genuinely new records.
+        const getKey = arrivalKeyRef.current || defaultArrivalKey;
+        if (seenKeysRef.current === null) {
+          const seed = new Set();
+          for (const it of itemsRef.current || []) {
+            const k = getKey(it);
+            if (k) seed.add(k);
+          }
+          seenKeysRef.current = seed;
+        }
+        const seen = seenKeysRef.current;
+        const arrivals = new Set();
+        for (const it of mapped) {
+          const k = getKey(it);
+          if (k && !seen.has(k)) arrivals.add(k);
+        }
+
+        // React 18 batches these back-to-back updates into one commit, so a
+        // new row mounts with its key already in `newKeys` and the entrance
+        // animation actually plays (mirrors the home feed's runRefresh).
+        setState({ items: mapped, status: 'ready', refreshedAt: new Date() });
+        if (rev) lastRevRef.current = rev;
+        if (arrivals.size > 0) {
+          for (const k of arrivals) seen.add(k);
+          setNewKeys(arrivals);
+          if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+          clearTimerRef.current = setTimeout(() => {
+            clearTimerRef.current = null;
+            setNewKeys(EMPTY_KEYS);
+          }, ARRIVAL_HOLD_MS);
+        }
+      } finally {
+        inflightRef.current = false;
+      }
+    };
+
+    const unsubscribe = subscribeRefreshTick(poll);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [live, ...deps]);
+
+  // Retire any pending arrival-highlight timer on unmount.
+  useEffect(
+    () => () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    },
+    [],
+  );
+
+  return { ...state, newKeys };
 }

--- a/src/pages/Listening.jsx
+++ b/src/pages/Listening.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import ListeningStats from '../components/ListeningStats.jsx';
@@ -13,7 +14,7 @@ import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
 import { collapseListens } from '../lib/listenSessions.js';
-import { resolvePds, listRecords } from '../lib/atproto.js';
+import { resolvePds, listRecords, getLatestCommit } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
 
@@ -21,10 +22,20 @@ export default function Listening() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
   const { title, intro } = usePageContent('listening');
+  const reduce = useReducedMotion();
 
-  const { items, status, refreshedAt } = useLiveFeed({
+  // `newKeys` are plays that arrived on the latest live refresh — a collapsed
+  // session row inherits its newest play's URI, so testing the row lights up.
+  const { items, status, refreshedAt, newKeys } = useLiveFeed({
     name: 'listening',
     strategy: 'live-first',
+    // Refresh on the shared 30s tick like the home feed. getRev skips the
+    // (up to ten-page) listRecords fan-out whenever the repo hasn't advanced.
+    live: true,
+    getRev: async () => {
+      const pds = await resolvePds(ME_DID);
+      return (await getLatestCommit(pds, ME_DID))?.rev || null;
+    },
     fetchLive: async () => {
       const pds = await resolvePds(ME_DID);
       return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.listen, max: 1000 });
@@ -74,7 +85,20 @@ export default function Listening() {
     );
     return collapseListens(sorted);
   }, [filtered]);
-  const groups = groupByDay(sessions, (i) => i.createdAt);
+  const groups = useMemo(() => groupByDay(sessions, (i) => i.createdAt), [sessions]);
+
+  // Top-down stagger order among the new arrivals currently on screen.
+  const arrivalIndex = useMemo(() => {
+    const map = new Map();
+    let i = 0;
+    for (const group of groups) {
+      for (const item of group.items) {
+        const uri = item?.atUri;
+        if (uri && newKeys.has(uri)) map.set(uri, i++);
+      }
+    }
+    return map;
+  }, [groups, newKeys]);
 
   // Feed page: report the newest visible record's time in the global footer.
   usePublishLatestRecord(useMemo(() => newestInstant(filtered), [filtered]));
@@ -107,14 +131,32 @@ export default function Listening() {
                   meta={listeningDayMeta(group.items)}
                 />
                 <ul className="feed-list" style={ledger ? undefined : { marginTop: 'var(--space-3)' }}>
-                  {group.items.map((item) => (
-                    <FeedItem
-                      key={item.atUri}
-                      item={item}
-                      showVerb={false}
-                      layout={ledger ? 'ledger' : 'cards'}
-                    />
-                  ))}
+                  <AnimatePresence initial={false}>
+                    {group.items.map((item) => {
+                      const uri = item.atUri;
+                      const isNew = uri ? newKeys.has(uri) : false;
+                      const stagger = isNew ? (arrivalIndex.get(uri) ?? 0) * 0.06 : 0;
+                      return (
+                        <motion.li
+                          key={uri}
+                          layout
+                          initial={isNew && !reduce ? { opacity: 0, y: -24 } : false}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{
+                            duration: reduce ? 0 : 0.45,
+                            ease: [0.22, 0.61, 0.36, 1],
+                            delay: reduce ? 0 : stagger,
+                          }}
+                        >
+                          <FeedItem
+                            item={item}
+                            showVerb={false}
+                            layout={ledger ? 'ledger' : 'cards'}
+                          />
+                        </motion.li>
+                      );
+                    })}
+                  </AnimatePresence>
                 </ul>
               </li>
             ))}

--- a/src/pages/Logging.jsx
+++ b/src/pages/Logging.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import PageShell from '../components/PageShell.jsx';
 import FeedItem from '../components/FeedItem.jsx';
 import DayOfLifeHeader from '../components/DayOfLifeHeader.jsx';
@@ -13,7 +14,7 @@ import { useEditMode } from '../hooks/useEditMode.jsx';
 import { useFeedLayout } from '../hooks/useFeedLayout.jsx';
 import { newestInstant, usePublishLatestRecord } from '../hooks/useFeedFooter.jsx';
 import { groupByDay } from '../lib/time.js';
-import { resolvePds, listRecords } from '../lib/atproto.js';
+import { resolvePds, listRecords, getLatestCommit } from '../lib/atproto.js';
 import { ME_DID, COLLECTIONS } from '../config.js';
 import '../components/Feed.css';
 
@@ -21,10 +22,20 @@ export default function Logging() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
   const { title, intro } = usePageContent('logging');
+  const reduce = useReducedMotion();
 
-  const { items, status, refreshedAt } = useLiveFeed({
+  // `newKeys` are status records that arrived on the latest live refresh, so
+  // the page can slide them in.
+  const { items, status, refreshedAt, newKeys } = useLiveFeed({
     name: 'now',
     strategy: 'live-first',
+    // Refresh on the shared 30s tick like the home feed. getRev skips the
+    // listRecords fan-out whenever the repo hasn't advanced.
+    live: true,
+    getRev: async () => {
+      const pds = await resolvePds(ME_DID);
+      return (await getLatestCommit(pds, ME_DID))?.rev || null;
+    },
     fetchLive: async () => {
       const pds = await resolvePds(ME_DID);
       return listRecords(pds, { repo: ME_DID, collection: COLLECTIONS.now, max: 500 });
@@ -49,7 +60,20 @@ export default function Logging() {
       }),
     [safeItems, q],
   );
-  const groups = groupByDay(filtered, (i) => i.createdAt);
+  const groups = useMemo(() => groupByDay(filtered, (i) => i.createdAt), [filtered]);
+
+  // Top-down stagger order among the new arrivals currently on screen.
+  const arrivalIndex = useMemo(() => {
+    const map = new Map();
+    let i = 0;
+    for (const group of groups) {
+      for (const item of group.items) {
+        const uri = item?.atUri;
+        if (uri && newKeys.has(uri)) map.set(uri, i++);
+      }
+    }
+    return map;
+  }, [groups, newKeys]);
 
   // Feed page: report the newest visible record's time in the global footer.
   usePublishLatestRecord(useMemo(() => newestInstant(filtered), [filtered]));
@@ -78,9 +102,28 @@ export default function Logging() {
               <li key={group.dateKey} className="feed-day-group">
                 <DayOfLifeHeader date={group.date} variant={ledger ? 'ledger' : 'default'} />
                 <ul className="feed-list" style={ledger ? undefined : { marginTop: 'var(--space-3)' }}>
-                  {group.items.map((item) => (
-                    <FeedItem key={item.atUri} item={item} layout={ledger ? 'ledger' : 'cards'} />
-                  ))}
+                  <AnimatePresence initial={false}>
+                    {group.items.map((item) => {
+                      const uri = item.atUri;
+                      const isNew = uri ? newKeys.has(uri) : false;
+                      const stagger = isNew ? (arrivalIndex.get(uri) ?? 0) * 0.06 : 0;
+                      return (
+                        <motion.li
+                          key={uri}
+                          layout
+                          initial={isNew && !reduce ? { opacity: 0, y: -24 } : false}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{
+                            duration: reduce ? 0 : 0.45,
+                            ease: [0.22, 0.61, 0.36, 1],
+                            delay: reduce ? 0 : stagger,
+                          }}
+                        >
+                          <FeedItem item={item} layout={ledger ? 'ledger' : 'cards'} />
+                        </motion.li>
+                      );
+                    })}
+                  </AnimatePresence>
                 </ul>
               </li>
             ))}


### PR DESCRIPTION
## Summary

The listening and logging feeds fetched once on mount and then went stale until a reload — only the home feed polled for new records. This wires both onto the same shared 30s refresh tick (the one NowPlaying, NowStatus, and the home feed already ride), so new plays and status posts appear on their own, and slides fresh rows in with the home feed's arrival animation.

## Changes

**`useLiveFeed`** gains an opt-in `live` mode:
- Subscribes to `subscribeRefreshTick` and re-runs the live fetch, gated so it can't race the initial paint and never overlaps itself.
- `getRev` (a cheap `getLatestCommit` probe) short-circuits the refresh when the repo head hasn't advanced, so an idle listening page costs one small request per tick instead of re-paginating up to 1000 records.
- Diffs each refresh against what's on screen and returns `newKeys`; the feed update and the arrival set commit together (React 18 batching) so the entrance animation actually plays. First paint and between-refresh renders never animate.
- Non-live consumers are untouched: the poll effect is inert without `live`, and the added `newKeys` return defaults to a stable empty set.

**Listening** and **Logging** opt in and render rows through `AnimatePresence`/`motion.li`, matching the home feed's slide-in and reduced-motion handling.

## Verification
- ESLint: 0 errors (pre-existing `safeItems` warnings unrelated to this change)
- Tests: 57 passing
- Production build: succeeds
- Confirmed the app uses `ReactDOM.createRoot`, so the automatic batching the arrival animation relies on holds (the same mechanism the home feed depends on)

Note: the 30s-tick behavior and slide-in need a live PDS and a new record over time, and this environment has no committed snapshot data to drive a headless render, so this was verified via static checks + matching the proven home-feed pattern rather than observing a live arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqREmUL3zGfuPPKaAiNsga

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqREmUL3zGfuPPKaAiNsga)_