### PR TITLE
Route mothing record pages to /mothing/{rkey}

### DIFF
--- a/src/lib/verbRegistry.js
+++ b/src/lib/verbRegistry.js
@@ -146,8 +146,14 @@ export const VERB_REGISTRY = [
     icon: 'Bug',
     renderer: 'ObservationCard',
     // Observation records are mirrored from iNaturalist onto the PDS by
-    // scripts/mirror-inaturalist.mjs; each carries its own iNat URL, so the
-    // feed links out there rather than to a bespoke record page.
+    // scripts/mirror-inaturalist.mjs. Each moth gets a bespoke record page at
+    // the short `/mothing/{rkey}` form (rkey = the iNaturalist observation id);
+    // Record.jsx renders it with ObservationCard. The card's own thumbnail +
+    // title still link out to the iNaturalist observation. Without this the feed
+    // would fall through to the generic `/{nsid}/{rkey}` URL — but only the
+    // `/mothing/{rkey}` form is wired for crawler cards (middleware.js matcher +
+    // og/records.js RECORD_SECTIONS), so this keeps shared links carding.
+    recordHref: ({ rkey }) => (rkey ? `/mothing/${rkey}` : null),
     pastTense: 'spotted',
     collections: [
       { nsid: 'is.dame.mothing.observation', source: 'inaturalist', kind: 'content', max: 500 },


### PR DESCRIPTION
## What

Give a specific moth observation its canonical record-page URL: `dame.is/mothing/{rkey}` (rkey = the iNaturalist observation id).

## Why

The `/mothing/:rkey` route already worked end-to-end — the router (`generatedRecordRoutes`), `Record.jsx` (renders `ObservationCard`), the OG middleware matcher, and the `og/records.js` crawler-card resolver were all built around the short verb form. The only gap: the `mothing` verb had no `recordHref` template in `verbRegistry.js`, so feed links fell through to the generic `/{nsid}/{rkey}` form (`/is.dame.mothing.observation/{rkey}`) — an uglier URL that the OG layers don't card.

## Change

One line (matching the existing `logging`/`listening` pattern):

```js
recordHref: ({ rkey }) => (rkey ? `/mothing/${rkey}` : null),
```

Now `recordHrefFor('mothing', …)` returns `/mothing/{rkey}`, consistent with `recordPathFromAtUri` (which already resolved to that form). The no-rkey case returns `null` so a missing key never produces a broken link. Sibling verb `observing` is intentionally left on the generic form — unlike `mothing`, it isn't wired into the OG middleware/resolver.

## Verification

- `recordHrefFor('mothing', {rkey})` → `/mothing/382838886` (was `/is.dame.mothing.observation/382838886`)
- Lint clean, 57/57 tests pass, production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh)_