### PR TITLE
Show each mothing session newest-first

### DIFF
--- a/src/lib/inaturalist.js
+++ b/src/lib/inaturalist.js
@@ -186,8 +186,9 @@ export function sessionDateFor(observedDate, observedHour) {
 /**
  * Group observations into numbered mothing sessions (oldest night = #1).
  * Returns `{ sessions, sessionCount, orphans }` where `sessions` is sorted
- * newest-first for display and each carries its own little stat block.
- * `orphans` are daytime / untimed observations that aren't part of a night.
+ * newest-first for display — and within each session the observations are
+ * newest-first too — and each carries its own little stat block. `orphans`
+ * are daytime / untimed observations that aren't part of a night.
  */
 export function buildSessions(observations) {
   const obs = Array.isArray(observations) ? observations : [];
@@ -215,14 +216,16 @@ export function buildSessions(observations) {
 }
 
 function summarizeSession(date, number, observations) {
-  const items = observations
+  // Chronological within the night (evening → after-midnight). This order
+  // drives the stats and the first/last time span; the displayed list is the
+  // reverse of it (see `observations` below).
+  const chronological = observations
     .slice()
-    // Within a night, order by local time (evening → after-midnight).
     .sort((a, b) => nightMinutes(a) - nightMinutes(b));
   const species = new Set();
   let research = 0;
-  const timed = items.filter((o) => o.observedTime);
-  for (const o of items) {
+  const timed = chronological.filter((o) => o.observedTime);
+  for (const o of chronological) {
     if (o.taxon?.id != null && (o.taxon.rank === 'species' || o.taxon.rank === 'subspecies')) {
       species.add(o.taxon.id);
     }
@@ -231,8 +234,12 @@ function summarizeSession(date, number, observations) {
   return {
     number,
     date, // the evening's date (YYYY-MM-DD)
-    observations: items,
-    observationCount: items.length,
+    // Newest-first for display — the night's latest sighting sits on top,
+    // matching the newest-first ordering of the sessions themselves (and the
+    // orphan list). firstTime/lastTime stay chronological so the header span
+    // still reads low→high (e.g. "8:47pm–1:17am").
+    observations: chronological.slice().reverse(),
+    observationCount: chronological.length,
     speciesCount: species.size,
     researchCount: research,
     firstTime: timed[0]?.observedTime || null,

--- a/src/lib/inaturalist.test.js
+++ b/src/lib/inaturalist.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isMothTaxon, normalizeObservation } from './inaturalist.js';
+import { isMothTaxon, normalizeObservation, buildSessions } from './inaturalist.js';
 import { LEPIDOPTERA_TAXON_ID, BUTTERFLY_TAXON_ID } from '../config.js';
 
 // The moth/observing split is: a moth is Lepidoptera (47157) MINUS butterflies
@@ -89,5 +89,36 @@ describe('normalizeObservation classification', () => {
     // Only the tz-free local wall-clock survives from the timestamp.
     expect(n.observedTime).toBe('21:30');
     expect(JSON.stringify(n)).not.toContain('-04:00');
+  });
+});
+
+describe('buildSessions ordering', () => {
+  // One night: an evening sighting (before midnight) plus two after-midnight
+  // ones that roll back into the same session date. Input is deliberately
+  // shuffled so the ordering under test can't pass by accident.
+  const oneNight = [
+    { id: 'b', observedDate: '2026-07-19', observedHour: 0, observedTime: '00:36' }, // 12:36am
+    { id: 'a', observedDate: '2026-07-18', observedHour: 22, observedTime: '22:05' }, // 10:05pm
+    { id: 'c', observedDate: '2026-07-19', observedHour: 1, observedTime: '01:17' }, // 1:17am
+  ];
+
+  it('groups an evening + after-midnight night into a single session', () => {
+    const { sessions, orphans } = buildSessions(oneNight);
+    expect(orphans).toHaveLength(0);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].date).toBe('2026-07-18');
+    expect(sessions[0].observationCount).toBe(3);
+  });
+
+  it('orders observations within a session newest-first', () => {
+    const [night] = buildSessions(oneNight).sessions;
+    // Latest sighting of the night sits on top; earliest at the bottom.
+    expect(night.observations.map((o) => o.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('keeps the header time span chronological (earliest → latest)', () => {
+    const [night] = buildSessions(oneNight).sessions;
+    expect(night.firstTime).toBe('22:05');
+    expect(night.lastTime).toBe('01:17');
   });
 });


### PR DESCRIPTION
## What

On the `/mothing` page, each night's session now lists its observations **newest-first** (the latest sighting on top). Previously they rendered oldest-first (evening → after-midnight), which clashed with the newest-first ordering of the sessions themselves and the orphan list.

## Change

One spot — `summarizeSession` in `src/lib/inaturalist.js`:

- The internal **chronological** sort is kept to compute the session's `firstTime`/`lastTime`, so the header time span still reads low→high (e.g. `8:47pm–1:17am`).
- The **displayed** `observations` array is that chronological list reversed → newest sighting first.

Because the order is fixed at the data level, it flows through consistently to the tile-grid layout, the ledger layout, and the lightbox prev/next walk.

## Tests

Added `buildSessions` tests covering:
- evening + after-midnight grouping into a single session,
- newest-first per-session ordering,
- the chronological header span.

## Verification

- 60/60 tests pass, lint clean, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh)_