### PR TITLE
Re-ink sigils and inkblots in the current theme palette

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1402,7 +1402,8 @@ a.reference-card-profile:focus-visible {
   margin: 0;
 }
 
-.lab-card-figure img {
+.lab-card-figure img,
+.lab-card-figure .lab-inkblot-canvas {
   display: block;
   width: 100%;
   max-width: 20rem;
@@ -1413,12 +1414,31 @@ a.reference-card-profile:focus-visible {
 }
 
 /* Sigils are single-stroke line figures on transparency — keep them compact
-   and give them a calm field so the one line reads. */
-.lab-card-figure-sigil img {
+   and give them a calm field so the one line reads. The stroke itself is the
+   SVG used as a mask (see .lab-sigil); the frame lives on the container. */
+.lab-card-figure-sigil {
   max-width: 14rem;
   aspect-ratio: 1 / 1;
-  object-fit: contain;
+  border-radius: var(--radius-2);
+  border: 1px solid var(--rule-soft);
+  background: var(--page);
   padding: var(--space-3);
+}
+
+/* The re-inked stroke: a flat --ink fill the sigil SVG masks to its lines, so
+   it reads as drawn in the page's ink at any hour (swap to var(--accent) for a
+   sky-tinted stroke instead). Mask images can't run script — as sandboxed as
+   the old <img>. */
+.lab-sigil {
+  width: 100%;
+  height: 100%;
+  background-color: var(--ink);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 /* Word Magnets poem — cream tiles re-laid faithfully from the saved board
@@ -1513,11 +1533,12 @@ a.reference-card-profile:focus-visible {
   max-width: 34rem;
 }
 
-.lab-card-record .lab-card-figure img {
+.lab-card-record .lab-card-figure img,
+.lab-card-record .lab-card-figure .lab-inkblot-canvas {
   max-width: 30rem;
 }
 
-.lab-card-record .lab-card-figure-sigil img {
+.lab-card-record .lab-card-figure-sigil {
   max-width: 22rem;
 }
 

--- a/src/components/cards/AnisotaLabCard.jsx
+++ b/src/components/cards/AnisotaLabCard.jsx
@@ -26,6 +26,7 @@ import {
   sigilSvgDataUrl,
   anisotaWorkUrl,
 } from '../../lib/anisotaLab.js';
+import InkblotFigure from './InkblotFigure.jsx';
 
 /** Short, lowercase label for each Lab collection — shown in small caps. */
 const KIND_LABEL = {
@@ -98,17 +99,35 @@ function LabBody({ nsid, value: v }) {
     }
 
     case 'net.anisota.lab.sigil': {
+      // Re-ink the stroke in the page's ink via a CSS mask over a flat fill,
+      // rather than showing the color Anisota baked into the SVG. Pure CSS, so
+      // it tracks the sky palette with no repaint of our own.
       const src = sigilSvgDataUrl(v.svg);
       return src ? (
         <div className="lab-card-figure lab-card-figure-sigil">
-          <img src={src} alt={v.name ? `Sigil: ${v.name}` : 'A sigil'} loading="lazy" />
+          <div
+            className="lab-sigil"
+            role="img"
+            aria-label={v.name ? `Sigil: ${v.name}` : 'A sigil'}
+            style={{ WebkitMaskImage: `url("${src}")`, maskImage: `url("${src}")` }}
+          />
         </div>
       ) : null;
     }
 
-    case 'net.anisota.lab.carving':
     case 'net.anisota.lab.inkblot':
+      // Duotoned per pixel into the live palette (see InkblotFigure); the
+      // `palette` slot picks which theme ramp it's re-inked along.
+      return isDataImage(v.image) ? (
+        <div className="lab-card-figure lab-card-figure-inkblot">
+          <InkblotFigure image={v.image} palette={v.palette} label={altForImage(nsid, v.name)} />
+        </div>
+      ) : null;
+
+    case 'net.anisota.lab.carving':
     case 'net.anisota.lab.petri':
+      // Left with their baked color — these aren't single-ink figures, so the
+      // theme-derived recolor that suits sigils and inkblots doesn't apply.
       return isDataImage(v.image) ? (
         <div className="lab-card-figure">
           <img src={v.image} alt={altForImage(nsid, v.name)} loading="lazy" decoding="async" />

--- a/src/components/cards/InkblotFigure.jsx
+++ b/src/components/cards/InkblotFigure.jsx
@@ -1,0 +1,68 @@
+/**
+ * A baked inkblot PNG, re-inked into the current sky palette. The blot is
+ * drawn to a canvas and duotoned per pixel (see recolorInkblot) so its layered
+ * depth survives while its hue tracks the hour. Because it's a raster — unlike
+ * the sigil, which re-inks in pure CSS via a mask — the recolor is redone in JS
+ * whenever the sky hour, and therefore the palette, changes.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { useTheme } from '../../hooks/useTheme.jsx';
+import { paletteForHour } from '../../lib/skyTheme.js';
+import { inkblotRamp, hexToRgb, recolorInkblot } from '../../lib/anisotaLab.js';
+
+export default function InkblotFigure({ image, palette, label }) {
+  const canvasRef = useRef(null);
+  const { skyDisplayHour } = useTheme();
+
+  // The two ramp stops for this blot's palette slot, resolved to the live
+  // hour's hex. Recomputed only when the hour (hence palette) actually moves.
+  const [denseHex, faintHex] = useMemo(() => {
+    const vars = paletteForHour(skyDisplayHour).vars;
+    return inkblotRamp(palette).map((token) => vars[token]);
+  }, [skyDisplayHour, palette]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const dense = hexToRgb(denseHex);
+    const faint = hexToRgb(faintHex);
+    if (!dense || !faint) return undefined;
+
+    let cancelled = false;
+    const img = new Image();
+    img.onload = () => {
+      if (cancelled) return;
+      const w = img.naturalWidth || 512;
+      const h = img.naturalHeight || 512;
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.clearRect(0, 0, w, h);
+      ctx.drawImage(img, 0, 0, w, h);
+      let id;
+      try {
+        id = ctx.getImageData(0, 0, w, h);
+      } catch {
+        return; // tainted canvas — shouldn't happen for a same-origin data URL
+      }
+      recolorInkblot(id.data, dense, faint);
+      ctx.putImageData(id, 0, 0);
+    };
+    img.src = image;
+    return () => {
+      cancelled = true;
+    };
+  }, [image, denseHex, faintHex]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="lab-inkblot-canvas"
+      width={512}
+      height={512}
+      role="img"
+      aria-label={label}
+    />
+  );
+}

--- a/src/lib/anisotaLab.js
+++ b/src/lib/anisotaLab.js
@@ -177,11 +177,86 @@ export function sanitizeSvgDocument(svg) {
 }
 
 /**
- * A sigil SVG as an <img>-ready data URL (sanitised first). Rendering the SVG
- * through an <img> rather than inline markup keeps it sandboxed — a record
- * can't run script. Returns '' if unrenderable.
+ * A sigil SVG as a data URL (sanitised first), ready for an <img src> or a
+ * CSS mask-image. Going through an image reference rather than inline markup
+ * keeps it sandboxed — a record can't run script. On dame.is the card uses it
+ * as a mask over a flat --ink fill so the one stroke tracks the page's ink
+ * instead of the color Anisota baked into the SVG. Returns '' if unrenderable.
  */
 export function sigilSvgDataUrl(svg) {
   const safe = sanitizeSvgDocument(svg);
   return safe ? 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(safe) : '';
+}
+
+/* ------------------------------------------------------------------ */
+/* Inkblot — re-ink a baked blot into the current theme                */
+/* ------------------------------------------------------------------ */
+
+// Inkblots arrive as a baked PNG: a symmetric blot in whatever color Anisota's
+// live theme gave the piece's `palette` slot when it was made (see the record's
+// `palette` field — 'ink', 'accent-deep', …). To re-ink one in dame.is's
+// current sky palette we can't just flat-fill it: the blot carries internal
+// light↔dark structure (the ink layered at different densities) that gives it
+// depth. So we duotone it — map each pixel's luminance onto a two-stop ramp
+// pulled from the live theme, densest ink → stop A, faintest → stop B. A
+// single-tone blot (no internal range — e.g. a blot baked in a flat white)
+// collapses to a flat stop-A silhouette, which is exactly what it should do.
+
+// Which pair of live --sky-* tokens a blot's `palette` slot maps onto, as
+// [dense, faint]. Anything unrecognised falls back to the ink ramp — the
+// blot's namesake, and the slot four of every five blots in the wild use.
+export const INKBLOT_RAMPS = {
+  ink: ['--sky-ink', '--sky-ink-muted'],
+  accent: ['--sky-accent', '--sky-accent-soft'],
+  'accent-deep': ['--sky-accent', '--sky-accent-soft'],
+  'accent-soft': ['--sky-accent', '--sky-accent-soft'],
+  tan: ['--sky-tan', '--sky-accent-soft'],
+};
+
+/** The [denseToken, faintToken] --sky-* ramp for a blot's `palette` slot. */
+export function inkblotRamp(palette) {
+  return INKBLOT_RAMPS[palette] || INKBLOT_RAMPS.ink;
+}
+
+/** Parse a `#rgb` / `#rrggbb` hex to `[r, g, b]` (0–255); null on anything else. */
+export function hexToRgb(hex) {
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(String(hex || '').trim());
+  if (!m) return null;
+  const h = m[1].length === 3 ? m[1].replace(/./g, (c) => c + c) : m[1];
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+// Rec. 709 luma, matching the weighting skyTheme.js's own palette math uses.
+function luma(r, g, b) {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Duotone a decoded inkblot in place. `data` is an RGBA byte array (a canvas
+ * ImageData.data); `dense` and `faint` are the ramp's two [r, g, b] stops.
+ * Fully transparent pixels are left untouched; every visible pixel is re-inked
+ * by where its luminance falls in the blot's own min→max range (normalised per
+ * blot, so even a faint original spans the full ramp). Alpha is preserved, so
+ * the blot's anti-aliased edges survive the recolor.
+ */
+export function recolorInkblot(data, dense, faint) {
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i + 3] === 0) continue;
+    const y = luma(data[i], data[i + 1], data[i + 2]);
+    if (y < lo) lo = y;
+    if (y > hi) hi = y;
+  }
+  if (hi < lo) return; // fully transparent — nothing to re-ink
+  const range = hi - lo || 1; // flat blot → every pixel lands on `dense`
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i + 3] === 0) continue;
+    let t = (luma(data[i], data[i + 1], data[i + 2]) - lo) / range;
+    t = t < 0 ? 0 : t > 1 ? 1 : t;
+    data[i] = Math.round(dense[0] + (faint[0] - dense[0]) * t);
+    data[i + 1] = Math.round(dense[1] + (faint[1] - dense[1]) * t);
+    data[i + 2] = Math.round(dense[2] + (faint[2] - dense[2]) * t);
+  }
 }

--- a/src/lib/anisotaLab.test.js
+++ b/src/lib/anisotaLab.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { inkblotRamp, hexToRgb, recolorInkblot } from './anisotaLab.js';
+
+describe('hexToRgb', () => {
+  it('parses #rrggbb', () => {
+    expect(hexToRgb('#1d2419')).toEqual([29, 36, 25]);
+  });
+  it('expands #rgb shorthand', () => {
+    expect(hexToRgb('#abc')).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+  it('is case- and whitespace-insensitive', () => {
+    expect(hexToRgb('  #FFFFFF ')).toEqual([255, 255, 255]);
+  });
+  it('rejects non-hex', () => {
+    expect(hexToRgb('rgb(1,2,3)')).toBeNull();
+    expect(hexToRgb('')).toBeNull();
+    expect(hexToRgb(null)).toBeNull();
+  });
+});
+
+describe('inkblotRamp', () => {
+  it('maps the ink slot to the ink ramp', () => {
+    expect(inkblotRamp('ink')).toEqual(['--sky-ink', '--sky-ink-muted']);
+  });
+  it('maps accent slots to the accent ramp', () => {
+    expect(inkblotRamp('accent-deep')).toEqual(['--sky-accent', '--sky-accent-soft']);
+  });
+  it('falls back to the ink ramp for unknown / missing slots', () => {
+    expect(inkblotRamp('mystery')).toEqual(['--sky-ink', '--sky-ink-muted']);
+    expect(inkblotRamp(undefined)).toEqual(['--sky-ink', '--sky-ink-muted']);
+  });
+});
+
+describe('recolorInkblot', () => {
+  const DENSE = [10, 20, 30];
+  const FAINT = [200, 210, 220];
+
+  // Build an RGBA buffer from [r,g,b,a] tuples.
+  const buf = (...px) => new Uint8ClampedArray(px.flat());
+
+  it('leaves fully transparent pixels untouched', () => {
+    const data = buf([123, 45, 67, 0]);
+    recolorInkblot(data, DENSE, FAINT);
+    expect([...data]).toEqual([123, 45, 67, 0]);
+  });
+
+  it('collapses a single-tone blot onto the dense stop', () => {
+    // Every visible pixel shares one luminance → all land on `dense`.
+    const data = buf([255, 255, 255, 255], [255, 255, 255, 128], [0, 0, 0, 0]);
+    recolorInkblot(data, DENSE, FAINT);
+    expect([...data.slice(0, 3)]).toEqual(DENSE);
+    expect([...data.slice(4, 7)]).toEqual(DENSE); // recolor ignores alpha level
+    expect(data[7]).toBe(128); // ...but preserves it
+    expect([...data.slice(8, 12)]).toEqual([0, 0, 0, 0]); // transparent untouched
+  });
+
+  it('maps the darkest visible pixel to dense and the lightest to faint', () => {
+    const data = buf([0, 0, 0, 255], [255, 255, 255, 255]);
+    recolorInkblot(data, DENSE, FAINT);
+    expect([...data.slice(0, 3)]).toEqual(DENSE);
+    expect([...data.slice(4, 7)]).toEqual(FAINT);
+  });
+
+  it('places a mid-luminance pixel between the stops', () => {
+    const data = buf([0, 0, 0, 255], [128, 128, 128, 255], [255, 255, 255, 255]);
+    recolorInkblot(data, DENSE, FAINT);
+    const mid = [...data.slice(4, 7)];
+    mid.forEach((c, k) => {
+      expect(c).toBeGreaterThan(DENSE[k]);
+      expect(c).toBeLessThan(FAINT[k]);
+    });
+  });
+
+  it('always preserves the alpha channel', () => {
+    const data = buf([40, 60, 80, 255], [40, 60, 80, 90], [40, 60, 80, 12]);
+    recolorInkblot(data, DENSE, FAINT);
+    expect([data[3], data[7], data[11]]).toEqual([255, 90, 12]);
+  });
+});

--- a/src/lib/feedBuilder.js
+++ b/src/lib/feedBuilder.js
@@ -351,7 +351,7 @@ export function transformRecords(records, nsid, pds, did = ME_DID, opts = {}) {
   // AnisotaLabCard only needs the finished text / tiles / figure / print. Drop
   // the reopen-the-studio payloads so they don't bloat the unified feed. What
   // the card renders (name, text, tiles+board, redacted+original, image, svg,
-  // description, tempo/steps/scale) is kept.
+  // palette, description, tempo/steps/scale) is kept.
   if (ANISOTA_LAB_HEAVY_FIELDS[nsid]) {
     for (const r of records) {
       const v = r?.value;


### PR DESCRIPTION
Anisota Lab sigils and inkblots rendered with the colors Anisota's own theme baked in at creation — an orange sigil stroke, a blot in whatever its `palette` slot resolved to that moment. On dame.is that read as off-palette, and some blots (a flat white one baked in Anisota's dark mode) all but vanished on a light sky page. This derives their colors from the live sky palette instead.

## Changes

- **Sigil** — render the stroke SVG as a CSS `mask` over a flat `var(--ink)` fill rather than an `<img>`, so the one line is drawn in the page's ink and tracks the palette with no repaint of ours. Still sandboxed — a mask image can't run script, same as the old `<img>`. (Swap `.lab-sigil`'s `background-color` to `var(--accent)` for a sky-tinted stroke instead.)
- **Inkblot** — a raster, so recolor it per pixel on a canvas (`InkblotFigure`). The blot carries internal light↔dark structure (ink layered at different densities), so a flat tint would flatten its depth — duotone it instead, mapping each pixel's luminance onto a two-stop ramp chosen from the record's `palette` slot (`ink` → ink ramp, `accent-deep` → accent ramp). Multi-tone blots keep their cloudy texture in the theme's hue; a single-tone blot collapses to a flat, legible silhouette. Re-runs when the sky hour changes.
- Recolor math (ramp lookup, hex parse, duotone) lives in `anisotaLab.js` with unit tests.
- Carvings and petri cultures are left with their baked color — they aren't single-ink figures, so the recolor doesn't apply.

## Verification

- `vitest run` — 72 tests pass (12 new for the recolor helpers)
- `eslint` clean on changed files; `vite build` succeeds
- Rendering confirmed in Chromium across four sky hours: colors track the theme, and the sigil + flat blot correctly invert to light ink on dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174v1PR3We9xxyDgABcWtet

---
_Generated by [Claude Code](https://claude.ai/code/session_0174v1PR3We9xxyDgABcWtet)_