### PR TITLE
Suppress the focus-visible ring on the modal panel container

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -98,6 +98,17 @@
   display: none;
 }
 
+/* The panel takes programmatic focus on open (see useFocusTrap) purely so a
+   screen reader announces the dialog label — it's a container, not a control.
+   Suppress the global :focus-visible ring (reset.css) so that anchor focus
+   doesn't paint a 2px accent outline around the whole panel. It's most visible
+   on the image lightbox, whose transparent panel hugs the photo, where the
+   ring reads as a stray accent border on the first image as it opens. Real
+   focusable controls inside the panel keep their own rings. */
+.modal-panel:focus {
+  outline: none;
+}
+
 .modal-variant-centered .modal-panel {
   width: min(560px, 100%);
   /* dvh tracks the live visual viewport on iOS, so the panel never


### PR DESCRIPTION
## What

Removes the stray accent outline that appeared around the first lightbox image as it opened.

## Why

When an overlay opens, the focus trap moves programmatic focus to the panel container (`tabindex="-1"`) so a screen reader announces the dialog label. Under keyboard modality that container matches `:focus-visible` and picks up the global `outline: 2px solid var(--accent)` from `reset.css` — painting an accent outline around the whole panel. On the image lightbox, whose transparent panel hugs the photo, it read as a stray accent border on the **first** image the moment it opened (focus isn't re-set when navigating, so only the first slide showed it; and only under keyboard-ish modality, hence "sometimes").

This is separate from the earlier `--rule` border removal (#315) — same visual symptom, different source.

## Change

`.modal-panel:focus { outline: none }` in `Modal.css`. The panel is an announcement anchor, not a control, so it shouldn't render a focus ring. Real focusable controls inside the panel (close, prev/next, links) keep their own `:focus-visible` rings, so keyboard accessibility is unchanged. Scoped to `.modal-panel`, so it covers every overlay.

## Verification

- Reproduced in headless Chromium: the programmatically-focused panel matched `:focus-visible` and computed `outline-width: 2px` in the accent color; with the fix it computes to `none`.
- Build passes, 60/60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6fighpUZigy2A5sg8rmUh)_