### PR TITLE
Fix repost URL text overflowing its quote box

### DIFF
--- a/src/components/PostEmbed.css
+++ b/src/components/PostEmbed.css
@@ -330,5 +330,6 @@ a.post-embed-quote {
   white-space: pre-wrap;
   color: var(--ink-soft);
   overflow-wrap: anywhere;
+  min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- `.post-embed-quote-text` is a flex item inside `.post-embed-quote` (`flex-direction: column`), but was missing the `min-width: 0` safety valve every sibling flex child in that container already carries alongside `overflow-wrap: anywhere`.
- Safari doesn't shrink a flex item's minimum size to respect `overflow-wrap` without `min-width: 0`, letting long unbroken link text (e.g. a bare URL) spill past the quote bubble's edge — as seen in a repost's link preview.
- Adds the missing `min-width: 0` to match the established pattern already used on `.post-embed-quote-head`, `.post-embed-quote-author`, etc.

## Test plan
- [x] Reproduced the layout locally (Feed.css + PostEmbed.css cascade) to confirm the fix targets the right element
- [ ] Visually confirm on an iOS/Safari device that long repost URLs no longer overflow the quote box


---
_Generated by [Claude Code](https://claude.ai/code/session_014YHYcZ8HvUM2E5zfwAXKES)_