### PR TITLE
Drop the accent border on the lightbox image

### DIFF
--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -69,7 +69,10 @@
   width: auto;
   height: auto;
   object-fit: contain;
-  border: 1px solid var(--rule);
+  /* No border: against the dark scrim the photo carries its own edge, and a
+     `--rule` hairline picks up the accent tint under the sky theme (reading as
+     a stray colored frame). A soft shadow + slight rounding is the whole
+     treatment. */
   border-radius: var(--radius-2);
   background: var(--page-edge);
   box-shadow: 0 16px 40px var(--shadow);


### PR DESCRIPTION
## What

Removes the border that framed the full-size image in the lightbox modal.

## Why

`.lightbox-image` carried a `1px solid var(--rule)` hairline. Against the dark scrim it read as a stray frame, and under the **sky theme** `--rule` is tinted toward the palette accent — so it showed up as a teal accent border around the photo (see report screenshot).

## Change

One line in `src/components/Lightbox.css`: drop the `border`. The soft drop shadow and slight corner rounding are kept, so the image still lifts off the scrim — just without the colored edge. It's the only rule that draws a border on the lightbox image (the panel is already `border: 0`).

## Verification

- Production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh)_