### PR TITLE
Lightbox: paint the thumb instantly, fade in the full image

### DIFF
--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -52,30 +52,56 @@
   --lightbox-maxh: calc(100dvh - var(--chrome-h) - 4rem);
 }
 
-/* Wrapper around the image and its optional attached caption bar, so the
-   two share a width, radius, and shadow and read as one surface. */
+/* Wrapper that carries the visible surface — rounded corners + soft shadow —
+   and stacks the low-res sizer under the full-res photo so the latter can
+   fade in over the former. No border: against the dark scrim the photo
+   carries its own edge, and a `--rule` hairline picks up the accent tint
+   under the sky theme (reading as a stray colored frame). */
 .lightbox-frame {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   max-width: 100%;
   min-height: 0;
+  border-radius: var(--radius-2);
+  background: var(--page-edge);
+  box-shadow: 0 16px 40px var(--shadow);
+  overflow: hidden;
 }
 
-.lightbox-image {
+/* In-flow low-res thumb. It holds the frame's dimensions open the instant the
+   lightbox opens (it's the already-cached grid image), giving the full-res
+   photo a sized, visible surface to fade in over. Decorative — the alt text
+   lives on the full image. */
+.lightbox-sizer {
   display: block;
   max-width: 100%;
   max-height: var(--lightbox-maxh);
   width: auto;
   height: auto;
   object-fit: contain;
-  /* No border: against the dark scrim the photo carries its own edge, and a
-     `--rule` hairline picks up the accent tint under the sky theme (reading as
-     a stray colored frame). A soft shadow + slight rounding is the whole
-     treatment. */
-  border-radius: var(--radius-2);
-  background: var(--page-edge);
-  box-shadow: 0 16px 40px var(--shadow);
+}
+
+/* Full-resolution photo, layered over the sizer and revealed once it loads. */
+.lightbox-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.lightbox-image.is-loaded {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lightbox-image {
+    transition: none;
+  }
 }
 
 /* Control bar — sits exactly where the bottom chrome nav is (fixed to

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -83,21 +83,14 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
         width: `min(${current.width}px, 100%, calc(var(--lightbox-maxh) * ${ratio.toFixed(5)}))`,
       }
     : undefined;
-  const placeholderStyle =
-    current.thumb && !loadedSrcs.has(current.src)
-      ? {
-          backgroundImage: `url(${current.thumb})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-        }
-      : null;
-  const imageStyle = ratio
-    ? {
-        width: '100%',
-        aspectRatio: `${current.width} / ${current.height}`,
-        ...placeholderStyle,
-      }
-    : placeholderStyle || undefined;
+  // The sizer holds the frame's box open. When the intrinsic ratio is known it
+  // reserves the exact box immediately (before any pixels arrive); otherwise it
+  // sizes to the thumb's own aspect once that small, already-cached image
+  // paints — either way the full-res photo fades in over a sized, visible
+  // frame instead of a collapsed box (the old "flash on open").
+  const sizerStyle = ratio
+    ? { width: '100%', aspectRatio: `${current.width} / ${current.height}` }
+    : undefined;
   const label = alt
     ? `Image: ${alt}`
     : count > 1
@@ -117,17 +110,26 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
       focusTrapRef={controlsRef}
     >
       <figure className="lightbox-figure">
-        <div
-          className="lightbox-frame"
-          style={frameStyle}
-        >
+        <div className="lightbox-frame" style={frameStyle}>
+          {/* In-flow sizer: the low-res thumb (already cached from the grid the
+              lightbox was opened from) gives the frame real dimensions the
+              instant it opens, so the full-resolution photo — which usually has
+              to download — fades in over a visible picture rather than a blank,
+              collapsed box. Decorative; the real alt lives on the full image
+              below. Falls back to the full src when a caller passes no thumb. */}
+          <img
+            src={current.thumb || current.src}
+            alt=""
+            aria-hidden="true"
+            className="lightbox-sizer"
+            decoding="async"
+            style={sizerStyle}
+          />
           <img
             key={current.src}
             src={current.src}
             alt={alt}
-            width={current.width || undefined}
-            height={current.height || undefined}
-            className="lightbox-image"
+            className={`lightbox-image${loadedSrcs.has(current.src) ? ' is-loaded' : ''}`}
             decoding="async"
             onLoad={() => markLoaded(current.src)}
             ref={(el) => {
@@ -135,7 +137,6 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
               // React attaches the handler; the ref callback catches those.
               if (el?.complete && el.naturalWidth) markLoaded(current.src);
             }}
-            style={imageStyle}
           />
         </div>
       </figure>


### PR DESCRIPTION
## What

Fixes the lightbox opening on a blank/collapsed frame before the full-size photo downloads (the "image doesn't appear right away" flash), and makes every lightbox on the site share one loading treatment.

## Why

The full-size image only reserved its box when the caller passed intrinsic `width`/`height`. Bluesky post embeds do; iNaturalist observations (mothing/observing) don't — so the loading `<img>` collapsed to zero size, its thumbnail placeholder never showed, and the frame stayed blank until the large image finished downloading. That's the flash, and why observation lightboxes felt different from post lightboxes.

## Change

Restructure `.lightbox-frame` into two layers:
1. a low-res **thumb held in flow** that gives the frame real dimensions the instant it opens (it's the already-cached grid image), and
2. the **full-resolution photo** absolutely positioned over it, fading in once loaded (`is-loaded`).

The frame now carries the rounded corners + soft shadow; neither layer has a border. Works whether or not a caller passes dimensions, so all lightboxes — home feed, posts, photos, blog, are.na, mothing, album art — open on a visible picture.

## Verification

- Rendered the new layout in headless Chromium: with the full-res image **not loaded**, the frame is fully sized and the thumb is visible (no collapse); with it loaded, the full image shows — and no border appears in either state even with `--rule` forced to a visible color.
- Build passes, lint clean, 60/60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh)_