### PR TITLE
Fix gallery lightbox crash; make gallery layout explicit in the editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
         "sharp": "^0.35.3",
         "vite": "^6.4.2",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {

--- a/src/components/LeafletDocument.css
+++ b/src/components/LeafletDocument.css
@@ -280,8 +280,9 @@ ul.leaflet-list ul.leaflet-list ul.leaflet-list {
 
 /* Gallery — a run of adjacent image blocks laid out as one unit rather than a
    tall stack. `data-layout` is the author's choice from the blocks editor
-   (LeafletDocument's GALLERY_LAYOUTS); `auto` is the default and picks its
-   column count from `data-count`. */
+   (LeafletDocument's GALLERY_LAYOUTS). Column counts hold at every width: the
+   author picked a shape, and a breakpoint quietly rewriting it is what made the
+   old count-derived layout unpredictable. Two-up is the default. */
 .leaflet-gallery {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -293,11 +294,8 @@ ul.leaflet-list ul.leaflet-list ul.leaflet-list {
   margin: 0;
 }
 
-/* Auto: counts that divide by three read better three-up. */
-.leaflet-gallery[data-layout="auto"][data-count="3"],
-.leaflet-gallery[data-layout="auto"][data-count="5"],
-.leaflet-gallery[data-layout="auto"][data-count="6"] {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.leaflet-gallery[data-layout="one-up"] {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .leaflet-gallery[data-layout="two-up"] {
@@ -331,17 +329,11 @@ ul.leaflet-list ul.leaflet-list ul.leaflet-list {
 }
 
 @media (max-width: 34rem) {
-  /* Auto galleries fall to a single column on a phone; an explicit multi-column
-     choice clamps to two rather than collapsing, so the author's shape holds.
-     `[data-count]` is here to match the specificity of the count-based rule
-     above — without it that rule outweighs this one and nothing collapses. */
-  .leaflet-gallery[data-layout="auto"][data-count] {
-    grid-template-columns: 1fr;
-  }
-
-  .leaflet-gallery[data-layout="three-up"],
-  .leaflet-gallery[data-layout="four-up"] {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  /* Column counts are deliberately NOT collapsed here — see the note above.
+     Only the gap tightens, so three or four across stays legible on a phone
+     instead of losing most of each frame to gutters. */
+  .leaflet-gallery {
+    gap: var(--space-2);
   }
 
   .leaflet-gallery[data-layout="filmstrip"] .leaflet-image {

--- a/src/components/LeafletDocument.css
+++ b/src/components/LeafletDocument.css
@@ -278,8 +278,10 @@ ul.leaflet-list ul.leaflet-list ul.leaflet-list {
   overflow-wrap: anywhere;
 }
 
-/* Gallery — a run of consecutive image blocks laid out as a grid so a photo
-   set reads as one unit. Two-up by default; single images keep full width. */
+/* Gallery — a run of adjacent image blocks laid out as one unit rather than a
+   tall stack. `data-layout` is the author's choice from the blocks editor
+   (LeafletDocument's GALLERY_LAYOUTS); `auto` is the default and picks its
+   column count from `data-count`. */
 .leaflet-gallery {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -291,15 +293,59 @@ ul.leaflet-list ul.leaflet-list ul.leaflet-list {
   margin: 0;
 }
 
-.leaflet-gallery[data-count="3"],
-.leaflet-gallery[data-count="5"],
-.leaflet-gallery[data-count="6"] {
+/* Auto: counts that divide by three read better three-up. */
+.leaflet-gallery[data-layout="auto"][data-count="3"],
+.leaflet-gallery[data-layout="auto"][data-count="5"],
+.leaflet-gallery[data-layout="auto"][data-count="6"] {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.leaflet-gallery[data-layout="two-up"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.leaflet-gallery[data-layout="three-up"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.leaflet-gallery[data-layout="four-up"] {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+/* Filmstrip: one row that scrolls sideways, each frame snapping into place.
+   Sized off the container so roughly two and a half frames peek in, which is
+   what tells the reader there's more to swipe to. */
+.leaflet-gallery[data-layout="filmstrip"] {
+  display: flex;
+  grid-template-columns: none;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-inline: var(--space-1);
+  padding-bottom: var(--space-2);
+}
+
+.leaflet-gallery[data-layout="filmstrip"] .leaflet-image {
+  flex: 0 0 min(40%, 18rem);
+  scroll-snap-align: start;
+}
+
 @media (max-width: 34rem) {
-  .leaflet-gallery {
+  /* Auto galleries fall to a single column on a phone; an explicit multi-column
+     choice clamps to two rather than collapsing, so the author's shape holds.
+     `[data-count]` is here to match the specificity of the count-based rule
+     above — without it that rule outweighs this one and nothing collapses. */
+  .leaflet-gallery[data-layout="auto"][data-count] {
     grid-template-columns: 1fr;
+  }
+
+  .leaflet-gallery[data-layout="three-up"],
+  .leaflet-gallery[data-layout="four-up"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .leaflet-gallery[data-layout="filmstrip"] .leaflet-image {
+    flex-basis: min(72%, 15rem);
   }
 }
 

--- a/src/components/LeafletDocument.jsx
+++ b/src/components/LeafletDocument.jsx
@@ -110,24 +110,32 @@ export const IMAGE_BLOCK_TYPE = 'pub.leaflet.blocks.image';
  * sit back to back, and `standalone` opts an image out of grouping entirely
  * (each renders full width, exactly as a lone image block does).
  *
- * `auto` (the default, and what an absent field means) keeps the original
- * behavior: the column count follows the number of images, chosen in CSS off
- * `data-count`.
+ * A column choice is honored at EVERY width — 3 across stays 3 across on a
+ * phone. Galleries used to guess their columns from the image count and had a
+ * narrow-screen collapse that (through a CSS specificity accident) never fired,
+ * so what published was hard to predict from the editor. An explicit count that
+ * doesn't change under you is the point of the control.
  */
+export const GALLERY_DEFAULT_LAYOUT = 'two-up';
+
 export const GALLERY_LAYOUTS = [
-  { value: 'auto', label: 'Auto grid', hint: 'Columns follow the image count' },
-  { value: 'two-up', label: '2 across', hint: 'Two columns at every width' },
-  { value: 'three-up', label: '3 across', hint: 'Three columns; two on narrow screens' },
-  { value: 'four-up', label: '4 across', hint: 'Four columns; two on narrow screens' },
+  { value: 'one-up', label: '1 across', hint: 'A single tight column' },
+  { value: 'two-up', label: '2 across', hint: 'Two columns at every width (default)' },
+  { value: 'three-up', label: '3 across', hint: 'Three columns at every width' },
+  { value: 'four-up', label: '4 across', hint: 'Four columns — small on a phone' },
   { value: 'filmstrip', label: 'Filmstrip', hint: 'One row that scrolls sideways' },
   { value: 'standalone', label: 'Separate images', hint: 'No grouping — full-width, stacked' },
 ];
 
 const GALLERY_LAYOUT_VALUES = new Set(GALLERY_LAYOUTS.map((l) => l.value));
 
-/** The effective layout of an image block; anything unrecognized reads as auto. */
+/**
+ * The effective layout of an image block. An absent field — every image block
+ * written before this control existed — reads as the default, so old documents
+ * publish as a plain two-up grid rather than something count-dependent.
+ */
 export function galleryLayoutOf(block) {
-  return GALLERY_LAYOUT_VALUES.has(block?.gallery) ? block.gallery : 'auto';
+  return GALLERY_LAYOUT_VALUES.has(block?.gallery) ? block.gallery : GALLERY_DEFAULT_LAYOUT;
 }
 
 /**

--- a/src/components/LeafletDocument.jsx
+++ b/src/components/LeafletDocument.jsx
@@ -99,34 +99,98 @@ export default function LeafletDocument({ doc }) {
   );
 }
 
+export const IMAGE_BLOCK_TYPE = 'pub.leaflet.blocks.image';
+
+/**
+ * Gallery layout — a dame.is rendering extension stored as `gallery` on each
+ * image block, in the same family as `indent` / `spaceTop` / `spaceBottom`.
+ *
+ * Adjacent image blocks group into one gallery, and they group only with
+ * neighbours carrying the SAME value — so two differently-shaped galleries can
+ * sit back to back, and `standalone` opts an image out of grouping entirely
+ * (each renders full width, exactly as a lone image block does).
+ *
+ * `auto` (the default, and what an absent field means) keeps the original
+ * behavior: the column count follows the number of images, chosen in CSS off
+ * `data-count`.
+ */
+export const GALLERY_LAYOUTS = [
+  { value: 'auto', label: 'Auto grid', hint: 'Columns follow the image count' },
+  { value: 'two-up', label: '2 across', hint: 'Two columns at every width' },
+  { value: 'three-up', label: '3 across', hint: 'Three columns; two on narrow screens' },
+  { value: 'four-up', label: '4 across', hint: 'Four columns; two on narrow screens' },
+  { value: 'filmstrip', label: 'Filmstrip', hint: 'One row that scrolls sideways' },
+  { value: 'standalone', label: 'Separate images', hint: 'No grouping — full-width, stacked' },
+];
+
+const GALLERY_LAYOUT_VALUES = new Set(GALLERY_LAYOUTS.map((l) => l.value));
+
+/** The effective layout of an image block; anything unrecognized reads as auto. */
+export function galleryLayoutOf(block) {
+  return GALLERY_LAYOUT_VALUES.has(block?.gallery) ? block.gallery : 'auto';
+}
+
+/**
+ * Split a page's blocks into gallery runs: maximal spans of adjacent image
+ * blocks that share one layout. Shared with the admin blocks editor so the
+ * editor's grouping is the published grouping, not a second guess at it.
+ *
+ * Returns `[{ start, end, size, layout }]` for every run of two or more —
+ * including `standalone` runs, which the editor surfaces as "not grouped" but
+ * the renderer emits as individual images.
+ */
+export function galleryRuns(blocks) {
+  const list = Array.isArray(blocks) ? blocks : [];
+  const runs = [];
+  let i = 0;
+  while (i < list.length) {
+    if (list[i]?.block?.$type !== IMAGE_BLOCK_TYPE) {
+      i += 1;
+      continue;
+    }
+    const layout = galleryLayoutOf(list[i].block);
+    let j = i;
+    while (
+      j < list.length &&
+      list[j]?.block?.$type === IMAGE_BLOCK_TYPE &&
+      galleryLayoutOf(list[j].block) === layout
+    ) {
+      j += 1;
+    }
+    if (j - i >= 2) runs.push({ start: i, end: j - 1, size: j - i, layout });
+    i = j;
+  }
+  return runs;
+}
+
 function LeafletPage({ page }) {
   const blocks = Array.isArray(page?.blocks) ? page.blocks : [];
   const out = [];
+  const runStarts = new Map();
+  for (const run of galleryRuns(blocks)) runStarts.set(run.start, run);
   let i = 0;
   while (i < blocks.length) {
-    const block = blocks[i]?.block;
-    // Collapse a run of consecutive image blocks into a gallery grid so a
-    // photo set reads as one unit instead of a tall stack.
-    if (block?.$type === 'pub.leaflet.blocks.image') {
-      const run = [];
-      while (i < blocks.length && blocks[i]?.block?.$type === 'pub.leaflet.blocks.image') {
-        run.push(blocks[i].block);
-        i += 1;
-      }
-      if (run.length >= 2) {
-        out.push(
-          <div className="leaflet-gallery" data-count={run.length} key={`g-${i}`}>
-            {run.map((b, j) => (
-              <LeafletBlock key={j} block={b} />
-            ))}
-          </div>,
-        );
-      } else {
-        out.push(<LeafletBlock key={`b-${i}`} block={run[0]} />);
-      }
+    // Collapse a run of adjacent image blocks into a gallery so a photo set
+    // reads as one unit instead of a tall stack. `standalone` runs skip the
+    // wrapper and fall through to the per-block path below.
+    const run = runStarts.get(i);
+    if (run && run.layout !== 'standalone') {
+      out.push(
+        <div
+          className="leaflet-gallery"
+          data-count={run.size}
+          data-layout={run.layout}
+          key={`g-${i}`}
+        >
+          {blocks.slice(run.start, run.end + 1).map((wrap, j) => (
+            <LeafletBlock key={j} block={wrap?.block} />
+          ))}
+        </div>,
+      );
+      i = run.end + 1;
       continue;
     }
-    out.push(<LeafletBlock key={`b-${i}`} block={block} />);
+    out.push(<LeafletBlock key={`b-${i}`} block={blocks[i]?.block} />);
     i += 1;
   }
   return <Fragment>{out}</Fragment>;

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -35,8 +35,22 @@ export default function Lightbox({ open, onClose, images, index = 0 }) {
   // the dialog's DOM subtree. Handing this ref to the Modal's focus trap keeps
   // the controls inside the lightbox's Tab cycle even from there.
   const controlsRef = useRef(null);
+  // The set of already-painted sources is mirrored in a ref so `markLoaded`
+  // can bail BEFORE enqueueing an update. That guard has to live outside the
+  // state updater: the `ref` callback below is an inline closure, so React
+  // detaches and re-attaches it on every render, and a cached image reports
+  // `complete` synchronously at attach time (WebKit does this reliably) — so
+  // an updater-only guard enqueues one update per render forever. Because each
+  // pass rebuilds the queue from the base state and returns a *fresh* Set, no
+  // two passes are `Object.is`-equal, React never bails out, and the cascade
+  // dies as "Maximum update depth exceeded" instead. Guarding here means a
+  // known-loaded src enqueues nothing at all.
+  const loadedRef = useRef(loadedSrcs);
   const markLoaded = useCallback((src) => {
-    setLoadedSrcs((prev) => (prev.has(src) ? prev : new Set(prev).add(src)));
+    if (!src || loadedRef.current.has(src)) return;
+    const next = new Set(loadedRef.current).add(src);
+    loadedRef.current = next;
+    setLoadedSrcs(next);
   }, []);
 
   // Sync external index changes (e.g. opening to a different starting

--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import TextBlockEditor from './TextBlockEditor.jsx';
 import HeadingBlockEditor from './HeadingBlockEditor.jsx';
 import ImageBlockEditor, { uploadImageFile } from './ImageBlockEditor.jsx';
@@ -6,7 +6,13 @@ import WebsiteBlockEditor from './WebsiteBlockEditor.jsx';
 import CodeBlockEditor from './CodeBlockEditor.jsx';
 import ListBlockEditor from './ListBlockEditor.jsx';
 import BskyPostBlockEditor from './BskyPostBlockEditor.jsx';
-import { LeafletBlock } from '../LeafletDocument.jsx';
+import {
+  GALLERY_LAYOUTS,
+  IMAGE_BLOCK_TYPE,
+  LeafletBlock,
+  galleryLayoutOf,
+  galleryRuns,
+} from '../LeafletDocument.jsx';
 import './blocks.css';
 
 const WRAPPER_TYPE = 'pub.leaflet.pages.linearDocument#block';
@@ -162,6 +168,27 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
     [blocks, commit],
   );
 
+  // Set the gallery layout across a span of image blocks. Every member of a run
+  // carries the same value — that's what holds the run together (see
+  // galleryRuns) — so changing one image's layout has to move its whole run,
+  // otherwise the run would silently split in two.
+  const setGalleryLayout = useCallback(
+    (start, end, value) => {
+      const next = blocks.slice();
+      for (let k = start; k <= end; k += 1) {
+        const block = next[k]?.block;
+        if (block?.$type !== IMAGE_BLOCK_TYPE) continue;
+        const updated = { ...block };
+        // `auto` is the absent-field default; don't write it out.
+        if (value === 'auto') delete updated.gallery;
+        else updated.gallery = value;
+        next[k] = { $type: WRAPPER_TYPE, block: updated };
+      }
+      commit(next, { kind: 'structural' });
+    },
+    [blocks, commit],
+  );
+
   const moveBlock = useCallback(
     (index, dir) => {
       const target = index + dir;
@@ -271,6 +298,17 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
     focusFirstField(activeItemRef.current);
   }, [activeIndex, activeType]);
 
+  // Which run (if any) each block index belongs to, so a row can draw itself as
+  // part of a gallery instead of as a lone image. Same function the renderer
+  // uses, so what the editor brackets is exactly what publishes as one unit.
+  const runByIndex = useMemo(() => {
+    const map = new Map();
+    for (const run of galleryRuns(blocks)) {
+      for (let k = run.start; k <= run.end; k += 1) map.set(k, run);
+    }
+    return map;
+  }, [blocks]);
+
   const handleRootKeyDown = useCallback(
     (e) => {
       if (e.key === 'Escape' && openInsertSlot != null) {
@@ -329,6 +367,8 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
             i === blocks.length - 1 &&
             dropIndex === blocks.length &&
             dropIndex !== dragIndex + 1;
+          const run = runByIndex.get(i) || null;
+          const grouped = !!run && run.layout !== 'standalone';
           const cls = [
             'blocks-editor-item',
             isActive ? 'is-active' : 'is-preview',
@@ -336,18 +376,33 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
             openInsertSlot === i ? 'has-insert-open' : '',
             showBefore ? 'drop-before' : '',
             showAfter ? 'drop-after' : '',
+            run ? 'is-run-member' : '',
+            grouped ? 'is-gallery-member' : '',
+            run && run.start === i ? 'is-run-first' : '',
+            run && run.end === i ? 'is-run-last' : '',
           ]
             .filter(Boolean)
             .join(' ');
 
           return (
+            <Fragment key={i}>
+            {run && run.start === i && (
+              <GalleryBand
+                run={run}
+                onChangeLayout={(value) => setGalleryLayout(run.start, run.end, value)}
+              />
+            )}
             <li
-              key={i}
               ref={isActive ? activeItemRef : null}
               className={cls}
               onDragOver={(e) => handleDragOver(e, i)}
               onDrop={(e) => handleDrop(e, i)}
             >
+              {run && (
+                <span className="blocks-editor-run-index gutter" aria-hidden="true">
+                  {i - run.start + 1}
+                </span>
+              )}
               {dragIndex == null && (
                 <InsertSlot
                   index={i}
@@ -424,7 +479,14 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
                     onSetCover={onSetCover}
                     onPasteBlocks={(payload) => pasteBlocksAt(i, payload)}
                   />
-                  <BlockLayoutControls block={block} onChange={(next) => updateBlock(i, next)} />
+                  <BlockLayoutControls
+                    block={block}
+                    onChange={(next) => updateBlock(i, next)}
+                    galleryRun={run}
+                    onChangeGallery={(value) =>
+                      setGalleryLayout(run ? run.start : i, run ? run.end : i, value)
+                    }
+                  />
                 </div>
               ) : (
                 <div
@@ -458,6 +520,7 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
                 ✕
               </button>
             </li>
+            </Fragment>
           );
         })}
       </ol>
@@ -501,15 +564,58 @@ function BlockBody({ block, agent, did, onChange, onSetCover, onPasteBlocks }) {
 }
 
 /**
- * Per-block layout controls under the active block's editor: indent (text
- * paragraphs only) plus extra space above / below any block, so an author can
- * shape spacing without inserting empty spacer blocks. Values are stored on the
- * block (`indent`, `spaceTop`, `spaceBottom`) and read by the renderer (see
- * LeafletDocument's blockLayoutStyle). Absent = the default: stacked paragraphs
- * auto-indent, and there's no extra space.
+ * Header for a run of adjacent image blocks. The published document lays those
+ * out as one gallery (or, for `standalone`, deliberately doesn't), and nothing
+ * in a flat list of image rows said so — this band names the group, counts it,
+ * and carries the one control that shapes the whole run. Ungrouping is just
+ * another option in the same select, so it's reversible from the same place.
  */
-function BlockLayoutControls({ block, onChange }) {
+function GalleryBand({ run, onChangeLayout }) {
+  const separate = run.layout === 'standalone';
+  const current = GALLERY_LAYOUTS.find((l) => l.value === run.layout);
+  return (
+    <li className={`blocks-editor-gallery-band${separate ? ' is-separate' : ''}`}>
+      <span className="blocks-editor-gallery-title small-caps">
+        {separate ? 'Separate images' : 'Gallery'}
+      </span>
+      <span className="blocks-editor-gallery-count gutter">
+        {run.size} {separate ? 'adjacent images' : 'images'}
+      </span>
+      <label className="blocks-editor-gallery-field">
+        <span className="small-caps">Layout</span>
+        <select
+          className="block-layout-select"
+          value={run.layout}
+          onChange={(e) => onChangeLayout(e.target.value)}
+          title={current?.hint}
+        >
+          {GALLERY_LAYOUTS.map((l) => (
+            <option key={l.value} value={l.value}>
+              {l.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {current?.hint && (
+        <span className="blocks-editor-gallery-hint gutter">{current.hint}</span>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Per-block layout controls under the active block's editor: indent (text
+ * paragraphs only), gallery layout (image blocks), plus extra space above /
+ * below any block, so an author can shape spacing without inserting empty
+ * spacer blocks. Values are stored on the block (`indent`, `gallery`,
+ * `spaceTop`, `spaceBottom`) and read by the renderer (see LeafletDocument's
+ * blockLayoutStyle and galleryRuns). Absent = the default: stacked paragraphs
+ * auto-indent, adjacent images group into an auto grid, and there's no extra
+ * space.
+ */
+function BlockLayoutControls({ block, onChange, galleryRun = null, onChangeGallery }) {
   const isText = block.$type === 'pub.leaflet.blocks.text';
+  const isImage = block.$type === IMAGE_BLOCK_TYPE;
   const setField = (key, value) => {
     const next = { ...block };
     if (value === undefined) delete next[key];
@@ -533,6 +639,27 @@ function BlockLayoutControls({ block, onChange }) {
             <option value="auto">Auto</option>
             <option value="on">Indented</option>
             <option value="off">Flush</option>
+          </select>
+        </label>
+      )}
+      {isImage && (
+        <label className="block-layout-field">
+          <span className="small-caps">Gallery</span>
+          <select
+            className="block-layout-select"
+            value={galleryLayoutOf(block)}
+            onChange={(e) => onChangeGallery(e.target.value)}
+            title={
+              galleryRun
+                ? `Applies to all ${galleryRun.size} images in this run`
+                : 'Applies once this image sits next to another one'
+            }
+          >
+            {GALLERY_LAYOUTS.map((l) => (
+              <option key={l.value} value={l.value}>
+                {l.label}
+              </option>
+            ))}
           </select>
         </label>
       )}
@@ -682,7 +809,7 @@ function BlockPalette({ agent, onInsert, onInsertMany }) {
         </AddButton>
         <AddButton
           onClick={() => galleryInputRef.current?.click()}
-          title="Upload several images at once — each becomes its own image block."
+          title="Upload several images at once. Each is its own image block; adjacent images publish as one gallery, and the band above them sets its layout."
         >
           Gallery…
         </AddButton>

--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -7,6 +7,7 @@ import CodeBlockEditor from './CodeBlockEditor.jsx';
 import ListBlockEditor from './ListBlockEditor.jsx';
 import BskyPostBlockEditor from './BskyPostBlockEditor.jsx';
 import {
+  GALLERY_DEFAULT_LAYOUT,
   GALLERY_LAYOUTS,
   IMAGE_BLOCK_TYPE,
   LeafletBlock,
@@ -179,8 +180,8 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
         const block = next[k]?.block;
         if (block?.$type !== IMAGE_BLOCK_TYPE) continue;
         const updated = { ...block };
-        // `auto` is the absent-field default; don't write it out.
-        if (value === 'auto') delete updated.gallery;
+        // Two-up is what an absent field means; don't write it out.
+        if (value === GALLERY_DEFAULT_LAYOUT) delete updated.gallery;
         else updated.gallery = value;
         next[k] = { $type: WRAPPER_TYPE, block: updated };
       }

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -560,3 +560,100 @@
   padding: 0.15rem 0.35rem;
   cursor: pointer;
 }
+
+/* ---- Gallery runs ------------------------------------------------------ */
+/* A run of adjacent image blocks publishes as one gallery. In the editor the
+   rows stay individually editable, draggable and deletable — the grouping is
+   drawn around them instead: a band naming the run, and a rail down the left
+   edge tying its members together. */
+
+.blocks-editor-gallery-band {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem 0.7rem;
+  margin-top: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px dashed var(--accent-soft, #8a9f6e);
+  border-bottom: 0;
+  background: color-mix(in srgb, var(--accent, #5e7a47) 6%, transparent);
+}
+
+/* An ungrouped run is a weaker claim — same information, none of the accent. */
+.blocks-editor-gallery-band.is-separate {
+  border-color: var(--rule-soft, rgba(0, 0, 0, 0.16));
+  background: transparent;
+}
+
+.blocks-editor-gallery-title {
+  letter-spacing: 0.1em;
+  color: var(--accent, #5e7a47);
+}
+
+.blocks-editor-gallery-band.is-separate .blocks-editor-gallery-title {
+  color: var(--ink-faint, rgba(0, 0, 0, 0.45));
+}
+
+.blocks-editor-gallery-count,
+.blocks-editor-gallery-hint {
+  font-size: 0.72rem;
+  color: var(--ink-faint, rgba(0, 0, 0, 0.45));
+}
+
+/* The hint trails the control and is the first thing to go when the band wraps
+   onto a phone-width column. */
+.blocks-editor-gallery-hint {
+  margin-left: auto;
+}
+
+.blocks-editor-gallery-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  color: var(--ink-faint, var(--ink));
+}
+
+/* Rail: members of a run share one continuous left edge, so the run reads as a
+   single object even though each row is its own block. */
+.blocks-editor-item.is-run-member {
+  border-left: 2px solid var(--rule-soft, rgba(0, 0, 0, 0.16));
+  border-top-color: transparent;
+}
+
+.blocks-editor-item.is-gallery-member {
+  border-left-color: var(--accent-soft, #8a9f6e);
+}
+
+.blocks-editor-item.is-run-first {
+  border-top-color: var(--rule-soft, rgba(0, 0, 0, 0.16));
+}
+
+/* Position within the run — the tile number an author counts by when deciding
+   what to reorder. */
+.blocks-editor-run-index {
+  position: absolute;
+  left: 0.15rem;
+  top: 0.15rem;
+  z-index: 2;
+  font-size: 0.65rem;
+  line-height: 1;
+  padding: 0.12rem 0.22rem;
+  color: var(--ink-faint, rgba(0, 0, 0, 0.45));
+  background: var(--page, #fff);
+  pointer-events: none;
+}
+
+/* Collapsed rows in a run preview as gallery tiles rather than full-bleed
+   images, so six images read as six tiles instead of six page-wide photos. */
+.blocks-editor-item.is-gallery-member .blocks-editor-preview-body .leaflet-image img {
+  max-height: 7rem;
+  width: auto;
+  max-width: 100%;
+}
+
+/* A run's insert "+" would otherwise sit on the rail between two tiles and read
+   as a gallery divider; keep it, but only on hover of that specific row. */
+.blocks-editor-item.is-run-member:not(:hover) > .blocks-editor-insert {
+  opacity: 0;
+}


### PR DESCRIPTION
## The crash

Stepping through a multi-image lightbox could take down the page with "Maximum update depth exceeded", which the route's error boundary showed as *"Something broke on this page."* It reproduced reliably in WebKit (iOS Safari) once an image was warm in the HTTP cache — hence hitting a few images into a gallery rather than on the one you opened first.

The full-resolution `<img>` carries an inline `ref` callback that calls `markLoaded()` when the element is already `complete` at attach time, to catch cache hits that finish before React wires up `onLoad`. Because the callback is a fresh closure every render, React detaches and re-attaches it on every render, so that path fired continuously. `markLoaded`'s only guard lived *inside* the state updater, so an update was enqueued each time regardless; React rebuilds the queue from the base state on each pass and the updater returns a brand new `Set` every pass, so no two passes were `Object.is`-equal, React never bailed out, and the cascade hit the nested-update limit.

Fix: mirror the loaded-source set in a ref and bail *before* enqueueing. The progressive fade-in is unchanged.

## Gallery layout

A photo set has always published as a gallery — the renderer collapses a run of adjacent image blocks into a grid — but nothing said so in the editor, where six images read as six unrelated full-width image blocks with no way to shape them or opt out.

**Renderer.** Image blocks take a `gallery` layout hint (a dame.is rendering extension alongside `indent` / `spaceTop` / `spaceBottom`): 1/2/3/4 across, filmstrip, or separate images. Adjacent images group only with neighbours carrying the same value, so two differently shaped galleries can sit back to back, and *separate images* opts a run out of grouping entirely. An absent field means 2 across.

Columns previously came from the image count (2, or 3 for counts of 3/5/6), and the intended narrow-screen collapse to one column never fired — `.leaflet-gallery` lost on specificity to `.leaflet-gallery[data-count="6"]`, so a six-image set published as three columns on a phone. The count is now explicit and holds at every width; narrow screens tighten the gap rather than rewriting the author's shape.

**Editor.** A run of adjacent images is bracketed by a band naming it ("Gallery — 6 images") that carries the layout select for the whole run, with a rail down the run's left edge and each member numbered by position. Collapsed members preview as tiles rather than page-wide photos. Ungrouping is another option in the same select, so it is reversible from the same control, and the per-block layout row carries the same select for an image not currently in a run. Selecting the default removes the field, so records stay clean.

The editor derives its grouping from the renderer's own `galleryRuns()`, so what the band brackets is exactly what publishes as one unit.

## Verification

Driven with Playwright against the real record (`site.standard.document/3mrllu3fdrh2d`, six images):

- WebKit, iPhone viewport: reproduced the crash on the pre-fix build, confirmed the exact update cascade by instrumenting `markLoaded`, then confirmed 14 forward/backward lightbox steps clean on the fix, with the loaded-fade still applying.
- All six layouts rendered at 900px and 400px; computed `grid-template-columns` checked per layout at both widths.
- Editor exercised in a scratch harness: band grouping, layout switching, ungroup/regroup, and that the default value is removed from the record rather than written out.
- `npm test` (72 passing), `eslint` clean on the changed files, production build succeeds.

## Note for review

The column count is honored at every width with no breakpoint clamping — 4 across on a 400px phone really is four ~86px frames. That was a deliberate call: a breakpoint silently rewriting the choice is the same class of surprise as the count-guessing it replaces. Clamping wide counts on phones would be a small change if preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6BSm7fWWAtM7PZ5FjgAM7)_