### PR TITLE
Preview sigils and inkblots in the home feed ledger

### DIFF
--- a/src/components/Feed.css
+++ b/src/components/Feed.css
@@ -1778,6 +1778,46 @@ a.ledger-verb:focus-visible {
   align-items: center;
 }
 
+/* Crafting rows (Anisota Lab sigils + inkblots) preview as a small themed
+   figure beside the title — the sigil re-inked through a mask, the inkblot
+   duotoned on a canvas — mirroring the observation thumbnail above. */
+.ledger-craft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.ledger-craft .ledger-text {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.ledger-craft-thumb {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 2px;
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius-2);
+  background: var(--page);
+}
+
+/* The sigil mask and inkblot canvas each fill the thumb's content box. The
+   card's .lab-inkblot-canvas rules are scoped to .lab-card-figure, so the
+   ledger's canvas needs its own box sizing here. */
+.ledger-craft-thumb .lab-sigil,
+.ledger-craft-thumb .lab-inkblot-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Center the verb/time labels against the taller thumbnail row, like obs. */
+.feed-ledger .feed-item-ledger:has(.ledger-craft) {
+  align-items: center;
+}
+
 /* Listening sessions: tapping the row (or its "N songs +" toggle, the
    keyboard-accessible affordance) expands the batch into one sub-row
    per track. */

--- a/src/components/FeedLedgerRow.jsx
+++ b/src/components/FeedLedgerRow.jsx
@@ -6,6 +6,9 @@ import { renderPlainTextWithTruncatedUrls } from '../lib/feedUrlFormat.jsx';
 import { getReplyHint } from '../lib/postReplyHint.js';
 import { recordPathFromAtUri } from '../lib/recordRoutes.js';
 import { photoUrl } from '../lib/inaturalist.js';
+import { nsidFromAtUri } from '../lib/verbRegistry.js';
+import { sigilSvgDataUrl } from '../lib/anisotaLab.js';
+import InkblotFigure from './cards/InkblotFigure.jsx';
 import PostEmbed from './PostEmbed.jsx';
 import RelativeTimeText from './RelativeTimeText.jsx';
 import { ME_DID } from '../config.js';
@@ -47,6 +50,20 @@ const LEDGER_VERB_LABELS = {
   logging: 'dame.is',
 };
 
+/* A nameless Anisota Lab piece falls back to what it *is* rather than the
+   generic "a lab piece" — the ledger cousin of the card's kind label, and of
+   the observation rows' "an unidentified moth". */
+const CRAFT_KIND_FALLBACK = {
+  'net.anisota.lab.poetry': 'a poem',
+  'net.anisota.lab.redaction': 'an erasure poem',
+  'net.anisota.lab.sigil': 'a sigil',
+  'net.anisota.lab.carving': 'a carving',
+  'net.anisota.lab.inkblot': 'an inkblot',
+  'net.anisota.lab.petri': 'a culture',
+  'net.anisota.lab.synth': 'a synth',
+  'net.anisota.spell.custom': 'a spell',
+};
+
 export default function FeedLedgerRow({ item, href, expanded = false, onToggle = null }) {
   const replyHint = item.verb === 'posting' ? getReplyHint(item.payload) : null;
   const threadContinuation = item.verb === 'posting' && item._thread?.continuesPrev;
@@ -66,6 +83,10 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
   // Blog entries render title + a muted summary line beneath (BlogLedgerBody)
   // rather than the single-line title summary.
   const isBlog = item.verb === 'blogging';
+  // Anisota Lab sigils + inkblots preview as a small themed thumbnail beside
+  // their title (the way observations show a specimen thumb); other crafting
+  // verbs — poems, erasures, spells — keep the plain title summary alone.
+  const craftThumb = item.verb === 'crafting' ? craftingThumb(item) : null;
   const summary =
     isRepost || isObservation || isBlog ? null : summarize(item, { expanded, onToggle });
   const embed = isRepost ? null : ledgerEmbed(item);
@@ -96,7 +117,14 @@ export default function FeedLedgerRow({ item, href, expanded = false, onToggle =
         {isRepost && <RepostQuote item={item} />}
         {isObservation && <ObservationLedgerBody item={item} />}
         {isBlog && <BlogLedgerBody item={item} />}
-        {summary && <p className="ledger-text">{summary}</p>}
+        {craftThumb ? (
+          <div className="ledger-craft">
+            {craftThumb}
+            {summary && <p className="ledger-text">{summary}</p>}
+          </div>
+        ) : (
+          summary && <p className="ledger-text">{summary}</p>
+        )}
         {embed && (
           <div className="ledger-embed">
             <PostEmbed embed={embed.embed} did={embed.did} />
@@ -255,8 +283,12 @@ function summarize(item, listenControls) {
       return plain(payload.text || payload.body || payload.content, 'a comment');
     case 'crafting':
       // Anisota Lab piece — lead with its title, else a poem/erasure's text,
-      // else a spell's description; falls back to a generic placeholder.
-      return plain(payload.name || payload.text || payload.description, 'a lab piece');
+      // else a spell's description; falls back to the kind (a sigil, an
+      // inkblot, …) so a nameless piece still reads as what it is.
+      return plain(
+        payload.name || payload.text || payload.description,
+        CRAFT_KIND_FALLBACK[nsidFromAtUri(item.atUri)] || 'a lab piece',
+      );
     default:
       return <Placeholder>a record</Placeholder>;
   }
@@ -438,6 +470,46 @@ function ObservationLedgerBody({ item }) {
       </span>
     </div>
   );
+}
+
+/**
+ * A crafting row's preview thumbnail — a small themed figure set beside the
+ * title, mirroring how observations lead with a specimen thumb. Only the
+ * figure-shaped Lab pieces get one: a sigil (its stroke SVG re-inked via a CSS
+ * mask, exactly like the card) or an inkblot (duotoned into the palette by
+ * InkblotFigure). Every other crafting verb — poems, erasures, spells —
+ * returns null and keeps the plain title summary. Null too when the media
+ * itself is absent: the static snapshot ships Lab pieces without their
+ * svg/image, and the live feed fills them back in, just as the cards do.
+ */
+function craftingThumb(item) {
+  const nsid = nsidFromAtUri(item.atUri);
+  const payload = item.payload || {};
+  if (nsid === 'net.anisota.lab.sigil') {
+    const src = sigilSvgDataUrl(payload.svg);
+    if (!src) return null;
+    return (
+      <span className="ledger-craft-thumb" aria-hidden="true">
+        <span
+          className="lab-sigil"
+          style={{ WebkitMaskImage: `url("${src}")`, maskImage: `url("${src}")` }}
+        />
+      </span>
+    );
+  }
+  if (nsid === 'net.anisota.lab.inkblot' && isDataImage(payload.image)) {
+    return (
+      <span className="ledger-craft-thumb" aria-hidden="true">
+        <InkblotFigure image={payload.image} palette={payload.palette} label="" />
+      </span>
+    );
+  }
+  return null;
+}
+
+/** Only self-contained data-URL images are renderable (mirrors AnisotaLabCard). */
+function isDataImage(image) {
+  return typeof image === 'string' && image.startsWith('data:image/');
 }
 
 /**


### PR DESCRIPTION
Follow-up to #318. In the ledger layout, `crafting` rows showed only the piece's title — you had to open the record to see the actual sigil or inkblot. This gives the figure-shaped Lab pieces a small themed thumbnail beside their title, the way observation rows lead with a specimen thumb.

## Changes

- **Ledger thumbnail** — `FeedLedgerRow` now renders a preview for sigil and inkblot crafting rows. The sigil re-inks through the same CSS mask the card uses; the inkblot reuses `InkblotFigure`, so both track the sky palette. Other crafting verbs (poems, erasures, spells) have no figure and keep the title-only summary.
- **Graceful when media is absent** — the thumbnail is null when `svg`/`image` isn't present, so the row degrades to text. The static feed snapshot ships Lab pieces without their media and the live feed fills it in — same as the cards layout.
- **Kind-specific fallback** — a nameless Lab piece now reads as its kind (`a sigil`, `an inkblot`, …) instead of the generic `a lab piece`, mirroring the observation rows' `an unidentified moth`.
- CSS mirrors the existing `.ledger-obs` thumbnail (2.25rem framed box, row centered via `:has()`), with the ledger canvas given its own box sizing since the card's `.lab-inkblot-canvas` rules are scoped to `.lab-card-figure`.

## Verification

- `vitest run` — 72 tests pass; `eslint` clean; `vite build` succeeds
- Rendering confirmed in Chromium against the real ledger grid + live records: thumbnails track the theme (dark ink at 1PM, light/purple at 10PM), and non-crafting rows are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174v1PR3We9xxyDgABcWtet

---
_Generated by [Claude Code](https://claude.ai/code/session_0174v1PR3We9xxyDgABcWtet)_