### PR TITLE
Fix taps that needed two or three tries

### DIFF
--- a/src/components/blocks/BlocksEditor.jsx
+++ b/src/components/blocks/BlocksEditor.jsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import TextBlockEditor from './TextBlockEditor.jsx';
 import HeadingBlockEditor from './HeadingBlockEditor.jsx';
 import ImageBlockEditor, { uploadImageFile } from './ImageBlockEditor.jsx';
@@ -173,13 +174,31 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
   }, [autoMarkdown]);
 
   /**
-   * Leave the block being edited, moving focus to `next` (or nowhere).
-   *
-   * This is where markdown written inside a text block becomes real blocks: the
+   * Turn markdown written inside the active text block into real blocks: the
    * author can write a whole passage — headings, links, a list — in one place
-   * and have it resolve when they step away. It replaces the block as a single
+   * and have it resolve when they step away. Replaces the block as a single
    * structural op, so one ⌘Z puts the markdown source back if the conversion
    * read something the author meant literally.
+   *
+   * Returns null when there was nothing to convert, otherwise where the block
+   * sat and how many extra blocks it grew into, so a caller holding an index
+   * past it can follow the shift.
+   */
+  const resolveMarkdown = useCallback(() => {
+    const i = activeIndex;
+    const converted = i == null || !autoMarkdown ? null : textBlockToBlocks(blocks[i]?.block);
+    if (!converted) return null;
+    const wrapped = converted.map((b) => ({ $type: WRAPPER_TYPE, block: b }));
+    const nextBlocks = blocks.slice();
+    nextBlocks.splice(i, 1, ...wrapped);
+    commit(nextBlocks, { kind: 'structural' });
+    // One block became several, so anything after it has shifted along.
+    return { at: i, grew: wrapped.length - 1 };
+  }, [activeIndex, autoMarkdown, blocks, commit]);
+
+  /**
+   * Leave the block being edited, moving focus to `next` (or nowhere),
+   * resolving its markdown on the way out.
    *
    * Only the deliberate exits route through here. Undo, redo, and dragging also
    * collapse the editor, but converting under them would fight the operation —
@@ -188,20 +207,14 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
    */
   const leaveActive = useCallback(
     (next = null) => {
-      const i = activeIndex;
-      const converted = i == null || !autoMarkdown ? null : textBlockToBlocks(blocks[i]?.block);
-      if (!converted) {
+      const shift = resolveMarkdown();
+      if (!shift) {
         setActiveIndex(next);
         return;
       }
-      const wrapped = converted.map((b) => ({ $type: WRAPPER_TYPE, block: b }));
-      const nextBlocks = blocks.slice();
-      nextBlocks.splice(i, 1, ...wrapped);
-      commit(nextBlocks, { kind: 'structural' });
-      // One block became several, so anything after it has shifted along.
-      setActiveIndex(next != null && next > i ? next + wrapped.length - 1 : next);
+      setActiveIndex(next != null && next > shift.at ? next + shift.grew : next);
     },
-    [activeIndex, autoMarkdown, blocks, commit],
+    [resolveMarkdown],
   );
 
   const removeBlock = useCallback(
@@ -318,18 +331,57 @@ export default function BlocksEditor({ agent, did, value, onChange, onSetCover }
     [dragIndex, moveTo],
   );
 
-  // Collapse the active editor / insert palette when the user clicks outside.
+  // Collapse the active editor / insert palette when the user presses outside
+  // it — without eating the press.
+  //
+  // This used to run on mousedown, and that made "Done" feel mandatory.
+  // Collapsing swaps a tall block editor back to a short preview, so
+  // everything below it jumps upward; doing that on mousedown pulled the
+  // pressed control out from under the pointer, mouseup landed somewhere else,
+  // and no click was ever generated. The first tap on Save only closed the
+  // block and saving took a second tap.
+  //
+  // So the press decides and the click acts. Only pointerdown can say where
+  // the press landed — by click time the preview it hit may already have been
+  // swapped for an editor, leaving a detached target that reads as "outside".
+  // By the click, mouseup has already happened on an unmoved control and the
+  // event's propagation path is fixed, so reflowing now cannot stop it
+  // arriving. Running in capture, ahead of the control's own handler, also
+  // means Save reads a document whose markdown is already resolved — what
+  // "Done" would have left behind. flushSync, because React would otherwise
+  // batch that past the end of the dispatch, and Save would read the document
+  // it was about to replace.
+  const pressedOutsideRef = useRef(false);
   useEffect(() => {
     if (activeIndex == null && openInsertSlot == null) return undefined;
-    function onDown(e) {
-      if (rootRef.current && !rootRef.current.contains(e.target)) {
-        leaveActive(null);
-        setOpenInsertSlot(null);
-      }
+    const inside = (target) => {
+      const root = rootRef.current;
+      return !!root && root.isConnected && root.contains(target);
+    };
+    function onPointerDown(e) {
+      pressedOutsideRef.current = !inside(e.target);
     }
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [activeIndex, openInsertSlot, leaveActive]);
+    function onClick(e) {
+      if (!pressedOutsideRef.current) return;
+      pressedOutsideRef.current = false;
+      // The click may have unmounted us (Save closes the quick-edit sheet);
+      // a detached root has nothing left to collapse. A press that started
+      // outside but released in here isn't a dismissal either.
+      if (!rootRef.current?.isConnected || inside(e.target)) return;
+      flushSync(() => {
+        resolveMarkdown();
+        setActiveIndex(null);
+        setOpenInsertSlot(null);
+      });
+    }
+    // Capture, so a handler that stops propagation can't hide either event.
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('click', onClick, true);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('click', onClick, true);
+    };
+  }, [activeIndex, openInsertSlot, resolveMarkdown]);
 
   // Editing a block and an open insert palette are mutually exclusive focuses:
   // opening one closes the other.

--- a/src/hooks/usePreventScrollChain.js
+++ b/src/hooks/usePreventScrollChain.js
@@ -1,5 +1,18 @@
 import { useEffect } from 'react';
 
+/**
+ * How far a finger may drift before we stop reading the gesture as a tap.
+ * Roughly matches the slop browsers themselves allow when deciding whether a
+ * touch still counts as a tap. Below it we never cancel — see
+ * `usePreventScrollChain` for why cancelling swallows the tap's click.
+ */
+export const TAP_SLOP_PX = 10;
+
+/** Has this touch moved far enough to be a drag rather than a tap? */
+export function exceedsTapSlop(dx, dy, slop = TAP_SLOP_PX) {
+  return Math.hypot(dx, dy) > slop;
+}
+
 /** Can `node` actually scroll in the gesture's direction right now? A node
  *  qualifies only if it truly overflows AND its overflow style allows
  *  scrolling (scrollHeight > clientHeight alone is true for `overflow:
@@ -39,6 +52,21 @@ function scrollsInDirection(node, dy) {
  * non-passively so `preventDefault()` actually takes — React's synthetic
  * touchmove is passive and can't cancel the scroll.
  *
+ * Cancelling has a cost the first cut of this hook missed: per the Touch
+ * Events spec, a canceled touchstart or *first* touchmove suppresses the
+ * compatibility mouse events for that touch — including the `click`. A tap is
+ * rarely perfectly still (a thumb rolls a pixel or two), so on a panel whose
+ * content fits, every slightly-imperfect tap fired a touchmove, got cancelled,
+ * and lost its click — buttons and links inside the sheet went dead until a
+ * stiller tap happened to produce no touchmove at all. That's the "tap it
+ * three times to open Admin" bug.
+ *
+ * So the guard now waits for the gesture to declare itself: within
+ * `TAP_SLOP_PX` of where the finger landed we never cancel, keeping the tap's
+ * click intact. Past that it's a drag, and the cancel latches for the rest of
+ * the touch so a drag that wanders back toward its origin can't un-arm the
+ * guard mid-scroll.
+ *
  * @param {import('react').RefObject<HTMLElement>} ref  the scroll container
  * @param {boolean} active  guard only while the overlay is open
  */
@@ -47,14 +75,30 @@ export function usePreventScrollChain(ref, active) {
     if (!active) return undefined;
     const el = ref.current;
     if (!el) return undefined;
+    let startX = 0;
     let startY = 0;
+    // Latched once this touch has travelled past tap slop: it's a drag, and
+    // stays one even if the finger drifts back toward where it started.
+    let isDrag = false;
     const onTouchStart = (e) => {
+      // A second finger landing mid-gesture isn't a new gesture — only reset
+      // the origin when this is the touch that starts one.
+      if (e.touches.length > 1) return;
+      startX = e.touches[0]?.clientX ?? 0;
       startY = e.touches[0]?.clientY ?? 0;
+      isDrag = false;
     };
     const onTouchMove = (e) => {
       // Leave pinch-zoom and other multi-touch gestures alone.
       if (e.touches.length > 1) return;
+      // Once the browser owns the gesture the event is no longer cancelable;
+      // calling preventDefault() would only log a warning.
+      if (!e.cancelable) return;
+      const dx = (e.touches[0]?.clientX ?? 0) - startX;
       const dy = (e.touches[0]?.clientY ?? 0) - startY;
+      // Still tap-sized: let it through so the click survives.
+      if (!isDrag && !exceedsTapSlop(dx, dy)) return;
+      isDrag = true;
       // Walk the ancestor chain from the touch target up through the
       // container; bail the moment something can take the scroll.
       let node = e.target;

--- a/src/hooks/usePreventScrollChain.test.js
+++ b/src/hooks/usePreventScrollChain.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { exceedsTapSlop, TAP_SLOP_PX } from './usePreventScrollChain.js';
+
+describe('exceedsTapSlop', () => {
+  // The scroll-chain guard cancels touchmove, and a canceled first touchmove
+  // costs the touch its click. Everything a tap can plausibly drift must stay
+  // under the threshold, or buttons inside our sheets go dead.
+  it('treats a still or barely-drifting touch as a tap', () => {
+    expect(exceedsTapSlop(0, 0)).toBe(false);
+    expect(exceedsTapSlop(1, -2)).toBe(false);
+    expect(exceedsTapSlop(0, 6)).toBe(false);
+  });
+
+  it('counts drift in either axis, and in both at once', () => {
+    expect(exceedsTapSlop(0, 40)).toBe(true);
+    expect(exceedsTapSlop(-40, 0)).toBe(true);
+    // 8 and 8 are each under the threshold; their diagonal (~11.3) is not.
+    expect(exceedsTapSlop(8, 8)).toBe(true);
+  });
+
+  it('needs to clear the threshold, not just reach it', () => {
+    expect(exceedsTapSlop(0, TAP_SLOP_PX)).toBe(false);
+    expect(exceedsTapSlop(0, TAP_SLOP_PX + 0.5)).toBe(true);
+  });
+
+  it('accepts a caller-supplied slop', () => {
+    expect(exceedsTapSlop(0, 6, 20)).toBe(false);
+    expect(exceedsTapSlop(0, 6, 2)).toBe(true);
+  });
+});


### PR DESCRIPTION
Two unrelated causes behind the same symptom: a press that does nothing until you repeat it.

## Taps swallowed inside sheets

`usePreventScrollChain` keeps a touch-drag on an open overlay from scrolling the concealed page, by cancelling `touchmove` when nothing in the ancestor chain can absorb the scroll. Per the Touch Events spec, a cancelled `touchstart` or *first* `touchmove` suppresses the compatibility mouse events for that touch — including `click`.

A tap is rarely perfectly still. On a panel whose content fits without overflowing, every slightly-imperfect tap fired a `touchmove`, got cancelled, and lost its click; only a tap still enough to fire no `touchmove` at all got through. Hence the Admin link in the account panel taking two or three tries.

The guard now waits for the gesture to declare itself: within 10px of where the finger landed it never cancels, so the tap keeps its click. Past that it's a drag and the cancel latches for the rest of the touch, so a drag wandering back toward its origin can't disarm the guard mid-scroll. Slop is measured on both axes, and a `touchmove` the browser has already committed to is left alone.

Affects `ActionDock`, `Modal`, `BottomSheet`, and `EditSheet`.

## Block editor needing "Done" before Save

Pressing Save while a block was open did nothing — Done first, then Save. The outside-press dismissal ran on `mousedown`, and collapsing swaps a tall block editor back to a short preview, so everything below jumped upward (224px in a two-block document). `mouseup` landed on whatever had slid under the pointer and no `click` was ever generated. Every control outside the editor was affected, not just Save.

Now the press decides and the click acts. `pointerdown` records whether the press landed outside — only it can, since by click time the preview it hit may already have been swapped for an editor, leaving a detached target that reads as "outside". By the click, `mouseup` has already happened on a control that hasn't moved and the propagation path is fixed, so collapsing then can't stop the click arriving.

Running in capture, ahead of the pressed control's own handler, also fixes what that control reads. Markdown resolution was tied to leaving a block, so a one-tap save would otherwise have stored the markdown source and converted it immediately afterward, leaving the record dirty the moment it was saved. Resolving in the same `flushSync` as the collapse means Save sees exactly the document Done would have left behind.

## Verification

The block editor fix was driven in Chromium against a harness of the editor. Typing then pressing Save — by mouse and by touch, with and without markdown — now matches Done-then-Save exactly; before, it saved nothing at all. Also confirmed that clicking a preview still opens it, switching blocks keeps edits, the insert palette still closes on outside click, and undo still steps back, with no console warnings.

The sheet fix is derived from the spec and the code, not from an observed repro — there was no iOS device available, so it's worth a check on a real phone.

`npm test` passes (185 tests, including a new one covering the tap-slop threshold), build is clean, and lint is unchanged from `main` (3 pre-existing errors in `PostCard.jsx` and `WebsiteBlockEditor.jsx`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhTCr55rLkojFwRit48cAo)_